### PR TITLE
CORE-31840 Updates to match latest gateway specs.

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -10,8 +10,8 @@
           content="default-src 'self';
             script-src 'self' 'unsafe-inline';
             style-src 'self' 'unsafe-inline';
-            img-src 'self' http://edgegateway.azurewebsites.net/dests https://edgegateway.azurewebsites.net/dests;
-            connect-src 'self' https://edgegateway.azurewebsites.net http://ex-edge.stable-stage.aam-npe.adobeinternal.net http://localhost:8080"/>
+            img-src *;
+            connect-src 'self' https://alpha.konductor.adobedc.net https://edgegateway.azurewebsites.net http://ex-edge.stable-stage.aam-npe.adobeinternal.net http://localhost:8080"/>
 
     <title>Mock website hosting Alloy</title>
 
@@ -35,6 +35,7 @@
       // Set localEdge to true to use a locally-running edge gateway mock
       // https://git.corp.adobe.com/Activation/edge-gateway-mock
       alloy("configure", {
+        // edgeDomain: "alpha.konductor.adobedc.net",
         propertyID: 9999999,
         log: true,
         prehidingId: "alloy-prehiding",
@@ -55,6 +56,7 @@
 
       // For Testing multiple instances
       organizationTwo("configure", {
+        // edgeDomain: "alpha.konductor.adobedc.net",
         propertyID: 8888888,
         log: true
       });

--- a/src/components/Audiences/index.js
+++ b/src/components/Audiences/index.js
@@ -16,16 +16,9 @@ const createAudiences = ({ config, logger }) => {
   return {
     lifecycle: {
       onBeforeEvent(event, options, isViewStart) {
-        if (!isViewStart) {
-          return;
+        if (isViewStart) {
+          event.expectResponse();
         }
-
-        // TODO: Remove; We won't need to request destinations explicitely.
-        // This is just for demo currently.
-        event.mergeQuery({
-          urlDestinations: true
-        });
-        event.expectResponse();
       },
       onResponse(response) {
         const destinations = response.getPayloadByType("activation:push") || [];

--- a/src/components/Identity/index.js
+++ b/src/components/Identity/index.js
@@ -31,11 +31,6 @@ const createIdentity = ({ config, logger, cookie }) => {
 
   const onBeforeEvent = event => {
     if (!ecid && !responseRequested) {
-      // TODO: Remove; We won't need to request id syncs explicitely.
-      // This is just for demo currently.
-      event.mergeQuery({
-        idSyncs: true
-      });
       event.expectResponse();
       responseRequested = true;
     }

--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -61,21 +61,11 @@ const createPersonalization = ({ config, logger }) => {
         );
       },
       onBeforeEvent(event, options, isViewStart) {
-        if (!isViewStart) {
-          return;
+        if (isViewStart) {
+          // For viewStart we try to hide the personalization containers
+          hideContainers(prehidingId, prehidingStyle);
+          event.expectResponse();
         }
-
-        // For viewStart we try to hide the personalization containers
-        hideContainers(prehidingId, prehidingStyle);
-
-        event.mergeQuery({
-          personalization: {
-            page: true,
-            views: true
-          }
-        });
-
-        event.expectResponse();
       },
       onResponse(response) {
         const fragments = response.getPayloadByType(PAGE_HANDLE) || [];

--- a/src/constants/apiVersion.js
+++ b/src/constants/apiVersion.js
@@ -1,0 +1,1 @@
+export default "v1";

--- a/src/core/network/createNetwork.js
+++ b/src/core/network/createNetwork.js
@@ -67,7 +67,7 @@ export default (config, logger, lifecycle, networkStrategy) => {
           }
           // #endif
 
-          const url = `${baseUrl}/${action}?propertyID=${propertyID}`;
+          const url = `${baseUrl}/v1/${action}?propertyID=${propertyID}`;
           const responseHandlingMessage = expectsResponse
             ? ""
             : " (no response is expected)";

--- a/src/core/network/createNetwork.js
+++ b/src/core/network/createNetwork.js
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import createPayload from "./createPayload";
 import createResponse from "./createResponse";
 import { uuid } from "../../utils";
+import apiVersion from "../../constants/apiVersion";
 
 export default (config, logger, lifecycle, networkStrategy) => {
   const handleResponse = (requestID, responseBody) => {
@@ -67,7 +68,7 @@ export default (config, logger, lifecycle, networkStrategy) => {
           }
           // #endif
 
-          const url = `${baseUrl}/v1/${action}?propertyID=${propertyID}`;
+          const url = `${baseUrl}/${apiVersion}/${action}?propertyID=${propertyID}`;
           const responseHandlingMessage = expectsResponse
             ? ""
             : " (no response is expected)";

--- a/test/unit/core/network/createNetwork.spec.js
+++ b/test/unit/core/network/createNetwork.spec.js
@@ -42,7 +42,7 @@ describe("createNetwork", () => {
   it("calls interact by default", () => {
     return network.sendRequest({}, true).then(() => {
       expect(networkStrategy).toHaveBeenCalledWith(
-        "https://alloy.mysite.com/interact?propertyID=mypropertyid",
+        "https://alloy.mysite.com/v1/interact?propertyID=mypropertyid",
         "{}",
         true
       );
@@ -52,7 +52,7 @@ describe("createNetwork", () => {
   it("can call collect", () => {
     return network.sendRequest({}, false).then(() => {
       expect(networkStrategy).toHaveBeenCalledWith(
-        "https://alloy.mysite.com/collect?propertyID=mypropertyid",
+        "https://alloy.mysite.com/v1/collect?propertyID=mypropertyid",
         "{}",
         false
       );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This updates Alloy to match the latest gateway specs. Namely, we no longer have to pass `true` for the query options, as the gateway assumes `true` by default. Also, the gateway endpoint paths are versioned now.

This change is NOT compatible with the current mock gateway, but it IS compatible with this mock gateway PR: https://git.corp.adobe.com/Activation/edge-gateway-mock/pull/16 As such, we should merge the mock gateway PR at the same time-ish as this PR.

This change is NOT compatible with the real gateway, only because the real gateway does not support the plain text MIME type. It only supports the JSON MIME type, which forces pre-flight requests. Therefore, gateway will need to fix the MIME type issue before we can start using Alloy with it.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-31840
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Allow alpha users to test the real gateway.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] Against the PR - I have run the Sandbox successfully.
