### PR TITLE
CORE-28203 Use assign utility so IE isn't broken.

### DIFF
--- a/src/components/Audiences/processDestinations.js
+++ b/src/components/Audiences/processDestinations.js
@@ -10,13 +10,18 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { isNonEmptyString, cookie, fireDestinations } from "../../utils";
+import {
+  assign,
+  isNonEmptyString,
+  cookie,
+  fireDestinations
+} from "../../utils";
 
 export default ({ destinations, config, logger }) => {
   const urlDestinations = destinations
     .filter(dest => dest.type === "url")
     .map(dest =>
-      Object.assign(
+      assign(
         {
           id: dest.id
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changed `Object.assign` to use `assign` utility so that it works in IE (tests were rightfully failing).
<!--- Describe your changes in detail -->

## Related Issue
CORE-28203

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
