### PR TITLE
Get the sandbox working in IE

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -5,6 +5,7 @@
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="theme-color" content="#000000" />
+    <script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"></script>
     <meta http-equiv="Content-Security-Policy"
           content="default-src 'self';
             script-src 'self' 'unsafe-inline';
@@ -39,7 +40,7 @@
           "xdm:URL": [location.href],
           "xdm:name": [location.pathname.substring(1) || "home"]
         }
-      }).then(() => {
+      }).then(function() {
         console.log("View start event has triggered.");
       });
 

--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -76,7 +76,10 @@ const showElement = selector => {
   const key = buildKey(KEY_PREFIX, selector);
   const elements = document.querySelectorAll(`.${key}`);
 
-  elements.forEach(e => removeFrom(document.head, e));
+  // elements is a nodeList, and in IE nodeList does not support forEach
+  for (let i = 0; i < elements.length; i += 1) {
+    removeFrom(document.head, elements[i]);
+  }
 };
 
 const render = (cache, event, logger) => {
@@ -150,7 +153,6 @@ const createPersonalization = ({ logger }) => {
           response.getPayloadByType("personalization:run") || [];
 
         // Caution!!! Here comes Target black magic
-
         personalization.forEach(option => {
           const { selector, eventToken } = option;
           const key = buildKey(KEY_DETECT_PREFIX, selector);

--- a/src/core/network/xhrRequest.js
+++ b/src/core/network/xhrRequest.js
@@ -31,7 +31,9 @@ export default XMLHttpRequest => {
           }
         }
       };
-      request.responseType = "text";
+      request.onloadstart = () => {
+        request.responseType = "text";
+      };
       request.open("POST", url, true);
       request.setRequestHeader("Content-Type", "application/json");
       request.withCredentials = false;


### PR DESCRIPTION
## Description

Fix xhrRequest network strategy so that it works with IE
Polyfill promise in the sandbox before the pre-amble code
Fix a forEach call in personalization that doesn't work in IE
Change anonymous function declaration in sandbox index to old style

## Related Issue

https://jira.corp.adobe.com/browse/CORE-27934 - fetch is throwing an error in IE.  After merging the network gateway, there were still a few problems in IE.

## Motivation and Context

Alloy will need to work with IE.

## How Has This Been Tested?

I ran the sandbox in IE through VMWare

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
