### PR TITLE
CORE-30400 Fix isBeacon boolean sent to onBeforeSend.

### DIFF
--- a/src/core/network/createNetwork.js
+++ b/src/core/network/createNetwork.js
@@ -63,7 +63,7 @@ export default (config, logger, lifecycle, networkStrategy) => {
             lifecycle.onBeforeSend({
               payload,
               responsePromise,
-              isBeacon: expectsResponse
+              isBeacon: !expectsResponse
             })
           )
           .then(() => {

--- a/test/unit/core/network/createNetwork.spec.js
+++ b/test/unit/core/network/createNetwork.spec.js
@@ -179,27 +179,21 @@ describe("createNetwork", () => {
 
   [true, false].forEach(expectsResponse => {
     it(`allows components to get the request info (beacon = ${expectsResponse})`, done => {
-      let lifecyclePayload;
-      let lifecycleResponsePromise;
-      let lifecycleIsBeacon;
       const lifecycle = {
-        onBeforeSend: ({ payload, responsePromise, isBeacon }) => {
-          lifecyclePayload = payload;
-          lifecycleResponsePromise = responsePromise;
-          lifecycleIsBeacon = isBeacon;
-          done();
-        }
+        onBeforeSend: jasmine.createSpy().and.callFake(() => Promise.resolve()),
+        onResponse: () => Promise.resolve()
       };
-      const networkStrategy = () => new Promise(() => undefined);
+      const networkStrategy = () => Promise.resolve("{}");
       const network = createNetwork(config, logger, lifecycle, networkStrategy);
       const { payload, send } = network.newRequest(expectsResponse);
       const responsePromise = send();
       responsePromise.then(() => {
-        expect(lifecyclePayload).toBe(payload);
-        expect(lifecycleResponsePromise).toBe(responsePromise);
-        expect(lifecycleIsBeacon).toBe(expectsResponse);
-        expect(responsePromise).toBe(lifecycleResponsePromise);
-        expect(expectsResponse).toBe(expectsResponse);
+        expect(lifecycle.onBeforeSend).toHaveBeenCalledWith({
+          payload,
+          responsePromise,
+          isBeacon: !expectsResponse
+        });
+        done();
       });
     });
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the `isBeacon` boolean that's sent to `lifecycle.onBeforeSend`. It was the opposite of what it should be. This was [found by @jonsnyder](https://github.com/adobe/alloy/pull/47#discussion_r294391542).

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-30400

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Automated tests.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] I have run the Sandbox successfully.
- [X] All new and existing tests passed.
