### PR TITLE
CORE-31840 Point to real gateway. Disconnect personalization component.

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -35,7 +35,10 @@
       // Set localEdge to true to use a locally-running edge gateway mock
       // https://git.corp.adobe.com/Activation/edge-gateway-mock
       alloy("configure", {
-        // edgeDomain: "alpha.konductor.adobedc.net",
+        // For testing with the mock gateway:
+        // edgeDomain: "edgegateway.azurewebsites.net",
+        // For testing with a locally-running mock gateway:
+        // localEdge: true,
         propertyID: 9999999,
         log: true,
         prehidingId: "alloy-prehiding",
@@ -56,7 +59,10 @@
 
       // For Testing multiple instances
       organizationTwo("configure", {
-        // edgeDomain: "alpha.konductor.adobedc.net",
+        // For testing with the mock gateway:
+        // edgeDomain: "edgegateway.azurewebsites.net",
+        // For testing with a locally-running mock gateway:
+        // localEdge: true,
         propertyID: 8888888,
         log: true
       });

--- a/src/core/configValidators.js
+++ b/src/core/configValidators.js
@@ -10,7 +10,7 @@ export default {
   },
   edgeDomain: {
     validate: validDomain,
-    defaultValue: "edgegateway.azurewebsites.net"
+    defaultValue: "alpha.konductor.adobedc.net"
   },
   prehidingId: {
     defaultValue: "alloy-prehiding"

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -21,7 +21,7 @@ import createLogController from "./createLogController";
 import createDataCollector from "../components/DataCollector";
 import createIdentity from "../components/Identity";
 import createAudiences from "../components/Audiences";
-import createPersonalization from "../components/Personalization";
+// import createPersonalization from "../components/Personalization";
 import createContext from "../components/Context";
 import createStitch from "../components/Stitch";
 import createLibraryInfo from "../components/LibraryInfo";
@@ -32,7 +32,7 @@ const componentCreators = [
   createDataCollector,
   createIdentity,
   createAudiences,
-  createPersonalization,
+  // createPersonalization,
   createContext,
   createStitch,
   createLibraryInfo


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Pointing to the real gateway. Right now the gateway isn't returning personalization content, but I'm not sure if that's just because nothing has been configured for personalization or if Konductor just isn't sending it regardless. To avoid any issues if Konductor happens to start returning personalization content, in which case it would be in an unexpected format, I've disconnected the personalization component entirely.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-31840
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Get to a state where we can create a build for alpha users to test the real gateway.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All tests pass and I've made any necessary test changes.
- [X] I have run the Sandbox successfully.
