### PR TITLE
CORE-30736 Returning request+response data from event command.

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -38,8 +38,8 @@
           "xdm:URL": [location.href],
           "xdm:name": [location.pathname.substring(1) || "home"]
         }
-      }).then(function() {
-        console.log("View start event has triggered.");
+      }).then(function(data) {
+        console.log("View start event has triggered.", data);
       });
 
       // For Testing multiple instances

--- a/src/core/network/createResponse.js
+++ b/src/core/network/createResponse.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { assign, find } from "../../utils";
+import { find } from "../../utils";
 
 /**
  * Represents a gateway response with the addition to helper methods.
@@ -25,23 +25,25 @@ import { assign, find } from "../../utils";
  * }
  *
  * @returns {Object<Response>} A Response object containing:
- *  - All the properties of the raw response, frozen
  *  - `getPayloadByType`: returns a fragment of the response by type
  *      - @param {String} type: A string with the current format: <namespace:action>
  *          example: "identity:persist"
  */
-export default (respDto = { requestId: "", handle: [] }) => {
-  const response = assign(Object.create(null), respDto);
+export default (content = { requestId: "", handle: [] }) => {
   // TODO: Should we freeze the response to prevent change by Components?
   // Object.freeze(response.handle.map(h => Object.freeze(h)));
-
-  response.getPayloadByType = type => {
-    const fragment = find(respDto.handle, content => content.type === type);
-    return fragment ? fragment.payload : null;
+  return {
+    getPayloadByType(type) {
+      const fragment = find(
+        content.handle,
+        handleContent => handleContent.type === type
+      );
+      return fragment ? fragment.payload : null;
+    },
+    toJSON() {
+      return content;
+    }
+    // TODO: Maybe consider the following API as well?
+    // - getPayloadsByAction
   };
-
-  // TODO: Maybe consider the following API as well?
-  // - getPayloadsByAction
-
-  return response;
 };

--- a/src/utils/clone.js
+++ b/src/utils/clone.js
@@ -1,0 +1,18 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/**
+ * Clones a value by serializing then deserializing the value.
+ * @param {*} value
+ * @returns {any}
+ */
+export default value => JSON.parse(JSON.stringify(value));

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -14,6 +14,7 @@ governing permissions and limitations under the License.
 
 // Please keep in alphabetical order.
 export { default as assign } from "./assign";
+export { default as clone } from "./clone";
 export { default as cookie } from "./cookie";
 export { default as createMerger } from "./createMerger";
 export { default as defer } from "./defer";

--- a/test/unit/core/network/createNetwork.spec.js
+++ b/test/unit/core/network/createNetwork.spec.js
@@ -165,7 +165,7 @@ describe("createNetwork", () => {
     const lifecycle = {
       onBeforeSend: () => undefined,
       onResponse: response => {
-        const cleanResponse = JSON.parse(JSON.stringify(response));
+        const cleanResponse = response.toJSON();
         expect(cleanResponse).toEqual(myresponse);
         done();
       }

--- a/test/unit/core/network/createNetwork.spec.js
+++ b/test/unit/core/network/createNetwork.spec.js
@@ -145,9 +145,10 @@ describe("createNetwork", () => {
       .send()
       .then(done.fail)
       .catch(e => {
-        expect(e.message).toContain(
-          "Error parsing server response.\nSyntaxError: Unexpected token b in JSON at position 0\nResponse body: badbody"
-        );
+        // The native parse error message is different based on the browser
+        // so we'll just check to parts we control.
+        expect(e.message).toContain("Error parsing server response.\n");
+        expect(e.message).toContain("\nResponse body: badbody");
         done();
       });
   });

--- a/test/unit/core/network/createNetwork.spec.js
+++ b/test/unit/core/network/createNetwork.spec.js
@@ -18,58 +18,44 @@ describe("createNetwork", () => {
     propertyID: "mypropertyid"
   };
 
-  const logger = console.log;
+  const logger = console;
 
   const nullLifecycle = {
     onBeforeSend: () => Promise.resolve(),
-    onResponseFragment: () => Promise.resolve()
+    onResponse: () => Promise.resolve()
   };
 
   it("calls interact by default", done => {
     const networkStrategy = url => {
-      return new Promise(() => {
-        expect(url).toEqual(
-          "https://alloy.mysite.com/interact?propertyID=mypropertyid"
-        );
-        done();
-      });
+      expect(url).toEqual(
+        "https://alloy.mysite.com/interact?propertyID=mypropertyid"
+      );
+      done();
+      return Promise.resolve();
     };
-    const network = createNetwork(
-      config,
-      logger,
-      nullLifecycle,
-      networkStrategy
-    );
-    const { send } = network.newRequest();
-    send();
+    createNetwork(config, logger, nullLifecycle, networkStrategy)
+      .newRequest()
+      .send();
   });
 
   it("can call collect", done => {
     const networkStrategy = url => {
-      return new Promise(() => {
-        expect(url).toEqual(
-          "https://alloy.mysite.com/collect?propertyID=mypropertyid"
-        );
-        done();
-      });
+      expect(url).toEqual(
+        "https://alloy.mysite.com/collect?propertyID=mypropertyid"
+      );
+      done();
+      return Promise.resolve();
     };
-    const network = createNetwork(
-      config,
-      logger,
-      nullLifecycle,
-      networkStrategy
-    );
-    const { send } = network.newRequest(false);
-    send();
+    createNetwork(config, logger, nullLifecycle, networkStrategy)
+      .newRequest(false)
+      .send();
   });
 
   it("sends the payload", done => {
     const networkStrategy = (url, json) => {
-      return new Promise(resolve => {
-        expect(JSON.parse(json).events[0]).toEqual({ id: "myevent1" });
-        resolve();
-        done();
-      });
+      expect(JSON.parse(json).events[0]).toEqual({ id: "myevent1" });
+      done();
+      return Promise.resolve();
     };
     const network = createNetwork(
       config,
@@ -82,73 +68,91 @@ describe("createNetwork", () => {
     send();
   });
 
-  it("resolves the returned promise", done => {
-    const networkStrategy = () => {
-      return new Promise(resolve => {
-        resolve(JSON.stringify({ requestId: "myrequestid", handle: [] }));
-      });
-    };
+  it("logs the request and response when response is expected", done => {
+    spyOn(logger, "log");
+    const mockResponse = { requestId: "myrequestid", handle: [] };
+    const networkStrategy = () => Promise.resolve(JSON.stringify(mockResponse));
     const network = createNetwork(
       config,
       logger,
       nullLifecycle,
       networkStrategy
     );
-    const { responsePromise, send } = network.newRequest();
-    responsePromise
-      .then(body => {
-        const { requestId, handle } = JSON.parse(body);
-        expect(requestId).toEqual("myrequestid");
-        expect(handle).toEqual([]);
+    const { payload, send } = network.newRequest();
+    payload.addEvent({ id: "myevent1" });
+    send().then(() => {
+      expect(logger.log).toHaveBeenCalledWith(
+        "Sending network request:",
+        payload.toJSON()
+      );
+      expect(logger.log).toHaveBeenCalledWith(
+        "Received network response:",
+        mockResponse
+      );
+      done();
+    });
+  });
+
+  it("logs only the request when no response is expected", done => {
+    spyOn(logger, "log");
+    const networkStrategy = () => Promise.resolve();
+    const network = createNetwork(
+      config,
+      logger,
+      nullLifecycle,
+      networkStrategy
+    );
+    const { payload, send } = network.newRequest(false);
+    payload.addEvent({ id: "myevent1" });
+    send().then(() => {
+      expect(logger.log).toHaveBeenCalledWith(
+        "Sending network request (response will be ignored):",
+        payload.toJSON()
+      );
+      expect(logger.log.calls.count()).toBe(1);
+      done();
+    });
+  });
+
+  it("resolves the returned promise", done => {
+    const networkStrategy = () =>
+      Promise.resolve(JSON.stringify({ requestId: "myrequestid", handle: [] }));
+    createNetwork(config, logger, nullLifecycle, networkStrategy)
+      .newRequest()
+      .send()
+      .then(response => {
+        expect(response.getPayloadByType).toEqual(jasmine.any(Function));
         done();
       })
       .catch(done.fail);
-    send();
   });
 
   it("rejects the returned promise", done => {
-    const networkStrategy = () => {
-      return new Promise((resolve, reject) => {
-        reject(new Error("myerror"));
-      });
-    };
-    const network = createNetwork(
-      config,
-      logger,
-      nullLifecycle,
-      networkStrategy
-    );
-    const { responsePromise, send } = network.newRequest();
-    responsePromise.catch(error => {
-      expect(error.message).toEqual("myerror");
-      done();
-    });
-    send();
-  });
-
-  it("resolves the promise even with invalid json", done => {
-    const networkStrategy = () => {
-      return new Promise(resolve => {
-        resolve("badbody");
-      });
-    };
-    const component = createNetwork(
-      config,
-      logger,
-      nullLifecycle,
-      networkStrategy
-    );
-    const { responsePromise, send } = component.newRequest();
-    responsePromise
-      .then(body => {
-        expect(body).toEqual("badbody");
+    const networkStrategy = () => Promise.reject(new Error("myerror"));
+    createNetwork(config, logger, nullLifecycle, networkStrategy)
+      .newRequest()
+      .send()
+      .catch(error => {
+        expect(error.message).toEqual("myerror");
         done();
-      })
-      .catch(done.fail);
-    send();
+      });
   });
 
-  it("allows components to handle response fragments", done => {
+  it("rejects the promise when response is invalid json", done => {
+    const networkStrategy = () => Promise.resolve("badbody");
+    createNetwork(config, logger, nullLifecycle, networkStrategy)
+      .newRequest()
+      .send()
+      .then(done.fail)
+      .catch(e => {
+        expect(e.message).toContain(
+          "Error parsing server response.\nSyntaxError: Unexpected token b in JSON at position 0\nResponse body: badbody"
+        );
+        done();
+      });
+  });
+
+  it("allows components to handle response", done => {
     const myresponse = {
       requestId: "myrequestid",
       handle: [
@@ -166,55 +170,37 @@ describe("createNetwork", () => {
         done();
       }
     };
-    const networkStrategy = () => {
-      return new Promise(resolve => {
-        resolve(JSON.stringify(myresponse));
-      });
-    };
-    const network = createNetwork(config, logger, lifecycle, networkStrategy);
-    network.newRequest().send();
+    const networkStrategy = () => Promise.resolve(JSON.stringify(myresponse));
+    createNetwork(config, logger, lifecycle, networkStrategy)
+      .newRequest()
+      .send();
   });
 
-  [true, false].forEach(b => {
-    it(`allows components to get the request info (beacon = ${b})`, done => {
-      let requestPayload;
-      let requestPromise;
+  [true, false].forEach(expectsResponse => {
+    it(`allows components to get the request info (beacon = ${expectsResponse})`, done => {
+      let lifecyclePayload;
+      let lifecycleResponsePromise;
+      let lifecycleIsBeacon;
       const lifecycle = {
-        onBeforeSend: ({ payload, responsePromise, isBeacon, send }) => {
-          expect(send).toBeUndefined();
-          expect(payload).toBe(requestPayload);
-          expect(responsePromise).toBe(requestPromise);
-          expect(isBeacon).toBe(b);
+        onBeforeSend: ({ payload, responsePromise, isBeacon }) => {
+          lifecyclePayload = payload;
+          lifecycleResponsePromise = responsePromise;
+          lifecycleIsBeacon = isBeacon;
           done();
-        },
-        onResponseFragment: () => undefined
+        }
       };
       const networkStrategy = () => new Promise(() => undefined);
       const network = createNetwork(config, logger, lifecycle, networkStrategy);
-      const { payload, responsePromise, send } = network.newRequest(b);
-      requestPayload = payload;
-      requestPromise = responsePromise;
-      send();
+      const { payload, send } = network.newRequest(expectsResponse);
+      const responsePromise = send();
+      responsePromise.then(() => {
+        expect(lifecyclePayload).toBe(payload);
+        expect(lifecycleResponsePromise).toBe(responsePromise);
+        expect(lifecycleIsBeacon).toBe(expectsResponse);
+        expect(responsePromise).toBe(lifecycleResponsePromise);
+        expect(expectsResponse).toBe(expectsResponse);
+      });
     });
-  });
-
-  it("logs json parse errors", done => {
-    const networkStrategy = () => {
-      return Promise.resolve("badbody1");
-    };
-    const loggerSpy = jasmine.createSpyObj("logger", ["warn"]);
-    const network = createNetwork(
-      config,
-      loggerSpy,
-      nullLifecycle,
-      networkStrategy
-    );
-    const { send } = network.newRequest();
-    send();
-    setTimeout(() => {
-      expect(loggerSpy.warn).toHaveBeenCalledTimes(1);
-      done();
-    }, 100);
   });
 
   it("doesn't try to parse the response on a beacon call", done => {

--- a/test/unit/core/network/createResponse.spec.js
+++ b/test/unit/core/network/createResponse.spec.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 import createResponse from "../../../../src/core/network/createResponse";
 
-const responseDto = {
+const responseContent = {
   requestId: 123,
   handle: [
     {
@@ -23,15 +23,7 @@ const responseDto = {
 };
 
 describe("createResponse", () => {
-  const response = createResponse(responseDto);
-
-  describe("Response object", () => {
-    it("should contain the DTO's properties and extra methods", () => {
-      ["requestId", "handle", "getPayloadByType"].forEach(prop => {
-        expect(response[prop]).toBeDefined();
-      });
-    });
-  });
+  const response = createResponse(responseContent);
 
   describe("getPayloadByType", () => {
     it("should return the correct payload", () => {
@@ -39,6 +31,12 @@ describe("createResponse", () => {
       const payload = response.getPayloadByType(type1);
       expect(payload).toBeDefined();
       expect(payload).toEqual("Same payload for namespace1:action1");
+    });
+  });
+
+  describe("toJSON", () => {
+    it("returns underlying content object", () => {
+      expect(response.toJSON()).toBe(responseContent);
     });
   });
 });

--- a/test/unit/utils/clone.spec.js
+++ b/test/unit/utils/clone.spec.js
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import clone from "../../../src/utils/clone";
+
+describe("clone", () => {
+  it("clone the object using JSON serialization/deserialization", () => {
+    const obj = {
+      toJSON() {
+        return { foo: "bar" };
+      }
+    };
+
+    const result = clone(obj);
+
+    expect(result).toEqual({
+      foo: "bar"
+    });
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This allows users to access the request body and response body after sending an event, like so: 

```
alloy("event", { ... }).then(function(data) {
  // data.requestBody
  // data.responseBody
});
```

Likewise, when the request is sent, we log the request body. When the response comes back, we log the response body.

There was some question as to what we should do when we don't expect a response from the server (in other words, it's just a beacon). In this case, the `data` object returned from the command will not have a `responseBody` property. Regarding logging, when the message that gets logged when a request goes out, it will say `Sending network request (response will be ignored): <requestbody>` instead of just `Sending network request: <requestbody>`. The response will not be logged.

<!--- Describe your changes in detail -->

## Related Issue
CORE-30736

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

This is in response to alpha tester feedback where they stated they wanted access to the request and response after executing an `event` command.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually and automated, but we need more automated tests around the Data Collector. I think in this case they should probably be functional tests, which I'd like to start getting more involved with.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. **Not yet...I want to get feedback on this first**
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
