### PR TITLE
CORE-31842 Show prehiding container on response error.

### DIFF
--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -79,6 +79,9 @@ const createPersonalization = ({ config, logger }) => {
         showContainers(prehidingId);
 
         executeFragments(fragments, ruleComponentModules, logger);
+      },
+      onResponseError() {
+        showContainers(prehidingId);
       }
     }
   };

--- a/src/core/createLifecycle.js
+++ b/src/core/createLifecycle.js
@@ -26,6 +26,7 @@ const hookNames = [
   "onComponentsRegistered",
   "onBeforeEvent",
   "onResponse",
+  "onResponseError",
   "onBeforeDataCollection"
 ];
 

--- a/src/core/network/createNetwork.js
+++ b/src/core/network/createNetwork.js
@@ -95,6 +95,10 @@ export default (config, logger, lifecycle, networkStrategy) => {
           }
 
           return handleResponsePromise;
+        })
+        .catch(error => {
+          lifecycle.onResponseError(error);
+          throw error;
         });
     }
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When the server returns an error or invalid JSON, unhide the website's default content because we failed to get personalized content.

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-31842
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Prevents the user from having to wait for the timeout period to finish before default content is shown.

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
