### PR TITLE
CORE-31305 break apart network's newRequest into two methods

### DIFF
--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -21,9 +21,9 @@ const createDataCollector = () => {
 
   const makeServerCall = event => {
     const { expectsResponse } = event;
-    const { payload, send } = network.newRequest(expectsResponse);
+    const payload = network.createPayload();
     payload.addEvent(event);
-    return send().then(response => {
+    return network.sendRequest(payload, expectsResponse).then(response => {
       const data = {
         requestBody: clone(payload)
       };

--- a/src/core/network/createNetwork.js
+++ b/src/core/network/createNetwork.js
@@ -39,9 +39,7 @@ export default (config, logger, lifecycle, networkStrategy) => {
      * Create a new payload.  Once you have added data to the payload, send it with
      * the sendRequest method.
      */
-    createPayload() {
-      return createPayload();
-    },
+    createPayload,
     /**
      * Send the request to either interact or collect based on expectsResponse.
      * The lifecycle method "onBeforeSend" will be triggered with

--- a/test/unit/core/network/createNetwork.spec.js
+++ b/test/unit/core/network/createNetwork.spec.js
@@ -33,9 +33,14 @@ describe("createNetwork", () => {
       done();
       return Promise.resolve();
     };
-    createNetwork(config, logger, nullLifecycle, networkStrategy)
-      .newRequest()
-      .send();
+    const network = createNetwork(
+      config,
+      logger,
+      nullLifecycle,
+      networkStrategy
+    );
+    const payload = network.createPayload();
+    network.sendRequest(payload);
   });
 
   it("can call collect", done => {
@@ -46,9 +51,14 @@ describe("createNetwork", () => {
       done();
       return Promise.resolve();
     };
-    createNetwork(config, logger, nullLifecycle, networkStrategy)
-      .newRequest(false)
-      .send();
+    const network = createNetwork(
+      config,
+      logger,
+      nullLifecycle,
+      networkStrategy
+    );
+    const payload = network.createPayload();
+    network.sendRequest(payload, false);
   });
 
   it("sends the payload", done => {
@@ -63,9 +73,9 @@ describe("createNetwork", () => {
       nullLifecycle,
       networkStrategy
     );
-    const { payload, send } = network.newRequest();
+    const payload = network.createPayload();
     payload.addEvent({ id: "myevent1" });
-    send();
+    network.sendRequest(payload);
   });
 
   it("logs the request and response when response is expected", done => {
@@ -78,9 +88,9 @@ describe("createNetwork", () => {
       nullLifecycle,
       networkStrategy
     );
-    const { payload, send } = network.newRequest();
+    const payload = network.createPayload();
     payload.addEvent({ id: "myevent1" });
-    send().then(() => {
+    network.sendRequest(payload).then(() => {
       expect(logger.log).toHaveBeenCalledWith(
         "Sending network request:",
         JSON.parse(JSON.stringify(payload))
@@ -102,9 +112,9 @@ describe("createNetwork", () => {
       nullLifecycle,
       networkStrategy
     );
-    const { payload, send } = network.newRequest(false);
+    const payload = network.createPayload();
     payload.addEvent({ id: "myevent1" });
-    send().then(() => {
+    network.sendRequest(payload, false).then(() => {
       expect(logger.log).toHaveBeenCalledWith(
         "Sending network request (no response is expected):",
         payload.toJSON()
@@ -117,9 +127,15 @@ describe("createNetwork", () => {
   it("resolves the returned promise", done => {
     const networkStrategy = () =>
       Promise.resolve(JSON.stringify({ requestId: "myrequestid", handle: [] }));
-    createNetwork(config, logger, nullLifecycle, networkStrategy)
-      .newRequest()
-      .send()
+    const network = createNetwork(
+      config,
+      logger,
+      nullLifecycle,
+      networkStrategy
+    );
+    const payload = network.createPayload();
+    network
+      .sendRequest(payload)
       .then(response => {
         expect(response.getPayloadByType).toEqual(jasmine.any(Function));
         done();
@@ -129,20 +145,30 @@ describe("createNetwork", () => {
 
   it("rejects the returned promise", done => {
     const networkStrategy = () => Promise.reject(new Error("myerror"));
-    createNetwork(config, logger, nullLifecycle, networkStrategy)
-      .newRequest()
-      .send()
-      .catch(error => {
-        expect(error.message).toEqual("myerror");
-        done();
-      });
+    const network = createNetwork(
+      config,
+      logger,
+      nullLifecycle,
+      networkStrategy
+    );
+    const payload = network.createPayload();
+    network.sendRequest(payload).catch(error => {
+      expect(error.message).toEqual("myerror");
+      done();
+    });
   });
 
   it("rejects the promise when response is invalid json", done => {
     const networkStrategy = () => Promise.resolve("badbody");
-    createNetwork(config, logger, nullLifecycle, networkStrategy)
-      .newRequest()
-      .send()
+    const network = createNetwork(
+      config,
+      logger,
+      nullLifecycle,
+      networkStrategy
+    );
+    const payload = network.createPayload();
+    network
+      .sendRequest(payload)
       .then(done.fail)
       .catch(e => {
         // The native parse error message is different based on the browser
@@ -172,9 +198,9 @@ describe("createNetwork", () => {
       }
     };
     const networkStrategy = () => Promise.resolve(JSON.stringify(myresponse));
-    createNetwork(config, logger, lifecycle, networkStrategy)
-      .newRequest()
-      .send();
+    const network = createNetwork(config, logger, lifecycle, networkStrategy);
+    const payload = network.createPayload();
+    network.sendRequest(payload);
   });
 
   [true, false].forEach(expectsResponse => {
@@ -185,8 +211,8 @@ describe("createNetwork", () => {
       };
       const networkStrategy = () => Promise.resolve("{}");
       const network = createNetwork(config, logger, lifecycle, networkStrategy);
-      const { payload, send } = network.newRequest(expectsResponse);
-      const responsePromise = send();
+      const payload = network.createPayload();
+      const responsePromise = network.sendRequest(payload, expectsResponse);
       responsePromise.then(() => {
         expect(lifecycle.onBeforeSend).toHaveBeenCalledWith({
           payload,
@@ -209,8 +235,8 @@ describe("createNetwork", () => {
       nullLifecycle,
       networkStrategy
     );
-    const { send } = network.newRequest(true);
-    send();
+    const payload = network.createPayload();
+    network.sendRequest(payload);
     setTimeout(() => {
       expect(loggerSpy.warn).not.toHaveBeenCalled();
       done();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The newRequest method of the network gateway proved to be confusing and limiting.  Having to announce whether the request expects a response before creating the payload is one example.  This PR splits the logic into methods `createPayload` and `sendRequest`.

## Related Issue

https://jira.corp.adobe.com/browse/CORE-31304



## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added/removed/modified tests to cover my changes and all tests pass.
- [x] I have run the Sandbox successfully.
