### PR TITLE
CORE-31332 Log raw payload with raw events.

### DIFF
--- a/src/core/network/createNetwork.js
+++ b/src/core/network/createNetwork.js
@@ -72,9 +72,17 @@ export default (config, logger, lifecycle, networkStrategy) => {
             const responseHandlingMessage = expectsResponse
               ? ""
               : " (response will be ignored)";
+            const stringifiedPayload = JSON.stringify(payload);
+
+            // We want to log raw payload and event data rather than
+            // our fancy wrapper objects. Calling payload.toJSON() is
+            // insufficient to get all the nested raw data, because it's
+            // not recursive (it doesn't call toJSON() on the event objects).
+            // Parsing the result of JSON.stringify(), however, gives the
+            // fully recursive raw data.
             logger.log(
               `Sending network request${responseHandlingMessage}:`,
-              payload.toJSON()
+              JSON.parse(stringifiedPayload)
             );
 
             return networkStrategy(

--- a/src/core/network/createNetwork.js
+++ b/src/core/network/createNetwork.js
@@ -85,11 +85,7 @@ export default (config, logger, lifecycle, networkStrategy) => {
               JSON.parse(stringifiedPayload)
             );
 
-            return networkStrategy(
-              url,
-              JSON.stringify(payload),
-              expectsResponse
-            );
+            return networkStrategy(url, stringifiedPayload, expectsResponse);
           })
           .then(responseBody => {
             let handleResponsePromise;

--- a/test/unit/core/network/createNetwork.spec.js
+++ b/test/unit/core/network/createNetwork.spec.js
@@ -83,7 +83,7 @@ describe("createNetwork", () => {
     send().then(() => {
       expect(logger.log).toHaveBeenCalledWith(
         "Sending network request:",
-        payload.toJSON()
+        JSON.parse(JSON.stringify(payload))
       );
       expect(logger.log).toHaveBeenCalledWith(
         "Received network response:",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When we log the payload before a network request goes out, we need to make sure the object is the raw data and not any of our wrapper objects. We were logging this, as an example:

![image](https://user-images.githubusercontent.com/210820/59867281-0a879a00-934b-11e9-823d-8c860e326156.png)

See how the event is our fancy wrapper object with all the helpers methods and such? Our users don't care about that. They want the raw data. The reason we were outputting the fancy event wrappers is because we were logging the result of `payload.toJSON()`. Payload's `toJSON()` returns the raw payload data, but it doesn't recursively call `toJSON()` on the fancy event wrappers that it holds. However, `JSON.stringify(payload)` _does_ call `toJSON()` recursively. As a result, if we parse the result of `JSON.stringify(payload)`, we arrive at the full raw payload data in the form of a JavaScript object.

There are a few ways of addressing this problem, but I feel this is the best one at the moment. It does have a performance impact on logging (we have to parse the payload JSON), but I think we can address the performance impact as part of https://jira.corp.adobe.com/browse/CORE-31336

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-31332

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Users don't care about our fancy wrapper objects. They want the data.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Automated & manual.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have run the Sandbox successfully.
- [x] All new and existing tests passed.
