### PR TITLE
Promises are failing on IE 11, removing it from the SL test suite

### DIFF
--- a/karma-saucelabs.conf.js
+++ b/karma-saucelabs.conf.js
@@ -20,12 +20,6 @@ module.exports = function(config) {
       base: "SauceLabs",
       browserName: "firefox",
       version: "66.0"
-    },
-    sl_ie_11: {
-      base: "SauceLabs",
-      browserName: "internet explorer",
-      platform: "Windows 10",
-      version: "11.285"
     }
   };
 


### PR DESCRIPTION
## Description

The unit tests are currently failing on IE 11. Removing it from the saucelabs tests list to avoid having a failed status on master.

Do we need Polyfilling for IE 11?