### PR TITLE
Ensure template literals are converted to + instead of concat()

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -14,5 +14,10 @@
         }
       }
     ]
+  ],
+  "plugins": [
+    ["@babel/plugin-transform-template-literals", {
+      "loose": true
+    }]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
+    "@babel/plugin-transform-template-literals": "^7.4.4",
     "@babel/preset-env": "^7.4.5",
     "babel-loader": "^8.0.5",
     "dotenv": "^6.2.0",


### PR DESCRIPTION
Using loose of template literals transformation from Babel

## Description

Using loose of template literals transformation from Babel

## Motivation and Context

Using loose template literals transformation to improve performance. The default `concat()` invocations are adding overhead.

## How Has This Been Tested?

By running all the tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have run the Sandbox successfully.
- [x] All new and existing tests passed.
