### PR TITLE
Tnt 32590

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -16,6 +16,14 @@
     <title>Mock website hosting Alloy</title>
 
     <script>
+      !function(e,n,t){var i=e.head;if(i){
+        var o=e.createElement("style");
+        o.id="alloy-prehiding",o.innerText=n,i.appendChild(o),
+        setTimeout(function(){o.parentNode&&o.parentNode.removeChild(o)},t)}}
+        (document, "section:nth-of-type(1) { opacity: 0 !important }", 3000);
+    </script>
+
+    <script>
       !function(n,o){o.forEach(function(o){n[o]||((n.__alloyNS=n.__alloyNS||
       []).push(o),n[o]=function(){var u=arguments;return new Promise(
       function(i,l){n[o].q.push([i,l,u])})},n[o].q=[])})}
@@ -27,7 +35,7 @@
       alloy("configure", {
         propertyID: 9999999,
         log: true,
-        prehidingSelector: "#container"
+        prehidingStyle: "section:nth-of-type(1) { opacity: 0 !important }"
       });
 
       alloy("event", {

--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -35,6 +35,7 @@
       alloy("configure", {
         propertyID: 9999999,
         log: true,
+        prehidingId: "alloy-prehiding",
         prehidingStyle: "section:nth-of-type(1) { opacity: 0 !important }"
       });
 

--- a/sandbox/src/Home.js
+++ b/sandbox/src/Home.js
@@ -42,12 +42,14 @@ function HomeWithHistory({ history }) {
 
   return (
       <div>
-        <section>
-          <div className="mbox"></div>
+        <section>  
           <div className="container">
             <h2>Some awesome default content</h2>
             <br/>
           </div>
+        </section>
+
+        <section> 
           <div>
             <h1>Alloy: Getting Started</h1>
             <h3>Installation</h3>

--- a/src/components/Personalization/flicker/index.js
+++ b/src/components/Personalization/flicker/index.js
@@ -10,8 +10,15 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { createNode, appendNode, removeNode } from "../../../utils/dom";
+import {
+  createNode,
+  appendNode,
+  removeNode,
+  findById
+} from "../../../utils/dom";
 
+const CONTAINERS_HIDING_ID = "alloy-prehiding";
+const HIDING_STYLE_DEFINITION = "{ visibility: hidden }";
 const STYLE_TAG = "style";
 const CACHE = {};
 
@@ -23,8 +30,9 @@ export const hideElements = prehidingSelector => {
     return;
   }
 
-  const node = createNode(STYLE_TAG);
-  node.innerText = `${prehidingSelector} { visibility: hidden }`;
+  const node = createNode(STYLE_TAG, {
+    text: `${prehidingSelector} ${HIDING_STYLE_DEFINITION}`
+  });
 
   appendNode(document.head, node);
 
@@ -37,4 +45,38 @@ export const showElements = prehidingSelector => {
   if (node) {
     removeNode(node);
   }
+};
+
+export const hideContainers = prehidingStyle => {
+  if (!prehidingStyle) {
+    return;
+  }
+
+  // If containers prehiding style has been added
+  // by customer's prehiding snippet we don't
+  // want to add the same node
+  const node = findById(CONTAINERS_HIDING_ID);
+
+  if (node) {
+    return;
+  }
+
+  const styleNode = createNode(STYLE_TAG, {
+    id: CONTAINERS_HIDING_ID,
+    text: prehidingStyle
+  });
+
+  appendNode(document.head, styleNode);
+};
+
+export const showContainers = () => {
+  // If containers prehiding style exists
+  // we will remove it
+  const node = findById(CONTAINERS_HIDING_ID);
+
+  if (!node) {
+    return;
+  }
+
+  removeNode(node);
 };

--- a/src/components/Personalization/flicker/index.js
+++ b/src/components/Personalization/flicker/index.js
@@ -17,37 +17,39 @@ import {
   findById
 } from "../../../utils/dom";
 
-const CONTAINERS_HIDING_ID = "alloy-prehiding";
 const HIDING_STYLE_DEFINITION = "{ visibility: hidden }";
 const STYLE_TAG = "style";
-const CACHE = {};
+const styleNodes = {};
 
 export const hideElements = prehidingSelector => {
   // if we have different events with the same
   // prehiding selector we don't want to recreate
   // the style tag
-  if (CACHE[prehidingSelector]) {
+  if (styleNodes[prehidingSelector]) {
     return;
   }
 
-  const node = createNode(STYLE_TAG, {
-    text: `${prehidingSelector} ${HIDING_STYLE_DEFINITION}`
-  });
+  const attrs = {};
+  const props = {
+    innerText: `${prehidingSelector} ${HIDING_STYLE_DEFINITION}`
+  };
+  const node = createNode(STYLE_TAG, attrs, props);
 
   appendNode(document.head, node);
 
-  CACHE[prehidingSelector] = node;
+  styleNodes[prehidingSelector] = node;
 };
 
 export const showElements = prehidingSelector => {
-  const node = CACHE[prehidingSelector];
+  const node = styleNodes[prehidingSelector];
 
   if (node) {
     removeNode(node);
+    delete styleNodes[prehidingSelector];
   }
 };
 
-export const hideContainers = prehidingStyle => {
+export const hideContainers = (prehidingId, prehidingStyle) => {
   if (!prehidingStyle) {
     return;
   }
@@ -55,24 +57,23 @@ export const hideContainers = prehidingStyle => {
   // If containers prehiding style has been added
   // by customer's prehiding snippet we don't
   // want to add the same node
-  const node = findById(CONTAINERS_HIDING_ID);
+  const node = findById(prehidingId);
 
   if (node) {
     return;
   }
 
-  const styleNode = createNode(STYLE_TAG, {
-    id: CONTAINERS_HIDING_ID,
-    text: prehidingStyle
-  });
+  const attrs = { id: prehidingId };
+  const props = { innerText: prehidingStyle };
+  const styleNode = createNode(STYLE_TAG, attrs, props);
 
   appendNode(document.head, styleNode);
 };
 
-export const showContainers = () => {
+export const showContainers = prehidingId => {
   // If containers prehiding style exists
   // we will remove it
-  const node = findById(CONTAINERS_HIDING_ID);
+  const node = findById(prehidingId);
 
   if (!node) {
     return;

--- a/src/components/Personalization/flicker/index.js
+++ b/src/components/Personalization/flicker/index.js
@@ -19,6 +19,9 @@ import {
 
 const HIDING_STYLE_DEFINITION = "{ visibility: hidden }";
 const STYLE_TAG = "style";
+
+// Using global is OK since we have a single DOM
+// so storing nodes even for multiple Alloy instances is fine
 const styleNodes = {};
 
 export const hideElements = prehidingSelector => {

--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -49,7 +49,7 @@ const executeFragments = (fragments, modules, logger) => {
 };
 
 const createPersonalization = ({ config, logger }) => {
-  const { prehidingStyle } = config;
+  const { prehidingId, prehidingStyle } = config;
   let ruleComponentModules;
 
   return {
@@ -66,7 +66,7 @@ const createPersonalization = ({ config, logger }) => {
         }
 
         // For viewStart we try to hide the personalization containers
-        hideContainers(prehidingStyle);
+        hideContainers(prehidingId, prehidingStyle);
 
         event.mergeQuery({
           personalization: {
@@ -86,7 +86,7 @@ const createPersonalization = ({ config, logger }) => {
 
         // Once the all element are hidden
         // we have to show the containers
-        showContainers(prehidingStyle);
+        showContainers(prehidingId);
 
         executeFragments(fragments, ruleComponentModules, logger);
       }

--- a/src/core/configValidators.js
+++ b/src/core/configValidators.js
@@ -12,7 +12,7 @@ export default {
     validate: validDomain,
     defaultValue: "edgegateway.azurewebsites.net"
   },
-  prehidingSelector: {
+  prehidingStyle: {
     validate: eitherNilOrNonEmpty
   },
   // TODO: For debugging purposes only. Remove eventually.

--- a/src/core/configValidators.js
+++ b/src/core/configValidators.js
@@ -12,6 +12,9 @@ export default {
     validate: validDomain,
     defaultValue: "edgegateway.azurewebsites.net"
   },
+  prehidingId: {
+    defaultValue: "alloy-prehiding"
+  },
   prehidingStyle: {
     validate: eitherNilOrNonEmpty
   },

--- a/src/utils/config-validators/validPrehidingSelector.js
+++ b/src/utils/config-validators/validPrehidingSelector.js
@@ -1,0 +1,26 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import isNil from "../isNil";
+import isNonEmptyString from "../isNonEmptyString";
+
+export default (config, key, currentValue) => {
+  if (isNil(currentValue)) {
+    return "";
+  }
+
+  if (isNonEmptyString(currentValue)) {
+    return "";
+  }
+
+  return `Invalid value for ${key}: ${currentValue}`;
+};

--- a/src/utils/dom/createNode.js
+++ b/src/utils/dom/createNode.js
@@ -10,6 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import isFunction from "../isFunction";
 import appendNode from "./appendNode";
 
 export default function createNode(
@@ -23,12 +24,18 @@ export default function createNode(
   Object.keys(attrs).forEach(key => {
     const value = attrs[key];
 
-    if (typeof value === "function") {
-      result[key] = value;
-    } else {
-      // This sets value to a string
-      result.setAttribute(key, value);
+    if (key === "text") {
+      result.innerText = value;
+      return;
     }
+
+    if (isFunction(value)) {
+      result[key] = value;
+      return;
+    }
+
+    // This sets value to a string
+    result.setAttribute(key, value);
   });
 
   children.forEach(child => appendNode(result, child));

--- a/src/utils/dom/createNode.js
+++ b/src/utils/dom/createNode.js
@@ -10,32 +10,23 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import isFunction from "../isFunction";
 import appendNode from "./appendNode";
 
 export default function createNode(
   tag,
   attrs = {},
+  props = {},
   children = [],
   doc = document
 ) {
   const result = doc.createElement(tag);
 
   Object.keys(attrs).forEach(key => {
-    const value = attrs[key];
+    result.setAttribute(key, attrs[key]);
+  });
 
-    if (key === "text") {
-      result.innerText = value;
-      return;
-    }
-
-    if (isFunction(value)) {
-      result[key] = value;
-      return;
-    }
-
-    // This sets value to a string
-    result.setAttribute(key, value);
+  Object.keys(props).forEach(key => {
+    result[key] = props[key];
   });
 
   children.forEach(child => appendNode(result, child));

--- a/src/utils/dom/findById.js
+++ b/src/utils/dom/findById.js
@@ -10,17 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import isNil from "../isNil";
-import isNonEmptyString from "../isNonEmptyString";
-
-export default (config, key, currentValue) => {
-  if (isNil(currentValue)) {
-    return "";
-  }
-
-  if (isNonEmptyString(currentValue)) {
-    return "";
-  }
-
-  return `Invalid value for ${key}: ${currentValue}`;
-};
+/**
+ * Returns an array of matched DOM nodes.
+ * @param {String} id
+ * @param {Node} doc, defaults to document
+ * @returns {HTMLElement} an element of null
+ */
+export default function findById(id, doc = document) {
+  return doc.getElementById(id);
+}

--- a/src/utils/fireImage.js
+++ b/src/utils/fireImage.js
@@ -22,13 +22,13 @@ const IMAGE_TAG = "img";
  */
 export default ({ currentDocument = document, src }) => {
   return new Promise((resolve, reject) => {
-    const attributes = {
+    const attrs = { src };
+    const props = {
       onload: resolve,
       onerror: reject,
-      onabort: reject,
-      src
+      onabort: reject
     };
 
-    createNode(IMAGE_TAG, attributes, [], currentDocument);
+    createNode(IMAGE_TAG, attrs, props, [], currentDocument);
   });
 };

--- a/test/unit/core/configValidators.spec.js
+++ b/test/unit/core/configValidators.spec.js
@@ -25,7 +25,7 @@ describe("configValidators", () => {
     {
       propertyID: "myproperty1",
       edgeDomain: "STATS.FIRSTPARY.COM",
-      prehidingSelector: "#foo"
+      prehidingStyle: "#foo"
     }
   ];
 
@@ -36,7 +36,7 @@ describe("configValidators", () => {
     {
       propertyID: "myproperty1",
       edgeDomain: "stats firstparty.com",
-      prehidingSelector: ""
+      prehidingStyle: ""
     }
   ];
 

--- a/test/unit/utils/dom/createNode.spec.js
+++ b/test/unit/utils/dom/createNode.spec.js
@@ -27,7 +27,7 @@ describe("createNode", () => {
   });
 
   it("should createNode with tag, child", () => {
-    const element = createNode("DIV", {}, [createNode("p")]);
+    const element = createNode("DIV", {}, {}, [createNode("p")]);
 
     expect(element.tagName).toEqual("DIV");
     expect(element.firstElementChild.tagName).toEqual("P");

--- a/test/unit/utils/dom/findById.spec.js
+++ b/test/unit/utils/dom/findById.spec.js
@@ -10,9 +10,26 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export { default as awaitSelector } from "./awaitSelector";
-export { default as createNode } from "./createNode";
-export { default as appendNode } from "./appendNode";
-export { default as removeNode } from "./removeNode";
-export { default as selectNodes } from "./selectNodes";
-export { default as findById } from "./findById";
+import {
+  selectNodes,
+  removeNode,
+  appendNode,
+  createNode,
+  findById
+} from "../../../../src/utils/dom";
+
+describe("findById", () => {
+  afterEach(() => {
+    selectNodes("#fooById").forEach(removeNode);
+  });
+
+  it("should return the node if exists", () => {
+    appendNode(document.head, createNode("style", { id: "fooById" }));
+
+    expect(findById("fooById")).not.toBeNull();
+  });
+
+  it("should return array when nodes are NOT present", () => {
+    expect(findById("fooById")).toBeNull();
+  });
+});


### PR DESCRIPTION
Adding personalization component support for page/containers prehiding

## Description

Personalization component modifies the DOM nodes, so we need a way to manage flicker. The solution was to use `prehidingStyle` config option to be able customize the prehiding behavior. Since our current sandbox uses async loading I have added a prehiding snippet, so we at least have an example how that might work.

Personalization component had to be adjust such that for `personalization:page` handle we have to check all the `elementExists` events and prehide the elements using `prehidingSelector`, this is again necessary to avoid flicker. In the nutshell the workflow is like this:

1. Hide the page/containers
2. Fire a request
3. `onResponse` get the `personalization:page` fragments
4. Prehide all the events that have `moduleType` === `elementExists`
5. Show the page/containers
6. Execute the rules

## Related Issue

None

## Motivation and Context

Flicker management

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
