### PR TITLE
Removed unnecessary options in sandbox examples.

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -26,8 +26,6 @@
     <script>
       alloy("configure", {
         propertyID: 9999999,
-        destinationsEnabled: true,
-        idSyncsEnabled: true,
         debug: true
       });
 
@@ -47,8 +45,6 @@
       // For Testing multiple instances
       organizationTwo("configure", {
         propertyID: 8888888,
-        destinationsEnabled: true,
-        idSyncsEnabled: true,
         debug: true
       });
     </script>

--- a/sandbox/src/OrgTwo.js
+++ b/sandbox/src/OrgTwo.js
@@ -12,7 +12,6 @@ export default function OrgTwo() {
             {`
                 organizationTwo("configure", {
                     propertyID: 8888888,
-                    destinationsEnabled: true,
                     debug: true
                 });
             `}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We already have a default value of `true` for both `destinationsEnabled` and `idSyncsEnabled`, so we don't need to pass them in through our `configure` examples.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Not confuse Alpha users.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
