### PR TITLE
CORE-31388 use XDM keys and values for event types

### DIFF
--- a/sandbox/src/Home.js
+++ b/sandbox/src/Home.js
@@ -8,7 +8,7 @@ function HomeWithHistory({ history }) {
     if (loc.pathname !== previousPath) {
       const instanceName = loc.pathname.includes("orgTwo") ? "organizationTwo" : "alloy";
       window[instanceName]("event", {
-        type: "viewStart",
+        eventType: "web.webpagedetails.pageViews",
         data: {
           "xdm:URL": [window.location.href],
           "xdm:name": [loc.pathname.substring(1)]
@@ -20,7 +20,7 @@ function HomeWithHistory({ history }) {
 
   const visitDoc = ev => {
     window.alloy("event", {
-      type: "visit-doc",
+      eventType: "web.webinteraction.linkClicks",
       data: {
         "activitystreams:href": [ev.target.href],
         "activitystreams:name": [ev.target.name],
@@ -31,7 +31,7 @@ function HomeWithHistory({ history }) {
 
   const copyBaseCode = ev => {
     window.alloy("event", {
-      type: "copy-base-code",
+      eventType: "web.webinteraction.linkClicks",
       data: {
         "activitystreams:href": ["https://launch.gitbook.io/adobe-experience-platform-web-sdk/"],
         "activitystreams:name": ["copyBaseCode"],

--- a/sandbox/src/Links.js
+++ b/sandbox/src/Links.js
@@ -4,6 +4,7 @@ export default function Links() {
 
   const adobeLink = event => {
     window.alloy("event", {
+      eventType: "web.webinteraction.linkClicks",
       beacon: true,
       data: {
         "activitystreams:href": ["http://www.adobe.com"]

--- a/src/components/DataCollector/createEvent.js
+++ b/src/components/DataCollector/createEvent.js
@@ -24,6 +24,9 @@ export default () => {
     setTimestamp(timestamp) {
       content.timestamp = timestamp;
     },
+    setEventType(eventType) {
+      content.eventType = eventType;
+    },
     mergeData: createMerger(content, "data"),
     mergeMeta: createMerger(content, "meta"),
     mergeQuery: createMerger(content, "query"),

--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 import createEvent from "./createEvent";
 import { clone } from "../../utils";
 
-const VIEW_START_EVENT = "viewStart";
+const VIEW_START_EVENT = "web.webpagedetails.pageViews";
 
 const createDataCollector = () => {
   let lifecycle;
@@ -45,8 +45,9 @@ const createDataCollector = () => {
 
   const createEventHandler = options => {
     const event = createEvent();
-    const isViewStart = options.type === VIEW_START_EVENT;
+    const isViewStart = options.eventType === VIEW_START_EVENT;
 
+    event.setEventType(options.eventType);
     event.mergeData(options.data);
     event.mergeMeta(options.meta);
 

--- a/test/unit/components/DataCollector/index.spec.js
+++ b/test/unit/components/DataCollector/index.spec.js
@@ -56,12 +56,14 @@ describe("Event Command", () => {
     });
   });
   it("Extracts isViewStart for onBeforeEvent", () => {
-    return eventCommand({ type: "viewStart" }).then(() => {
-      expect(lifecycle.onBeforeEvent).toHaveBeenCalledWith(
-        jasmine.anything(),
-        true
-      );
-    });
+    return eventCommand({ eventType: "web.webpagedetails.pageViews" }).then(
+      () => {
+        expect(lifecycle.onBeforeEvent).toHaveBeenCalledWith(
+          jasmine.anything(),
+          true
+        );
+      }
+    );
   });
   it("Calls onBeforeEvent with a matching event", () => {
     eventCommand({ data: { a: 1 }, meta: { b: 2 } }).then(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Using the [xdm spec](https://github.com/adobe/xdm/blob/master/docs/reference/data/time-series.schema.md) for event type designations.  Key off of this for determining if the page is a viewStart or not.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[CORE-31388](https://jira.corp.adobe.com/browse/CORE-31388)

## Motivation and Context

The event type was not being passed on and only used internally.  This data should be passed to Konductor so that it can be reported on.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
