### PR TITLE
CORE-28203 Make fireImage return a promise, simplify fireDestinations.

### DIFF
--- a/src/utils/fireDestinations.js
+++ b/src/utils/fireDestinations.js
@@ -1,5 +1,3 @@
-import isNil from "./isNil";
-import isNonEmptyString from "./isNonEmptyString";
 import fireImage from "./fireImage";
 import { appendNode, awaitSelector, createNode, removeNode } from "./dom";
 
@@ -13,7 +11,8 @@ const IFRAME_ATTRS = {
   style: "display: none; width: 0; height: 0;"
 };
 
-const createFilterResultByStatus = status => result => result.status === status;
+const createFilterResultBySucceeded = succeeded => result =>
+  result.succeeded === succeeded;
 const mapResultToDest = result => result.dest;
 
 export default ({ logger, destinations }) => {
@@ -29,58 +28,34 @@ export default ({ logger, destinations }) => {
     return iframePromise;
   };
 
-  const fireInIframe = ({ attributes }) => {
+  const fireInIframe = ({ src }) => {
     return createIframe().then(iframe => {
       const currentDocument = iframe.contentWindow.document;
-      fireImage({ attributes, currentDocument });
+      return fireImage({ src, currentDocument });
     });
   };
 
   return Promise.all(
     destinations.map(dest => {
-      return new Promise(resolve => {
-        if (isNonEmptyString(dest.url)) {
-          if (!isNil(dest.hideReferrer)) {
-            const attributes = {
-              onload: () => {
-                resolve({
-                  status: "loaded",
-                  dest
-                });
-              },
-              onerror: () => {
-                logger.log(`Destination failed: ${dest.url}`);
-                resolve({
-                  status: "errored",
-                  dest
-                });
-              },
-              onabort: () => {
-                logger.log(`Destination aborted: ${dest.url}`);
-                resolve({
-                  status: "aborted",
-                  dest
-                });
-              },
-              src: dest.url
-            };
+      const imagePromise = dest.hideReferrer
+        ? fireInIframe({ src: dest.url })
+        : fireOnPage({ src: dest.url });
 
-            if (dest.hideReferrer) {
-              fireInIframe({ attributes });
-            } else {
-              fireOnPage({ attributes });
-            }
-          } else {
-            logger.error(
-              `Destination hideReferrer property is not defined for url ${
-                dest.url
-              } .`
-            );
-          }
-        } else {
-          logger.error("Destination url is not a populated string.");
-        }
-      });
+      return imagePromise
+        .then(() => {
+          logger.log(`Destination failed: ${dest.url}`);
+          return {
+            succeeded: true,
+            dest
+          };
+        })
+        .catch(() => {
+          logger.log(`Destination aborted: ${dest.url}`);
+          return {
+            succeeded: false,
+            dest
+          };
+        });
     })
   ).then(results => {
     if (iframePromise) {
@@ -88,14 +63,11 @@ export default ({ logger, destinations }) => {
     }
 
     return {
-      loaded: results
-        .filter(createFilterResultByStatus("loaded"))
+      succeeded: results
+        .filter(createFilterResultBySucceeded(true))
         .map(mapResultToDest),
-      errored: results
-        .filter(createFilterResultByStatus("errored"))
-        .map(mapResultToDest),
-      aborted: results
-        .filter(createFilterResultByStatus("aborted"))
+      failed: results
+        .filter(createFilterResultBySucceeded(false))
         .map(mapResultToDest)
     };
   });

--- a/src/utils/fireDestinations.js
+++ b/src/utils/fireDestinations.js
@@ -43,14 +43,14 @@ export default ({ logger, destinations }) => {
 
       return imagePromise
         .then(() => {
-          logger.log(`Destination failed: ${dest.url}`);
+          logger.log(`Destination succeeded: ${dest.url}`);
           return {
             succeeded: true,
             dest
           };
         })
         .catch(() => {
-          logger.log(`Destination aborted: ${dest.url}`);
+          logger.log(`Destination failed: ${dest.url}`);
           return {
             succeeded: false,
             dest

--- a/src/utils/fireImage.js
+++ b/src/utils/fireImage.js
@@ -10,7 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import isNonEmptyString from "./isNonEmptyString";
 import { createNode } from "./dom";
 
 const IMAGE_TAG = "img";
@@ -18,11 +17,18 @@ const IMAGE_TAG = "img";
 /**
  * Fires an image pixel from the current document's window.
  * @param {object} currentDocument
- * @param {object} attributes - must include src
- * @returns {undefined}
+ * @param {string} src
+ * @returns {Promise}
  */
-export default ({ currentDocument = document, attributes = {} }) => {
-  if (isNonEmptyString(attributes.src)) {
+export default ({ currentDocument = document, src }) => {
+  return new Promise((resolve, reject) => {
+    const attributes = {
+      onload: resolve,
+      onerror: reject,
+      onabort: reject,
+      src
+    };
+
     createNode(IMAGE_TAG, attributes, [], currentDocument);
-  }
+  });
 };

--- a/test/unit/utils/fireDestinations.spec.js
+++ b/test/unit/utils/fireDestinations.spec.js
@@ -31,14 +31,13 @@ describe("fireDestinations", () => {
 
     fireDestinations({ logger, destinations: urlDestinations }).then(
       firedDests => {
-        expect(firedDests.errored[0].id).toEqual(2097728);
-        expect(firedDests.errored[0].url).toEqual(
+        expect(firedDests.failed[0].id).toEqual(2097728);
+        expect(firedDests.failed[0].url).toEqual(
           "http://www.adobe.com?def=456"
         );
-        expect(firedDests.errored[0].hideReferrer).toEqual(1);
-        expect(firedDests.errored[1]).toBeUndefined();
-        expect(firedDests.loaded.length).toEqual(0);
-        expect(firedDests.aborted.length).toEqual(0);
+        expect(firedDests.failed[0].hideReferrer).toEqual(1);
+        expect(firedDests.failed.length).toEqual(1);
+        expect(firedDests.succeeded.length).toEqual(0);
         done();
       }
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This builds on https://github.com/adobe/alloy/pull/20. It changes `fireImage` to return a promise. Without doing so, it's likely that every consumer of `fireImage` will need to provide `onload`, `onerror`, and `onabort` attributes, which makes `fireImage` not particularly useful. This change does make the assumption that we don't need to distinguish between failed image requests and aborted image requests. I can't think of any use case where that distinction would be useful, but maybe you can. If the distinction is necessary, we can tweak some things while still returning a promise from `fireImage`.

Another theme of this PR is that it's my take (and we've discussed it as a group) that we shouldn't be adding logic that validates that data coming back from the server is in a valid state or that data from a component to a utility or another component is in a valid state. I believe we should typically make the assumption that the data is well-formed and blow up if it isn't. I believe validation should typically be reserved for user input/configuration where we don't own the input.

<!--- Describe your changes in detail -->

## Related Issue
CORE-28203

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Simplifying code. Make fireImage more useful.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually and automated.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
