### PR TITLE
Add the ability to interpret selectors with "eq(...)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@adobe/reactor-cookie": "^1.0.0",
     "@adobe/reactor-object-assign": "^1.0.0",
     "@adobe/reactor-query-string": "^1.0.0",
+    "css.escape": "^1.5.1",
     "mitt": "^1.1.3",
     "mockserver-node": "^5.5.2",
     "uuid": "^3.3.2"

--- a/src/components/Personalization/flicker/index.js
+++ b/src/components/Personalization/flicker/index.js
@@ -34,7 +34,7 @@ export const hideElements = prehidingSelector => {
 
   const attrs = {};
   const props = {
-    innerText: `${prehidingSelector} ${HIDING_STYLE_DEFINITION}`
+    textContent: `${prehidingSelector} ${HIDING_STYLE_DEFINITION}`
   };
   const node = createNode(STYLE_TAG, attrs, props);
 
@@ -67,7 +67,7 @@ export const hideContainers = (prehidingId, prehidingStyle) => {
   }
 
   const attrs = { id: prehidingId };
-  const props = { innerText: prehidingStyle };
+  const props = { textContent: prehidingStyle };
   const styleNode = createNode(STYLE_TAG, attrs, props);
 
   appendNode(document.head, styleNode);

--- a/src/utils/dom/awaitSelector.js
+++ b/src/utils/dom/awaitSelector.js
@@ -113,8 +113,8 @@ export const awaitUsingTimer = (selector, timeout, selectFunc) => {
 
 export default function awaitSelector(
   selector,
-  timeout = MAX_POLLING_TIMEOUT,
   selectFunc = selectNodes,
+  timeout = MAX_POLLING_TIMEOUT,
   win = window,
   doc = document
 ) {

--- a/src/utils/dom/index.js
+++ b/src/utils/dom/index.js
@@ -15,4 +15,5 @@ export { default as createNode } from "./createNode";
 export { default as appendNode } from "./appendNode";
 export { default as removeNode } from "./removeNode";
 export { default as selectNodes } from "./selectNodes";
+export { selectNodesWithEq } from "./selectNodesWithEq";
 export { default as findById } from "./findById";

--- a/src/utils/dom/selectNodesWithEq.js
+++ b/src/utils/dom/selectNodesWithEq.js
@@ -14,6 +14,7 @@ import isNonEmptyString from "../isNonEmptyString";
 import selectNodes from "./selectNodes";
 
 // ID and CSS classes can not start with digits
+// Pleas check https://www.w3.org/TR/css-syntax-3/#escaping
 const DIGIT_IN_SELECTOR_PATTERN = /(#|\.)(-)?(\d{1})(.*)/g;
 // This is required to remove leading " > " from parsed pieces
 const SIBLING_PATTERN = /^\s*>?\s*/;

--- a/src/utils/dom/selectNodesWithEq.js
+++ b/src/utils/dom/selectNodesWithEq.js
@@ -1,0 +1,121 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import isNonEmptyArray from "../isNonEmptyArray";
+import isNonEmptyString from "../isNonEmptyString";
+import selectNodes from "./selectNodes";
+
+// ID and CSS classes can not start with digits
+const DIGIT_IN_SELECTOR_PATTERN = /((\.|#)(-)?\d{1})/g;
+// This is required to remove leading " > " from parsed pieces
+const SIBLING_PATTERN = /^\s*>?\s*/;
+const EQ_START = ":eq(";
+const EQ_PATTERN = /:eq\((\d+)\)/g;
+
+const cleanUp = str => str.replace(SIBLING_PATTERN, "").trim();
+const isNotEqSelector = str => str.indexOf(EQ_START) === -1;
+
+const createPair = match => {
+  const first = match.charAt(0);
+  const second = match.charAt(1);
+  const third = match.charAt(2);
+  const result = { key: match };
+
+  if (second === "-") {
+    result.val = `${first}${second}\\3${third} `;
+  } else {
+    result.val = `${first}\\3${second} `;
+  }
+
+  return result;
+};
+
+export const escapeDigitsInSelector = selector => {
+  const matches = selector.match(DIGIT_IN_SELECTOR_PATTERN);
+
+  if (isNonEmptyArray(matches)) {
+    const pairs = matches.map(createPair);
+
+    return pairs.reduce(
+      (acc, pair) => acc.replace(pair.key, pair.val),
+      selector
+    );
+  }
+
+  return selector;
+};
+
+export const parseSelector = rawSelector => {
+  const result = [];
+  const selector = escapeDigitsInSelector(rawSelector.trim());
+  const parts = selector.split(EQ_PATTERN).filter(isNonEmptyString);
+  const { length } = parts;
+  let i = 0;
+
+  while (i < length) {
+    const sel = cleanUp(parts[i]);
+    const eq = parts[i + 1];
+
+    if (eq) {
+      result.push({ sel, eq: Number(eq) });
+    } else {
+      result.push({ sel });
+    }
+
+    i += 2;
+  }
+
+  return result;
+};
+
+/**
+ * Returns an array of matched DOM nodes.
+ * @param {String} selector that contains Sizzle "eq(...)" pseudo selector
+ * @param {Node} doc, defaults to document
+ * @returns {Array} an array of DOM nodes
+ */
+export const selectNodesWithEq = (selector, doc = document) => {
+  if (isNotEqSelector(selector)) {
+    return selectNodes(selector, doc);
+  }
+
+  const parts = parseSelector(selector);
+  const { length } = parts;
+  let result = null;
+  let context = doc;
+  let i = 0;
+
+  while (i < length) {
+    const { sel, eq } = parts[i];
+    const nodes = selectNodes(sel, context);
+
+    if (i < length - 1) {
+      if (eq == null) {
+        [context] = nodes;
+      } else {
+        context = nodes[eq];
+      }
+    }
+
+    if (i === length - 1) {
+      if (eq == null) {
+        result = nodes;
+      } else {
+        result = [nodes[eq]];
+      }
+    }
+
+    i += 1;
+  }
+
+  return result;
+};

--- a/test/unit/components/Personalization/actions/setHtml.spec.js
+++ b/test/unit/components/Personalization/actions/setHtml.spec.js
@@ -9,13 +9,13 @@ import createSetHtml from "../../../../../src/components/Personalization/actions
 const cleanUp = () => {
   selectNodes("div#setHtml").forEach(removeNode);
   selectNodes("style").forEach(node => {
-    if (node.innerText.indexOf("setHtml") !== -1) {
+    if (node.textContent.indexOf("setHtml") !== -1) {
       removeNode(node);
     }
   });
 };
 
-describe("Presonalization::actions::setHtml", () => {
+describe("Personalization::actions::setHtml", () => {
   beforeEach(() => {
     cleanUp();
   });
@@ -28,7 +28,7 @@ describe("Presonalization::actions::setHtml", () => {
     const collect = jasmine.createSpy();
     const setHtml = createSetHtml(collect);
     const element = createNode("div", { id: "setHtml" });
-    element.innerText = "foo";
+    element.textContent = "foo";
 
     appendNode(document.body, element);
 
@@ -37,7 +37,7 @@ describe("Presonalization::actions::setHtml", () => {
 
     setHtml(settings, event);
 
-    expect(element.innerText).toEqual("bar");
+    expect(element.textContent).toEqual("bar");
     expect(collect).toHaveBeenCalledWith({
       meta: { personalization: { a: 1 } }
     });

--- a/test/unit/components/Personalization/events/elementExists.spec.js
+++ b/test/unit/components/Personalization/events/elementExists.spec.js
@@ -9,13 +9,13 @@ import elementExists from "../../../../../src/components/Personalization/events/
 const cleanUp = () => {
   selectNodes("span#elementExists").forEach(removeNode);
   selectNodes("style").forEach(node => {
-    if (node.innerText.indexOf("elementExists") !== -1) {
+    if (node.textContent.indexOf("elementExists") !== -1) {
       removeNode(node);
     }
   });
 };
 
-describe("Presonalization::events::elementExists", () => {
+describe("Personalization::events::elementExists", () => {
   beforeEach(() => {
     cleanUp();
   });

--- a/test/unit/components/Personalization/flicker/index.spec.js
+++ b/test/unit/components/Personalization/flicker/index.spec.js
@@ -4,7 +4,7 @@ import {
   showElements
 } from "../../../../../src/components/Personalization/flicker";
 
-describe("Presonalization::flicker", () => {
+describe("Personalization::flicker", () => {
   beforeEach(() => {
     selectNodes("style").forEach(removeNode);
   });
@@ -22,7 +22,7 @@ describe("Presonalization::flicker", () => {
 
     expect(styles.length).toEqual(1);
 
-    const styleDefinition = styles[0].innerText;
+    const styleDefinition = styles[0].textContent;
 
     expect(styleDefinition).toEqual(
       `${prehidingSelector} { visibility: hidden }`

--- a/test/unit/utils/dom/appendNode.spec.js
+++ b/test/unit/utils/dom/appendNode.spec.js
@@ -15,7 +15,7 @@ import appendNode from "../../../../src/utils/dom/appendNode";
 import selectNodes from "../../../../src/utils/dom/selectNodes";
 import removeNode from "../../../../src/utils/dom/removeNode";
 
-describe("appendNode", () => {
+describe("DOM::appendNode", () => {
   afterEach(() => {
     selectNodes("div").forEach(removeNode);
   });

--- a/test/unit/utils/dom/awaitSelector.spec.js
+++ b/test/unit/utils/dom/awaitSelector.spec.js
@@ -14,7 +14,7 @@ import awaitSelector from "../../../../src/utils/dom/awaitSelector";
 import selectNodes from "../../../../src/utils/dom/selectNodes";
 import { createNode, appendNode, removeNode } from "../../../../src/utils/dom";
 
-describe("awaitSelector", () => {
+describe("DOM::awaitSelector", () => {
   const createAndAppendNodeDelayed = id => {
     setTimeout(() => {
       appendNode(document.head, createNode("div", { id }));
@@ -28,7 +28,7 @@ describe("awaitSelector", () => {
   };
 
   const awaitSelectorAndAssert = (id, win, doc, done) => {
-    const result = awaitSelector(`#${id}`, 1000, selectNodes, win, doc);
+    const result = awaitSelector(`#${id}`, selectNodes, 1000, win, doc);
 
     createAndAppendNodeDelayed(id);
 

--- a/test/unit/utils/dom/createNode.spec.js
+++ b/test/unit/utils/dom/createNode.spec.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 import createNode from "../../../../src/utils/dom/createNode";
 
-describe("createNode", () => {
+describe("DOM::createNode", () => {
   it("should createNode with tag only", () => {
     const element = createNode("DIV");
 

--- a/test/unit/utils/dom/findById.spec.js
+++ b/test/unit/utils/dom/findById.spec.js
@@ -18,7 +18,7 @@ import {
   findById
 } from "../../../../src/utils/dom";
 
-describe("findById", () => {
+describe("DOM::findById", () => {
   afterEach(() => {
     selectNodes("#fooById").forEach(removeNode);
   });

--- a/test/unit/utils/dom/removeNode.spec.js
+++ b/test/unit/utils/dom/removeNode.spec.js
@@ -15,7 +15,7 @@ import appendNode from "../../../../src/utils/dom/appendNode";
 import removeNode from "../../../../src/utils/dom/removeNode";
 import selectNodes from "../../../../src/utils/dom/selectNodes";
 
-describe("removeNode", () => {
+describe("DOM::removeNode", () => {
   afterEach(() => {
     selectNodes("div").forEach(removeNode);
   });

--- a/test/unit/utils/dom/selectNodes.spec.js
+++ b/test/unit/utils/dom/selectNodes.spec.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 import selectNodes from "../../../../src/utils/dom/selectNodes";
 
-describe("selectNodes", () => {
+describe("DOM::selectNodes", () => {
   it("should return array when nodes are present", () => {
     expect(selectNodes("HEAD").length).toEqual(1);
   });

--- a/test/unit/utils/dom/selectNodesWithEq.spec.js
+++ b/test/unit/utils/dom/selectNodesWithEq.spec.js
@@ -50,13 +50,6 @@ describe("DOM::escapeDigitsInSelector", () => {
     expect(result).toEqual(".-\\31 23");
     expect(document.querySelector(result)).toEqual(null);
   });
-
-  it("should escape when double hyphens and digits class selector", () => {
-    const result = escapeDigitsInSelector(".--123");
-
-    expect(result).toEqual(".--123");
-    expect(document.querySelector(result)).toEqual(null);
-  });
 });
 
 describe("DOM::parseSelector", () => {

--- a/test/unit/utils/dom/selectNodesWithEq.spec.js
+++ b/test/unit/utils/dom/selectNodesWithEq.spec.js
@@ -1,0 +1,142 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+  createNode,
+  appendNode,
+  selectNodes,
+  removeNode
+} from "../../../../src/utils/dom";
+import {
+  escapeDigitsInSelector,
+  parseSelector,
+  selectNodesWithEq
+} from "../../../../src/utils/dom/selectNodesWithEq";
+
+describe("DOM::escapeDigitsInSelector", () => {
+  it("should escape when digits only for ID selector", () => {
+    const result = escapeDigitsInSelector("#123");
+
+    expect(result).toEqual("#\\31 23");
+    expect(document.querySelector(result)).toEqual(null);
+  });
+
+  it("should escape when digits only for class selector", () => {
+    const result = escapeDigitsInSelector(".123");
+
+    expect(result).toEqual(".\\31 23");
+    expect(document.querySelector(result)).toEqual(null);
+  });
+
+  it("should escape when hyphen and digits ID selector", () => {
+    const result = escapeDigitsInSelector("#-123");
+
+    expect(result).toEqual("#-\\31 23");
+    expect(document.querySelector(result)).toEqual(null);
+  });
+
+  it("should escape when hyphen and digits class selector", () => {
+    const result = escapeDigitsInSelector(".-123");
+
+    expect(result).toEqual(".-\\31 23");
+    expect(document.querySelector(result)).toEqual(null);
+  });
+
+  it("should escape when double hyphens and digits class selector", () => {
+    const result = escapeDigitsInSelector(".--123");
+
+    expect(result).toEqual(".--123");
+    expect(document.querySelector(result)).toEqual(null);
+  });
+});
+
+describe("DOM::parseSelector", () => {
+  it("should parse selector when no eq", () => {
+    const result = parseSelector("#test");
+
+    expect(result[0]).toEqual({ sel: "#test" });
+  });
+
+  it("should parse selector when eq", () => {
+    const result = parseSelector(
+      "HTML > BODY > DIV.wrapper:eq(0) > HEADER.header:eq(0) > DIV.pagehead:eq(0) > P:nth-of-type(1)"
+    );
+
+    expect(result[0]).toEqual({ sel: "HTML > BODY > DIV.wrapper", eq: 0 });
+    expect(result[1]).toEqual({ sel: "HEADER.header", eq: 0 });
+    expect(result[2]).toEqual({ sel: "DIV.pagehead", eq: 0 });
+    expect(result[3]).toEqual({ sel: "P:nth-of-type(1)" });
+  });
+});
+
+describe("DOM::selectNodesWithEq", () => {
+  afterEach(() => {
+    selectNodes(".eq").forEach(removeNode);
+  });
+
+  it("should select when no eq", () => {
+    appendNode(document.body, createNode("DIV", { id: "noEq", class: "eq" }));
+
+    const result = selectNodesWithEq("#noEq");
+
+    expect(result[0].tagName).toEqual("DIV");
+    expect(result[0].id).toEqual("noEq");
+  });
+
+  it("should select when eq and just one element", () => {
+    const content = `
+      <div class="b">
+        <div class="c">first</div>
+
+        <div class="c">second</div>
+        
+        <div class="c">third</div>
+      </div>
+    `;
+
+    appendNode(
+      document.body,
+      createNode("DIV", { id: "abc", class: "eq" }, { innerHTML: content })
+    );
+
+    const result = selectNodesWithEq("#abc:eq(0) > div.b:eq(0) > div.c:eq(0)");
+
+    expect(result[0].tagName).toEqual("DIV");
+    expect(result[0].textContent).toEqual("first");
+  });
+
+  it("should select when eq and multiple elements", () => {
+    const content = `
+      <div class="b">
+        <div class="c">first</div>
+
+        <div class="c">second</div>
+        
+        <div class="c">third</div>
+      </div>
+    `;
+
+    appendNode(
+      document.body,
+      createNode("DIV", { id: "abc", class: "eq" }, { innerHTML: content })
+    );
+
+    const result = selectNodesWithEq("#abc:eq(0) > div.b:eq(0) > div.c");
+
+    expect(result[0].tagName).toEqual("DIV");
+    expect(result[0].textContent).toEqual("first");
+    expect(result[1].tagName).toEqual("DIV");
+    expect(result[1].textContent).toEqual("second");
+    expect(result[2].tagName).toEqual("DIV");
+    expect(result[2].textContent).toEqual("third");
+  });
+});

--- a/test/unit/utils/dom/selectNodesWithEq.spec.js
+++ b/test/unit/utils/dom/selectNodesWithEq.spec.js
@@ -17,35 +17,35 @@ import {
   removeNode
 } from "../../../../src/utils/dom";
 import {
-  escapeDigitsInSelector,
+  escapeIdentifiersInSelector,
   parseSelector,
   selectNodesWithEq
 } from "../../../../src/utils/dom/selectNodesWithEq";
 
-describe("DOM::escapeDigitsInSelector", () => {
+describe("DOM::escapeIdentifiersInSelector", () => {
   it("should escape when digits only for ID selector", () => {
-    const result = escapeDigitsInSelector("#123 > #foo div.345");
+    const result = escapeIdentifiersInSelector("#123 > #foo div.345");
 
     expect(result).toEqual("#\\31 23 > #foo div.\\33 45");
     expect(document.querySelector(result)).toEqual(null);
   });
 
   it("should escape when digits only for class selector", () => {
-    const result = escapeDigitsInSelector(".123");
+    const result = escapeIdentifiersInSelector(".123");
 
     expect(result).toEqual(".\\31 23");
     expect(document.querySelector(result)).toEqual(null);
   });
 
   it("should escape when hyphen and digits ID selector", () => {
-    const result = escapeDigitsInSelector("#-123");
+    const result = escapeIdentifiersInSelector("#-123");
 
     expect(result).toEqual("#-\\31 23");
     expect(document.querySelector(result)).toEqual(null);
   });
 
   it("should escape when hyphen and digits class selector", () => {
-    const result = escapeDigitsInSelector(".-123");
+    const result = escapeIdentifiersInSelector(".-123");
 
     expect(result).toEqual(".-\\31 23");
     expect(document.querySelector(result)).toEqual(null);


### PR DESCRIPTION
Add the ability to interpret selectors with "eq(...)"

## Description

If the personalization engine that runs on the Experience Edge is powered by Adobe Target we might get selectors that are not 100% CSS selectors, these might contain `eq(...)` pseudo selectors. This PR add a new DOM related function named `selectNodesWithEq` that should be able to interpret these selectors and find the right DOM nodes.

## Related Issue

None

## Motivation and Context

Allow Adobe Target decisions and personalization content to be used without any issues.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
