### PR TITLE
CORE-31304 move onBeforeSend into DataCollector as onBeforeDataCollection

### DIFF
--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -27,19 +27,18 @@ const createDataCollector = () => {
         return lifecycle.onBeforeDataCollection(payload, responsePromise);
       })
       .then(() => {
-        return network
-          .sendRequest(payload, payload.expectsResponse)
-          .then(response => {
-            const data = {
-              requestBody: clone(payload)
-            };
+        return network.sendRequest(payload, payload.expectsResponse);
+      })
+      .then(response => {
+        const data = {
+          requestBody: clone(payload)
+        };
 
-            if (response) {
-              data.responseBody = clone(response);
-            }
+        if (response) {
+          data.responseBody = clone(response);
+        }
 
-            return data;
-          });
+        return data;
       });
     return responsePromise;
   };

--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -20,20 +20,28 @@ const createDataCollector = () => {
   let network;
 
   const makeServerCall = event => {
-    const { expectsResponse } = event;
     const payload = network.createPayload();
     payload.addEvent(event);
-    return network.sendRequest(payload, expectsResponse).then(response => {
-      const data = {
-        requestBody: clone(payload)
-      };
+    const responsePromise = Promise.resolve()
+      .then(() => {
+        return lifecycle.onBeforeDataCollection(payload, responsePromise);
+      })
+      .then(() => {
+        return network
+          .sendRequest(payload, payload.expectsResponse)
+          .then(response => {
+            const data = {
+              requestBody: clone(payload)
+            };
 
-      if (response) {
-        data.responseBody = clone(response);
-      }
+            if (response) {
+              data.responseBody = clone(response);
+            }
 
-      return data;
-    });
+            return data;
+          });
+      });
+    return responsePromise;
   };
 
   const createEventHandler = options => {

--- a/src/components/Identity/index.js
+++ b/src/components/Identity/index.js
@@ -42,7 +42,7 @@ const createIdentity = ({ config, logger, cookie }) => {
   };
 
   // TO-DOCUMENT: We wait for ECID before trigger any events.
-  const onBeforeSend = ({ payload }) => {
+  const onBeforeDataCollection = payload => {
     payload.mergeMeta({
       identity: {
         lastSyncTS: 1222,
@@ -97,7 +97,7 @@ const createIdentity = ({ config, logger, cookie }) => {
   return {
     lifecycle: {
       onBeforeEvent,
-      onBeforeSend,
+      onBeforeDataCollection,
       onResponse
     },
     commands: {

--- a/src/core/createLifecycle.js
+++ b/src/core/createLifecycle.js
@@ -79,8 +79,13 @@ export default componentRegistry => {
     onOptInChanged: guardLifecycleMethod(permissions => {
       return invokeHook(componentRegistry, "onOptInChanged", permissions);
     }),
-    onBeforeSend: guardLifecycleMethod(request => {
-      return invokeHook(componentRegistry, "onBeforeSend", request);
+    onBeforeDataCollection: guardLifecycleMethod((payload, responsePromise) => {
+      return invokeHook(
+        componentRegistry,
+        "onBeforeDataCollection",
+        payload,
+        responsePromise
+      );
     })
     // TODO: We might need an `onError(error)` hook.
   };

--- a/src/core/network/createNetwork.js
+++ b/src/core/network/createNetwork.js
@@ -43,26 +43,19 @@ export default (config, logger, lifecycle, networkStrategy) => {
     createPayload,
     /**
      * Send the request to either interact or collect based on expectsResponse.
-     * The lifecycle method "onBeforeSend" will be triggered with
-     * { payload, responsePromise, isBeacon } as the parameter.  When the
-     * response is returned it will call the lifecycle method "onResponse"
+     * When the response is returned it will call the lifecycle method "onResponse"
      * with the returned response object.
      *
+     * @param {Object} payload This will be JSON stringified and sent as the post body.
      * @param {boolean} [expectsResponse=true] The endpoint and request mechanism
      * will be determined by whether a response is expected.
      * @returns {Promise} a promise resolved with the response object once the response is
-     * completely processed.
+     * completely processed.  If expectsResponse==false, the promise will be resolved
+     * with undefined.
      */
     sendRequest(payload, expectsResponse = true) {
       const requestID = uuid();
-      const responsePromise = Promise.resolve()
-        .then(() =>
-          lifecycle.onBeforeSend({
-            payload,
-            responsePromise,
-            isBeacon: !expectsResponse
-          })
-        )
+      return Promise.resolve()
         .then(() => {
           const action = expectsResponse ? "interact" : "collect";
           const url = `https://${edgeDomain}/${action}?propertyID=${propertyID}`;
@@ -93,8 +86,6 @@ export default (config, logger, lifecycle, networkStrategy) => {
 
           return handleResponsePromise;
         });
-
-      return responsePromise;
     }
   };
 };

--- a/src/core/network/createPayload.js
+++ b/src/core/network/createPayload.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { createMerger } from "../../utils";
+import { createMerger, find, isNonEmptyArray } from "../../utils";
 
 export default () => {
   const content = {};
@@ -30,6 +30,12 @@ export default () => {
       content.events.push(event);
     },
     mergeMeta: createMerger(content, "meta"),
+    get expectsResponse() {
+      return (
+        isNonEmptyArray(content.events) &&
+        find(content.events, event => event.expectsResponse) !== undefined
+      );
+    },
     toJSON() {
       return content;
     }

--- a/src/core/network/createPayload.js
+++ b/src/core/network/createPayload.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { createMerger, find, isNonEmptyArray } from "../../utils";
+import { createMerger } from "../../utils";
 
 export default () => {
   const content = {};
@@ -32,8 +32,8 @@ export default () => {
     mergeMeta: createMerger(content, "meta"),
     get expectsResponse() {
       return (
-        isNonEmptyArray(content.events) &&
-        find(content.events, event => event.expectsResponse) !== undefined
+        Array.isArray(content.events) &&
+        content.events.some(event => event.expectsResponse)
       );
     },
     toJSON() {

--- a/test/unit/components/DataCollector/index.spec.js
+++ b/test/unit/components/DataCollector/index.spec.js
@@ -1,0 +1,167 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import createDataCollector from "../../../../src/components/DataCollector/index";
+import createPayload from "../../../../src/core/network/createPayload";
+import { defer } from "../../../../src/utils";
+
+const flushPromises = () => {
+  const deferred = defer();
+  setTimeout(deferred.resolve, 0);
+  return deferred.promise;
+};
+
+describe("Event Command", () => {
+  let eventCommand;
+  let onBeforeEventSpy;
+  let onBeforeDataCollectionSpy;
+  let sendRequestSpy;
+  const lifecycle = {
+    onBeforeEvent: () => Promise.resolve(),
+    onBeforeDataCollection: () => Promise.resolve()
+  };
+  const network = {
+    createPayload,
+    sendRequest: () => Promise.resolve({})
+  };
+  beforeEach(() => {
+    onBeforeEventSpy = spyOn(lifecycle, "onBeforeEvent").and.callThrough();
+    onBeforeDataCollectionSpy = spyOn(
+      lifecycle,
+      "onBeforeDataCollection"
+    ).and.callThrough();
+    sendRequestSpy = spyOn(network, "sendRequest").and.callThrough();
+    const dataCollector = createDataCollector();
+    dataCollector.lifecycle.onComponentsRegistered({ lifecycle, network });
+    eventCommand = dataCollector.commands.event;
+  });
+
+  it("Calls onBeforeEvent", () => {
+    return eventCommand({}).then(() => {
+      expect(lifecycle.onBeforeEvent).toHaveBeenCalledWith(
+        jasmine.anything(),
+        false
+      );
+    });
+  });
+  it("Extracts isViewStart for onBeforeEvent", () => {
+    return eventCommand({ type: "viewStart" }).then(() => {
+      expect(lifecycle.onBeforeEvent).toHaveBeenCalledWith(
+        jasmine.anything(),
+        true
+      );
+    });
+  });
+  it("Calls onBeforeEvent with a matching event", () => {
+    eventCommand({ data: { a: 1 }, meta: { b: 2 } }).then(() => {
+      expect(lifecycle.onBeforeEvent.calls.argsFor(0)[0].toJSON().data).toEqual(
+        { a: 1 }
+      );
+      expect(lifecycle.onBeforeEvent.calls.argsFor(0)[0].toJSON().meta).toEqual(
+        { b: 2 }
+      );
+    });
+  });
+
+  it("Allows other components to modify the event", () => {
+    onBeforeEventSpy.and.callFake(event => {
+      event.mergeData({ a: "changed" });
+      return Promise.resolve();
+    });
+    return eventCommand({ data: { a: 1 } }).then(() => {
+      expect(
+        network.sendRequest.calls
+          .argsFor(0)[0]
+          .toJSON()
+          .events[0].toJSON().data
+      ).toEqual({ a: "changed" });
+    });
+  });
+
+  it("Allows other components to hold up the event", () => {
+    const deferred = defer();
+    onBeforeEventSpy.and.returnValue(deferred.promise);
+    eventCommand({});
+    return flushPromises().then(() => {
+      expect(lifecycle.onBeforeEvent).toHaveBeenCalled();
+      expect(network.sendRequest).not.toHaveBeenCalled();
+      deferred.resolve();
+      flushPromises().then(() => {
+        expect(network.sendRequest).toHaveBeenCalled();
+      });
+    });
+  });
+
+  it("Sends the event through to the Network Gateway", () => {
+    return eventCommand({ data: { a: 1 } }).then(() => {
+      expect(network.sendRequest).toHaveBeenCalled();
+    });
+  });
+
+  it("Calls onBeforeDataCollection", () => {
+    return eventCommand({}).then(() => {
+      expect(lifecycle.onBeforeDataCollection).toHaveBeenCalled();
+    });
+  });
+  it("The promise on onBeforeDataCollection resolves", () => {
+    return eventCommand({}).then(() => {
+      return lifecycle.onBeforeDataCollection.calls.argsFor(0)[1].then(data => {
+        expect(data.requestBody).toBeDefined();
+        expect(data.responseBody).toBeDefined();
+      });
+    });
+  });
+
+  it("Waits for onBeforeDataCollection promises", () => {
+    const deferred = defer();
+    onBeforeDataCollectionSpy.and.returnValue(deferred.promise);
+    eventCommand({});
+    return flushPromises().then(() => {
+      expect(lifecycle.onBeforeDataCollection).toHaveBeenCalled();
+      expect(network.sendRequest).not.toHaveBeenCalled();
+      deferred.resolve();
+      flushPromises().then(() => {
+        expect(network.sendRequest).toHaveBeenCalled();
+      });
+    });
+  });
+
+  it("Returns a promise resolved with the request and response", () => {
+    sendRequestSpy.and.returnValue(Promise.resolve({ my: "response" }));
+    return eventCommand({}).then(data => {
+      expect(data.requestBody).toBeDefined();
+      expect(data.responseBody).toEqual({ my: "response" });
+    });
+  });
+
+  it("sends expectsResponse == true", () => {
+    onBeforeEventSpy.and.callFake(event => {
+      event.expectResponse();
+      return Promise.resolve();
+    });
+    return eventCommand({}).then(() => {
+      expect(network.sendRequest).toHaveBeenCalledWith(
+        jasmine.anything(),
+        true
+      );
+    });
+  });
+
+  it("sends expectsResponse == false", () => {
+    return eventCommand({}).then(() => {
+      expect(network.sendRequest).toHaveBeenCalledWith(
+        jasmine.anything(),
+        false
+      );
+    });
+  });
+});

--- a/test/unit/components/DataCollector/index.spec.js
+++ b/test/unit/components/DataCollector/index.spec.js
@@ -3,7 +3,6 @@ Copyright 2019 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software distributed under
 the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 OF ANY KIND, either express or implied. See the License for the specific language
@@ -46,7 +45,7 @@ describe("Event Command", () => {
   });
   afterEach(() => {
     return flushPromises();
-  })
+  });
 
   it("Calls onBeforeEvent", () => {
     return eventCommand({}).then(() => {
@@ -66,12 +65,10 @@ describe("Event Command", () => {
   });
   it("Calls onBeforeEvent with a matching event", () => {
     eventCommand({ data: { a: 1 }, meta: { b: 2 } }).then(() => {
-      expect(lifecycle.onBeforeEvent.calls.argsFor(0)[0].toJSON().data).toEqual(
-        { a: 1 }
-      );
-      expect(lifecycle.onBeforeEvent.calls.argsFor(0)[0].toJSON().meta).toEqual(
-        { b: 2 }
-      );
+      expect(lifecycle.onBeforeEvent).toHaveBeenCalledWith({
+        data: { a: 1 },
+        meta: { b: 2 }
+      });
     });
   });
 

--- a/test/unit/components/DataCollector/index.spec.js
+++ b/test/unit/components/DataCollector/index.spec.js
@@ -14,9 +14,9 @@ import createDataCollector from "../../../../src/components/DataCollector/index"
 import createPayload from "../../../../src/core/network/createPayload";
 import { defer } from "../../../../src/utils";
 
-const flushPromises = () => {
+const flushPromises = returnValue => {
   const deferred = defer();
-  setTimeout(deferred.resolve, 0);
+  setTimeout(() => deferred.resolve(returnValue), 0);
   return deferred.promise;
 };
 
@@ -31,7 +31,7 @@ describe("Event Command", () => {
   };
   const network = {
     createPayload,
-    sendRequest: () => Promise.resolve({})
+    sendRequest: () => flushPromises({})
   };
   beforeEach(() => {
     onBeforeEventSpy = spyOn(lifecycle, "onBeforeEvent").and.callThrough();
@@ -44,6 +44,9 @@ describe("Event Command", () => {
     dataCollector.lifecycle.onComponentsRegistered({ lifecycle, network });
     eventCommand = dataCollector.commands.event;
   });
+  afterEach(() => {
+    return flushPromises();
+  })
 
   it("Calls onBeforeEvent", () => {
     return eventCommand({}).then(() => {

--- a/test/unit/core/network/createPayload.spec.js
+++ b/test/unit/core/network/createPayload.spec.js
@@ -1,0 +1,54 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import createPayload from "../../../../src/core/network/createPayload";
+import createEvent from "../../../../src/components/DataCollector/createEvent";
+
+describe("Payload", () => {
+  const interactEvent = createEvent();
+  interactEvent.expectResponse();
+  const collectEvent = createEvent();
+
+  it("doesn't expect a response when empty", () => {
+    expect(createPayload().expectsResponse).toBe(false);
+  });
+
+  it("doesn't expect a response with one collect event", () => {
+    const payload = createPayload();
+    payload.addEvent(collectEvent);
+    expect(payload.expectsResponse).toBe(false);
+  });
+
+  it("expects a response with one interact event", () => {
+    const payload = createPayload();
+    payload.addEvent(interactEvent);
+    expect(payload.expectsResponse).toBe(true);
+  });
+
+  it("expects a response with lots of events", () => {
+    const payload = createPayload();
+    payload.addEvent(collectEvent);
+    payload.addEvent(collectEvent);
+    payload.addEvent(interactEvent);
+    payload.addEvent(collectEvent);
+    expect(payload.expectsResponse).toBe(true);
+  });
+
+  it("doesn't expect a response with a bunch of collect Events", () => {
+    const payload = createPayload();
+    payload.addEvent(collectEvent);
+    payload.addEvent(collectEvent);
+    payload.addEvent(collectEvent);
+    payload.addEvent(collectEvent);
+    expect(payload.expectsResponse).toBe(false);
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Move onBeforeSend into DataCollector and rename it to onBeforeDataCollection.

## Related Issue

https://jira.corp.adobe.com/browse/CORE-31304
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

This gives the data collector more control over when the request is actually sent out.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
