### PR TITLE
CORE-31430 Fix issue where identity would only be requested on viewStart

### DIFF
--- a/src/components/Audiences/index.js
+++ b/src/components/Audiences/index.js
@@ -25,6 +25,7 @@ const createAudiences = ({ config, logger }) => {
         event.mergeQuery({
           urlDestinations: true
         });
+        event.expectResponse();
       },
       onResponse(response) {
         const destinations = response.getPayloadByType("activation:push") || [];

--- a/src/components/DataCollector/createEvent.js
+++ b/src/components/DataCollector/createEvent.js
@@ -15,6 +15,7 @@ import { createMerger } from "../../utils";
 
 export default () => {
   const content = {};
+  let expectsResponse = false;
 
   return {
     setCorrelationId(correlationId) {
@@ -30,8 +31,11 @@ export default () => {
     mergeDevice: createMerger(content, "device"),
     mergeEnvironment: createMerger(content, "environment"),
     mergePlaceContext: createMerger(content, "placeContext"),
-    expectsResponse() {
-      return Boolean(content.query);
+    expectResponse() {
+      expectsResponse = true;
+    },
+    get expectsResponse() {
+      return expectsResponse;
     },
     toJSON() {
       return content;

--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -20,7 +20,7 @@ const createDataCollector = () => {
   let network;
 
   const makeServerCall = event => {
-    const expectsResponse = event.expectsResponse();
+    const { expectsResponse } = event;
     const { payload, send } = network.newRequest(expectsResponse);
     payload.addEvent(event);
     return send().then(response => {

--- a/src/components/Identity/index.js
+++ b/src/components/Identity/index.js
@@ -58,7 +58,9 @@ const createIdentity = ({ config, logger, cookie }) => {
       // We don't have an ECID, but the first request has gone out to
       // fetch it. We must wait for the response to come back with the
       // ECID before we can apply it to this payload.
+      logger.log("Delaying request while retrieving ECID from server.");
       promise = deferredForEcid.promise.then(() => {
+        logger.log("Resuming previously delayed request.");
         addIdsContext(payload, ecid);
       });
     } else {

--- a/src/components/Identity/index.js
+++ b/src/components/Identity/index.js
@@ -26,18 +26,19 @@ const createIdentity = ({ config, logger, cookie }) => {
   const getEcid = () => cookie.get(ECID_NAMESPACE);
 
   let ecid = getEcid();
+  let responseRequested = false;
   let deferredForEcid;
 
-  const onBeforeEvent = (event, isViewStart) => {
-    if (!isViewStart) {
-      return;
+  const onBeforeEvent = event => {
+    if (!ecid && !responseRequested) {
+      // TODO: Remove; We won't need to request id syncs explicitely.
+      // This is just for demo currently.
+      event.mergeQuery({
+        idSyncs: true
+      });
+      event.expectResponse();
+      responseRequested = true;
     }
-
-    // TODO: Remove; We won't need to request id syncs explicitely.
-    // This is just for demo currently.
-    event.mergeQuery({
-      idSyncs: true
-    });
   };
 
   // TO-DOCUMENT: We wait for ECID before trigger any events.

--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -37,6 +37,7 @@ const createPersonalization = ({ logger }) => {
             views: true
           }
         });
+        event.expectResponse();
       },
       onResponse(response) {
         const fragments = response.getPayloadByType(PAGE_HANDLE) || [];

--- a/src/core/network/fetch.js
+++ b/src/core/network/fetch.js
@@ -16,8 +16,7 @@ export default fetch => {
       method: "POST",
       cache: "no-cache",
       headers: {
-        // TODO: this will trigger a pre-flight request
-        "Content-Type": "application/json"
+        "Content-Type": "text/plain; charset=UTF-8"
       },
       referrer: "client",
       body


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This solves the problem brought up in https://github.com/adobe/alloy/issues/69. That is, if the ECID is not available on the client and the website executes `event` commands that do NOT have `type: viewStart`, then the first request would be sent but no ECID requested. The response therefore did not have an ECID and subsequent requests would never be sent (they were stuck in the queue waiting for an ECID). This PR fixes the problem by requesting the ECID on the first event regardless of whether it is `type: viewStart`.

This PR also gives components greater control over whether a response is expected by exposing an `expectResponse` method on the event rather than basing the response expectation on the existence of a `query` object. We were going to need this anyway when gateway becomes less reliant on the `query` object for sending data back from the server.

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-31430
https://jira.corp.adobe.com/browse/CORE-31429

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] (all tests pass, but we need functional tests) I have added/removed/modified tests to cover my changes and all tests pass.
- [X] I have run the Sandbox successfully.
