### PR TITLE
CORE-32120 Added opt-in support.

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -36,6 +36,7 @@
       // https://git.corp.adobe.com/Activation/edge-gateway-mock
       alloy("configure", {
         // edgeDomain: "alpha.konductor.adobedc.net",
+        // optInEnabled: true,
         propertyID: 9999999,
         log: true,
         prehidingId: "alloy-prehiding",

--- a/sandbox/src/Stitch.js
+++ b/sandbox/src/Stitch.js
@@ -9,7 +9,7 @@ export default function Stitch() {
         "key1": "value1"
       },
       stitchId: stitchId.current
-    });
+    }).catch(console.error);
 
     setTimeout(() => {
       window.alloy("event", {
@@ -17,7 +17,7 @@ export default function Stitch() {
           "key2": "value2"
         },
         stitchId: stitchId.current
-      });
+      }).catch(console.error);
     }, 3000);
   }, []);
 

--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -18,6 +18,7 @@ const VIEW_START_EVENT = "viewStart";
 const createDataCollector = () => {
   let lifecycle;
   let network;
+  let optIn;
 
   const makeServerCall = event => {
     const payload = network.createPayload();
@@ -58,11 +59,13 @@ const createDataCollector = () => {
   return {
     lifecycle: {
       onComponentsRegistered(tools) {
-        ({ lifecycle, network } = tools);
+        ({ lifecycle, network, optIn } = tools);
       }
     },
     commands: {
-      event: createEventHandler
+      event(options) {
+        return optIn.whenOptedIn().then(() => createEventHandler(options));
+      }
     }
   };
 };

--- a/src/components/Privacy/index.js
+++ b/src/components/Privacy/index.js
@@ -1,0 +1,71 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { boolean } from "../../utils/config-validators";
+import { isString } from "../../utils";
+
+const throwInvalidPurposesError = purposes => {
+  throw new Error(
+    `Opt-in purposes must be "all" or "none". Received: ${purposes}`
+  );
+};
+
+const createPrivacy = ({ config, logger, enableOptIn, cookie }) => {
+  let optIn;
+
+  if (config.optInEnabled) {
+    enableOptIn(cookie);
+  }
+
+  return {
+    lifecycle: {
+      onComponentsRegistered(tools) {
+        ({ optIn } = tools);
+      }
+    },
+    commands: {
+      optIn({ purposes }) {
+        if (config.optInEnabled) {
+          if (isString(purposes)) {
+            const lowerCasePurposes = purposes.toLowerCase();
+
+            if (
+              lowerCasePurposes === optIn.ALL ||
+              lowerCasePurposes === optIn.NONE
+            ) {
+              optIn.setPurposes(purposes);
+            } else {
+              throwInvalidPurposesError(purposes);
+            }
+          } else {
+            throwInvalidPurposesError(purposes);
+          }
+        } else {
+          logger.warn(
+            "optInEnabled must be set to true before using the optIn command."
+          );
+        }
+      }
+    }
+  };
+};
+
+createPrivacy.namespace = "Privacy";
+
+createPrivacy.configValidators = {
+  optInEnabled: {
+    defaultValue: false,
+    validate: boolean
+  }
+};
+
+export default createPrivacy;

--- a/src/core/createCookie.js
+++ b/src/core/createCookie.js
@@ -23,23 +23,57 @@ const safeJSONParse = (object, cookieName) => {
   }
 };
 
+/**
+ * The purpose of this proxy is to cache the cookie so we don't have to
+ * read and deserialize it every time a piece of it is accessed.
+ */
+const createCookieProxy = (propertyID, cookieDomain = "") => {
+  const cookieName = `${ALLOY_COOKIE_NAME}_${propertyID}`;
+
+  let deserializedCookie;
+  let cookieHasBeenRead = false;
+
+  return {
+    get() {
+      // We don't read the cookie right when the cookie proxy is created
+      // because we don't know if the user has opted in. If the user
+      // hasn't opted in, we're legally obligated to not read the cookie.
+      // If a component tries to read something off the cookie though,
+      // we assume that the component has received word that the user
+      // has opted-in. The responsibility is on the component.
+      if (!cookieHasBeenRead) {
+        const serializedCookie = cookie.get(cookieName);
+        deserializedCookie =
+          serializedCookie && safeJSONParse(serializedCookie, cookieName);
+        cookieHasBeenRead = true;
+      }
+      return deserializedCookie;
+    },
+    set(updatedCookie) {
+      deserializedCookie = updatedCookie;
+      cookie.set(cookieName, updatedCookie, {
+        expires: ALLOY_COOKIE_TTL,
+        domain: cookieDomain || getTopLevelCookieDomain(window, cookie)
+      });
+    }
+  };
+};
+
 // TODO: Support passing a configurable expiry in the config when creating this cookie.
-const createCookie = (prefix, id, cookieDomain = "") => {
+const createCookie = (componentNamespace, propertyID, cookieDomain = "") => {
+  const cookieProxy = createCookieProxy(propertyID, cookieDomain);
+
   return {
     /**
      * Returns the value from AlloyCookie for a prefix and a key.
      * @param {...*} arg String key stored in alloy cookie under a component prefix.
      */
     get(name) {
-      const cookieName = `${ALLOY_COOKIE_NAME}_${id}`;
-      const currentCookie = cookie.get(cookieName);
-      const currentCookieParsed =
-        currentCookie && safeJSONParse(currentCookie, cookieName);
-
+      const currentCookie = cookieProxy.get();
       return (
-        currentCookieParsed &&
-        currentCookieParsed[prefix] &&
-        currentCookieParsed[prefix][name]
+        currentCookie &&
+        currentCookie[componentNamespace] &&
+        currentCookie[componentNamespace][name]
       );
     },
     /**
@@ -47,34 +81,27 @@ const createCookie = (prefix, id, cookieDomain = "") => {
      * @param {...*} arg Strings with key and value to be stored in alloy cookie.
      */
     set(key, value) {
-      const cookieName = `${ALLOY_COOKIE_NAME}_${id}`;
-      const currentCookie = cookie.get(cookieName)
-        ? safeJSONParse(cookie.get(cookieName))
-        : {};
-      const updatedCookie = {
-        ...currentCookie,
-        [prefix]: { ...currentCookie[prefix], [key]: value }
-      };
-
-      cookie.set(cookieName, updatedCookie, {
-        expires: ALLOY_COOKIE_TTL,
-        domain: cookieDomain || getTopLevelCookieDomain(window, cookie)
-      });
+      const currentCookie = cookieProxy.get() || {};
+      // Yes, we're mutating the object returned from the cookie proxy, but
+      // it's reasonably controlled since the side effects are all contained
+      // within this file.
+      currentCookie[componentNamespace] =
+        currentCookie[componentNamespace] || {};
+      currentCookie[componentNamespace][key] = value;
+      cookieProxy.set(currentCookie);
     },
     /**
      * Removes a key from alloy cookie.
      * @param {...*} arg String key stored in alloy cookie under a component prefix.
      */
     remove(key) {
-      const cookieName = `${ALLOY_COOKIE_NAME}_${id}`;
-      const currentCookie = cookie.get(cookieName);
-      const currentCookieParsed = currentCookie && safeJSONParse(currentCookie);
-      if (currentCookieParsed && currentCookieParsed[prefix]) {
-        delete currentCookieParsed[prefix][key];
-        cookie.set(cookieName, currentCookieParsed, {
-          expires: ALLOY_COOKIE_TTL,
-          domain: cookieDomain || getTopLevelCookieDomain(window, cookie)
-        });
+      const currentCookie = cookieProxy.get();
+      if (currentCookie && currentCookie[componentNamespace]) {
+        // Yes, we're mutating the object returned from the cookie proxy, but
+        // it's reasonably controlled since the side effects are all contained
+        // within this file.
+        delete currentCookie[componentNamespace][key];
+        cookieProxy.set(currentCookie);
       }
     }
   };

--- a/src/core/createLogController.js
+++ b/src/core/createLogController.js
@@ -10,13 +10,13 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export default (instanceNamespace, getNamespacedStorage) => {
+export default (instanceNamespace, createNamespacedStorage) => {
   // Segregate whether logging is enabled by the SDK instance name.
   // This way consumers can log one instance at a time.
   // TODO: Figure out how this plays out with segregating Web Storage
   // in the rest of the SDK. Is it segregated by Org ID or Property ID
   // in the rest of the SDK?
-  const storage = getNamespacedStorage(`instance.${instanceNamespace}.`);
+  const storage = createNamespacedStorage(`instance.${instanceNamespace}.`);
 
   let logEnabled = storage.persistent.getItem("log") === "true";
 

--- a/src/core/createOptIn.js
+++ b/src/core/createOptIn.js
@@ -14,13 +14,13 @@ import { defer } from "../utils";
 
 const COOKIE_NAMESPACE = "optIn";
 
-// The user has opted into all behaviors.
+// The user has opted into all purposes.
 const ALL = "all";
 
-// The user has opted into no behaviors.
+// The user has opted into no purposes.
 const NONE = "none";
 
-// The user has yet to provide opt-in behaviors.
+// The user has yet to provide opt-in purposes.
 const PENDING = "pending";
 
 export default () => {
@@ -65,7 +65,7 @@ export default () => {
       processDeferreds();
     },
     /**
-     * Whether the user has opted into all behaviors.
+     * Whether the user has opted into all purposes.
      * @returns {boolean}
      */
     // TODO Once we support opting into specific purposes, this
@@ -75,9 +75,9 @@ export default () => {
       return purposes === ALL;
     },
     /**
-     * Returns a promise that is resolved once the user opts into all behaviors.
+     * Returns a promise that is resolved once the user opts into all purposes.
      * If the user has already opted in, the promise will already be resolved.
-     * The user user opts into no behaviors, the promise will be rejected.
+     * The user user opts into no purposes, the promise will be rejected.
      */
     // TODO Once we support opting into specific purposes, this
     // method will accept an array of purpose names as an argument and

--- a/src/core/createOptIn.js
+++ b/src/core/createOptIn.js
@@ -1,0 +1,95 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { defer } from "../utils";
+
+const COOKIE_NAMESPACE = "optIn";
+
+// The user has opted into all behaviors.
+const ALL = "all";
+
+// The user has opted into no behaviors.
+const NONE = "none";
+
+// The user has yet to provide opt-in behaviors.
+const PENDING = "pending";
+
+export default () => {
+  const deferredsAwaitingResolution = [];
+  let cookie;
+  let purposes = ALL;
+
+  const processDeferreds = () => {
+    if (purposes === ALL || purposes === NONE) {
+      const optedIn = purposes === ALL;
+      while (deferredsAwaitingResolution.length) {
+        const deferred = deferredsAwaitingResolution.shift();
+
+        if (optedIn) {
+          deferred.resolve();
+        } else {
+          deferred.reject(new Error("User has opted out."));
+        }
+      }
+    }
+  };
+
+  return {
+    /**
+     * Only to be called by the Privacy component during startup. If opt-in
+     * isn't enabled, this method will not be called.
+     * @param {Object} _cookie The cookie management object, namespaced
+     * to the Privacy component.
+     */
+    enable(_cookie) {
+      cookie = _cookie;
+      purposes = cookie.get(COOKIE_NAMESPACE) || PENDING;
+    },
+    /**
+     * Update the purposes the user has opted into. Only to be called by the
+     * Privacy component.
+     * @param {string} newPurposes Can be "all" or "none".
+     */
+    setPurposes(newPurposes) {
+      purposes = newPurposes;
+      cookie.set(COOKIE_NAMESPACE, newPurposes);
+      processDeferreds();
+    },
+    /**
+     * Whether the user has opted into all behaviors.
+     * @returns {boolean}
+     */
+    // TODO Once we support opting into specific purposes, this
+    // method will accept an array of purpose names as an argument and
+    // return whether the user has opted into the specified purposes.
+    isOptedIn() {
+      return purposes === ALL;
+    },
+    /**
+     * Returns a promise that is resolved once the user opts into all behaviors.
+     * If the user has already opted in, the promise will already be resolved.
+     * The user user opts into no behaviors, the promise will be rejected.
+     */
+    // TODO Once we support opting into specific purposes, this
+    // method will accept an array of purpose names as an argument and
+    // will return a promise that will be resolved once the user has opted
+    // into the specified purposes.
+    whenOptedIn() {
+      const deferred = defer();
+      deferredsAwaitingResolution.push(deferred);
+      processDeferreds();
+      return deferred.promise;
+    },
+    ALL,
+    NONE
+  };
+};

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -23,6 +23,7 @@ import createIdentity from "../components/Identity";
 import createAudiences from "../components/Audiences";
 import createPersonalization from "../components/Personalization";
 import createContext from "../components/Context";
+import createPrivacy from "../components/Privacy";
 import createStitch from "../components/Stitch";
 import createLibraryInfo from "../components/LibraryInfo";
 
@@ -34,6 +35,7 @@ const componentCreators = [
   createAudiences,
   createPersonalization,
   createContext,
+  createPrivacy,
   createStitch,
   createLibraryInfo
 ];
@@ -41,17 +43,20 @@ const componentCreators = [
 // eslint-disable-next-line no-underscore-dangle
 const namespaces = window.__alloyNS;
 
-const storage = storageFactory(window);
+const createNamespacedStorage = storageFactory(window);
 
 if (namespaces) {
   namespaces.forEach(namespace => {
-    const logController = createLogController(namespace, storage);
+    const logController = createLogController(
+      namespace,
+      createNamespacedStorage
+    );
     const logger = createLogger(window, logController, `[${namespace}]`);
 
     const initializeComponents = initializeComponentsFactory(
       componentCreators,
       logger,
-      storage,
+      createNamespacedStorage,
       createCookie
     );
 

--- a/src/utils/config-validators/boolean.js
+++ b/src/utils/config-validators/boolean.js
@@ -10,7 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export { default as required } from "./required";
-export { default as validDomain } from "./validDomain";
-export { default as eitherNilOrNonEmpty } from "./eitherNilOrNonEmpty";
-export { default as boolean } from "./boolean";
+import isBoolean from "../isBoolean";
+
+export default (config, key, currentValue) => {
+  return isBoolean(currentValue)
+    ? ""
+    : `Value for ${key} is not a boolean: ${currentValue}`;
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -27,6 +27,7 @@ export { default as getNestedObject } from "./getNestedObject";
 export { default as getTopLevelCookieDomain } from "./getTopLevelCookieDomain";
 export { default as includes } from "./includes";
 export { default as intersection } from "./intersection";
+export { default as isBoolean } from "./isBoolean";
 export { default as isFunction } from "./isFunction";
 export { default as isNonEmptyArray } from "./isNonEmptyArray";
 export { default as isNonEmptyString } from "./isNonEmptyString";

--- a/src/utils/isBoolean.js
+++ b/src/utils/isBoolean.js
@@ -10,7 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export { default as required } from "./required";
-export { default as validDomain } from "./validDomain";
-export { default as eitherNilOrNonEmpty } from "./eitherNilOrNonEmpty";
-export { default as boolean } from "./boolean";
+/**
+ * Returns whether the value is a boolean.
+ * @param {*} value
+ * @returns {boolean}
+ */
+export default value => typeof value === "boolean";

--- a/test/unit/components/DataCollector/index.spec.js
+++ b/test/unit/components/DataCollector/index.spec.js
@@ -12,12 +12,7 @@ governing permissions and limitations under the License.
 import createDataCollector from "../../../../src/components/DataCollector/index";
 import createPayload from "../../../../src/core/network/createPayload";
 import { defer } from "../../../../src/utils";
-
-const flushPromises = returnValue => {
-  const deferred = defer();
-  setTimeout(() => deferred.resolve(returnValue), 0);
-  return deferred.promise;
-};
+import flushPromises from "../../flushPromises";
 
 describe("Event Command", () => {
   let eventCommand;
@@ -30,7 +25,12 @@ describe("Event Command", () => {
   };
   const network = {
     createPayload,
-    sendRequest: () => flushPromises({})
+    sendRequest: () => flushPromises().then(() => ({}))
+  };
+  const optIn = {
+    whenOptedIn() {
+      return Promise.resolve();
+    }
   };
   beforeEach(() => {
     onBeforeEventSpy = spyOn(lifecycle, "onBeforeEvent").and.callThrough();
@@ -40,7 +40,11 @@ describe("Event Command", () => {
     ).and.callThrough();
     sendRequestSpy = spyOn(network, "sendRequest").and.callThrough();
     const dataCollector = createDataCollector();
-    dataCollector.lifecycle.onComponentsRegistered({ lifecycle, network });
+    dataCollector.lifecycle.onComponentsRegistered({
+      lifecycle,
+      network,
+      optIn
+    });
     eventCommand = dataCollector.commands.event;
   });
   afterEach(() => {

--- a/test/unit/core/createCookie.spec.js
+++ b/test/unit/core/createCookie.spec.js
@@ -65,6 +65,17 @@ describe("createCookie", () => {
     );
   });
 
+  it("should only read the cookie from storage once (for optimization)", () => {
+    cookie.set(`${COOKIE_NAME}_${testID1}`, `{"${prefix}":{"key1":"val1"}}`);
+    alloyCookie = createCookie(prefix, testID1);
+    expect(alloyCookie.get("key1")).toBe("val1");
+    removeAllCookies();
+    expect(alloyCookie.get("key1")).toBe("val1");
+    alloyCookie.set("key1", "val2");
+    removeAllCookies();
+    expect(alloyCookie.get("key1")).toBe("val2");
+  });
+
   it("should update a stored value", () => {
     alloyCookie = createCookie(prefix, testID1);
 

--- a/test/unit/core/createOptIn.spec.js
+++ b/test/unit/core/createOptIn.spec.js
@@ -118,5 +118,19 @@ describe("createOptIn", () => {
         expect(optedOutSpy).toHaveBeenCalledWith(jasmine.any(Error));
       });
     });
+
+    it("resolves nested whenOptedIn calls", () => {
+      const optedInSpy = jasmine.createSpy();
+      optIn.enable(cookie);
+      optIn
+        .whenOptedIn()
+        .then(() => optIn.whenOptedIn())
+        .then(optedInSpy);
+      optIn.setPurposes("all");
+
+      return flushPromises().then(() => {
+        expect(optedInSpy).toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/test/unit/core/createOptIn.spec.js
+++ b/test/unit/core/createOptIn.spec.js
@@ -1,0 +1,122 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import createOptIn from "../../../src/core/createOptIn";
+import flushPromises from "../flushPromises";
+
+describe("createOptIn", () => {
+  let optIn;
+
+  beforeEach(() => {
+    optIn = createOptIn();
+  });
+
+  describe("when disabled", () => {
+    it("considers the user opted in", () => {
+      expect(optIn.isOptedIn()).toBe(true);
+      return optIn.whenOptedIn();
+    });
+  });
+
+  describe("when enabled", () => {
+    let cookie;
+
+    beforeEach(() => {
+      cookie = jasmine.createSpyObj("cookie", ["get", "set"]);
+      cookie.get.and.returnValue(null);
+    });
+
+    it("considers the user opted in if cookie is set to 'all'", () => {
+      cookie.get.and.returnValue("all");
+      optIn.enable(cookie);
+
+      expect(optIn.isOptedIn()).toBe(true);
+      return optIn.whenOptedIn();
+    });
+
+    it("considers the user opted out if cookie is set to 'none'", done => {
+      cookie.get.and.returnValue("none");
+      optIn.enable(cookie);
+
+      expect(optIn.isOptedIn()).toBe(false);
+      optIn.whenOptedIn().catch(error => {
+        expect(error).toBeDefined();
+        done();
+      });
+    });
+
+    it("considers the user pending opt in if cookie is not set", () => {
+      const optedInSpy = jasmine.createSpy();
+      optIn.enable(cookie);
+
+      expect(optIn.isOptedIn()).toBe(false);
+      optIn.whenOptedIn().then(optedInSpy);
+      return flushPromises().then(() => {
+        expect(optedInSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    it("considers the user opted in after the user opts in", () => {
+      const optedInSpy = jasmine.createSpy();
+      optIn.enable(cookie);
+      optIn.whenOptedIn().then(optedInSpy);
+      optIn.setPurposes("all");
+
+      expect(cookie.set).toHaveBeenCalledWith("optIn", "all");
+      expect(optIn.isOptedIn()).toBe(true);
+      return flushPromises().then(() => {
+        expect(optedInSpy).toHaveBeenCalled();
+      });
+    });
+
+    it("considers the user opted out after the user opts out", () => {
+      const optedOutSpy = jasmine.createSpy();
+      optIn.enable(cookie);
+      optIn.whenOptedIn().catch(optedOutSpy);
+      optIn.setPurposes("none");
+
+      expect(cookie.set).toHaveBeenCalledWith("optIn", "none");
+      expect(optIn.isOptedIn()).toBe(false);
+      return flushPromises().then(() => {
+        expect(optedOutSpy).toHaveBeenCalledWith(jasmine.any(Error));
+      });
+    });
+
+    it("considers the user opted in after the user opts out then opts in", () => {
+      const optedInSpy = jasmine.createSpy();
+      optIn.enable(cookie);
+      optIn.setPurposes("none");
+      optIn.setPurposes("all");
+      optIn.whenOptedIn().then(optedInSpy);
+
+      expect(cookie.set).toHaveBeenCalledWith("optIn", "all");
+      expect(optIn.isOptedIn()).toBe(true);
+      return flushPromises().then(() => {
+        expect(optedInSpy).toHaveBeenCalled();
+      });
+    });
+
+    it("considers the user opted out after the user opts in then opts out", () => {
+      const optedOutSpy = jasmine.createSpy();
+      optIn.enable(cookie);
+      optIn.setPurposes("all");
+      optIn.setPurposes("none");
+      optIn.whenOptedIn().catch(optedOutSpy);
+
+      expect(cookie.set).toHaveBeenCalledWith("optIn", "none");
+      expect(optIn.isOptedIn()).toBe(false);
+      return flushPromises().then(() => {
+        expect(optedOutSpy).toHaveBeenCalledWith(jasmine.any(Error));
+      });
+    });
+  });
+});

--- a/test/unit/flushPromises.js
+++ b/test/unit/flushPromises.js
@@ -3,14 +3,14 @@ Copyright 2019 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software distributed under
 the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
 
-export { default as required } from "./required";
-export { default as validDomain } from "./validDomain";
-export { default as eitherNilOrNonEmpty } from "./eitherNilOrNonEmpty";
-export { default as boolean } from "./boolean";
+/**
+ * Returns a promise that will be resolved after all currently resolved promises.
+ * @returns {Promise}
+ */
+export default () => new Promise(resolve => setTimeout(resolve));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There's some verbiage that's a little weird here. The user can opt into all purposes or no purposes (later, we plan to support opting into specific purposes). Another way you could say that the user is opted into no purposes is that they've "opted out", but using the term "opted out" can be confusing because "opt out" is a separate effort/task/flag that is separate from opt-in. So, yeah.

Opt-in can currently be in one of three statuses:

* The user's opt-in preferences are pending (we're waiting for the user to tell us what they're okay with).
* The user has opted into all purposes.
* The user has opted into no purposes.

Opt-in can be enabled by settings `optInEnabled: true` through the `configure` command. If opt-in is not enabled, then we assume that the user has opted into all purposes.

Our customers can set whether the user has opted into all purposes or no purposes as follows:

```
alloy("optIn", {
  purposes: "all"
});
```

or

```
alloy("optIn", {
  purposes: "none"
});
```

If the `optIn` command has not been called for the user, then whenever Alloy needs to do something that depends on the user having opted in (e.g., send data to the server), it will wait for the `optIn` command to be called before proceeding. If `optIn` is called with `purposes: "all"`, then Alloy will proceed doing to the work that was previously queued. If `optIn` is called with `purposes: "none"`, then Alloy will not proceed with the work that was previously queued and the promises returned from the prior commands will be rejected.

Once the `optIn` command has been called, the user's preferences will be stored in a cookie and used in perpetuity until the cookie expires or the `optIn` command is called again to change the user's preferences.

As far as architecture goes, I've added an `optIn` object that gets passed to all components. The components can use the `whenOptedIn` and `isOptedIn` methods on the `optIn` object to decision based on whether the user has opted into all purposes. See the documentation above each of the methods for more information and how they might change when we start supporting opting into individual purposes.

I've added a new component called Privacy. It is in charge of setting up the optIn object that handed to all the components. For example, it's in charge of telling the optIn object whether opt-in is enabled. It's also in charge of providing the optIn object with a cookie object that manages the privacy namespace in the alloy cookie. Because this setup needs to happen before components start calling `whenOptedIn` and `isOptedIn`, a function called `enableOptIn` is first passed to all component instances when they are created. The privacy component calls this `enableOptIn` function right away and should be the only component to call that function. Then, all components will receive the configured optIn object during `onComponentsRegistered` and therefore can start calling `whenOptedIn` and `isOptedIn`.

I think that covers the general design.

I did not add tests at the component level. There's a discussion that needs to happen as a team regarding (1) how we flush promises during tests and (2) what we want to unit test vs functional test. I'd like to see where that conversation goes before implementing such tests.

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-32120

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Users like privacy.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All tests pass and I've made any necessary test changes.
- [X] I have run the Sandbox successfully.
