### PR TITLE
CORE-28205 Retry failed requests.

### DIFF
--- a/src/utils/executeWithRetry.js
+++ b/src/utils/executeWithRetry.js
@@ -1,0 +1,35 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/**
+ * Executes a function that returns promise. If the promise is rejected, the
+ * function will executed again. This will process continue until a promise
+ * returned from the function successfully resolves or the maximum number
+ * of retries has been reached.
+ * @param {Function} fn A function which returns a promise.
+ * @param {number} [maxRetries=3] The max number of retries.
+ */
+export default (fn, maxRetries = 3) => {
+  let retryCount = 0;
+  const execute = () => {
+    return fn().catch(e => {
+      if (retryCount < maxRetries) {
+        retryCount += 1;
+        return execute();
+      }
+
+      throw e;
+    });
+  };
+
+  return execute();
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -18,6 +18,7 @@ export { default as clone } from "./clone";
 export { default as cookie } from "./cookie";
 export { default as createMerger } from "./createMerger";
 export { default as defer } from "./defer";
+export { default as executeWithRetry } from "./executeWithRetry";
 export { default as find } from "./find";
 export { default as fireDestinations } from "./fireDestinations";
 export { default as fireImage } from "./fireImage";

--- a/test/unit/utils/executeWithRetry.spec.js
+++ b/test/unit/utils/executeWithRetry.spec.js
@@ -1,0 +1,42 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import executeWithRetry from "../../../src/utils/executeWithRetry";
+
+describe("executeWithRetry", () => {
+  it("executes a function only once if promise is resolved", () => {
+    const fn = jasmine.createSpy().and.returnValue(Promise.resolve("abc"));
+    return executeWithRetry(fn, 10).then(result => {
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(result).toBe("abc");
+    });
+  });
+
+  it("executes a function multiple times if promise is rejected", () => {
+    const fn = jasmine.createSpy().and.callFake(() => {
+      return fn.calls.count() < 4 ? Promise.reject() : Promise.resolve("abc");
+    });
+    return executeWithRetry(fn, 10).then(result => {
+      expect(fn).toHaveBeenCalledTimes(4);
+      expect(result).toBe("abc");
+    });
+  });
+
+  it("executes a function until maxRetries is met if promise is rejected", () => {
+    const mockError = new Error("bad thing");
+    const fn = jasmine.createSpy().and.returnValue(Promise.reject(mockError));
+    return executeWithRetry(fn, 10).catch(error => {
+      expect(fn).toHaveBeenCalledTimes(11);
+      expect(error).toBe(mockError);
+    });
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When a request fails, retry it up to a maximum of 3 retries (4 requests total).

We do have a case to consider where request 1 goes out, request 2 goes out, request 1 fails, request 2 succeeds, then the request 1 _retry_ goes out and succeeds. Will the server think that event 1 occurred after event 2? Should we be sending a timestamp so the server can sort it out correctly? I've brought this up on the alloy Slack channel if you'd like to join the conversation.

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-28205
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Trying hard to make requests succeed.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):
See the video in the alloy Slack channel.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All tests pass and I've made any necessary test changes.
- [X] I have run the Sandbox successfully.
