### PR TITLE
TNT-32917 - adding rearrange Target VEC action support

### DIFF
--- a/src/components/Personalization/actions/rearrange.js
+++ b/src/components/Personalization/actions/rearrange.js
@@ -17,7 +17,7 @@ const COMMENT_NODE = 8;
 const toArray = elements => [].slice.call(elements);
 const notComment = element => element.nodeType !== COMMENT_NODE;
 
-const rearangeChildren = (element, from, to) => {
+const rearrangeChildren = (element, from, to) => {
   const children = toArray(element.children).filter(notComment);
   const elementFrom = children[from];
   const elementTo = children[to];
@@ -42,7 +42,7 @@ export default collect => {
     const { from, to } = content;
 
     elements.forEach(element => {
-      rearangeChildren(element, from, to);
+      rearrangeChildren(element, from, to);
     });
 
     // after rendering we should remove the flicker control styles

--- a/src/components/Personalization/actions/rearrange.js
+++ b/src/components/Personalization/actions/rearrange.js
@@ -14,10 +14,11 @@ import { showElements } from "../flicker";
 
 const COMMENT_NODE = 8;
 
+const toArray = elements => [].slice.call(elements);
+const notComment = element => element.nodeType !== COMMENT_NODE;
+
 const rearangeChildren = (element, from, to) => {
-  const children = [...element.children].filter(
-    e => e.nodeType !== COMMENT_NODE
-  );
+  const children = toArray(element.children).filter(notComment);
   const elementFrom = children[from];
   const elementTo = children[to];
 

--- a/src/components/Personalization/actions/rearrange.js
+++ b/src/components/Personalization/actions/rearrange.js
@@ -1,0 +1,53 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { showElements } from "../flicker";
+
+const COMMENT_NODE = 8;
+
+const rearangeChildren = (element, from, to) => {
+  const children = [...element.children].filter(
+    e => e.nodeType !== COMMENT_NODE
+  );
+  const elementFrom = children[from];
+  const elementTo = children[to];
+
+  if (!elementFrom || !elementTo) {
+    // TODO: We will need to add logging
+    // to ease troubleshooting
+    return;
+  }
+
+  if (from < to) {
+    element.insertBefore(elementFrom, elementTo.nextElementSibling);
+  } else {
+    element.insertBefore(elementFrom, elementTo);
+  }
+};
+
+export default collect => {
+  return (settings, event) => {
+    const { elements, prehidingSelector } = event;
+    const { content, meta } = settings;
+    const { from, to } = content;
+
+    elements.forEach(element => {
+      rearangeChildren(element, from, to);
+    });
+
+    // after rendering we should remove the flicker control styles
+    showElements(prehidingSelector);
+
+    // make sure we send back the metadata after successful rendering
+    collect({ meta: { personalization: meta } });
+  };
+};

--- a/src/components/Personalization/turbine/initRuleComponentModules.js
+++ b/src/components/Personalization/turbine/initRuleComponentModules.js
@@ -18,6 +18,7 @@ import createSetImageSource from "../actions/setImageSource";
 import createSetStyle from "../actions/setStyle";
 import createMove from "../actions/move";
 import createResize from "../actions/resize";
+import createRearrange from "../actions/rearrange";
 
 export default collect => {
   const setHtml = createSetHtml(collect);
@@ -27,6 +28,7 @@ export default collect => {
   const setStyle = createSetStyle(collect);
   const move = createMove(collect);
   const resize = createResize(collect);
+  const rearrange = createRearrange(collect);
 
   return {
     elementExists,
@@ -36,6 +38,7 @@ export default collect => {
     setImageSource,
     setStyle,
     move,
-    resize
+    resize,
+    rearrange
   };
 };

--- a/test/unit/components/Personalization/actions/rearrange.spec.js
+++ b/test/unit/components/Personalization/actions/rearrange.spec.js
@@ -1,0 +1,92 @@
+import {
+  selectNodes,
+  removeNode,
+  appendNode,
+  createNode
+} from "../../../../../src/utils/dom";
+import createRearrange from "../../../../../src/components/Personalization/actions/rearrange";
+
+const cleanUp = () => {
+  selectNodes("ul#rearrange").forEach(removeNode);
+  selectNodes("style").forEach(node => {
+    if (node.textContent.indexOf("rearrange") !== -1) {
+      removeNode(node);
+    }
+  });
+};
+
+describe("Presonalization::actions::rearrange", () => {
+  beforeEach(() => {
+    cleanUp();
+  });
+
+  afterEach(() => {
+    cleanUp();
+  });
+
+  it("should rearrange elements when from < to", () => {
+    const collect = jasmine.createSpy();
+    const rearrange = createRearrange(collect);
+    const content = `
+      <li>1</li>
+      <li>2</li>
+      <li>3</li>
+    `;
+    const element = createNode(
+      "ul",
+      { id: "rearrange" },
+      { innerHTML: content }
+    );
+    const elements = [element];
+
+    appendNode(document.body, element);
+
+    const settings = { content: { from: 0, to: 2 }, meta: { a: 1 } };
+    const event = { elements, prehidingSelector: "#rearrange" };
+
+    rearrange(settings, event);
+
+    const result = selectNodes("li");
+
+    expect(result[0].textContent).toEqual("2");
+    expect(result[1].textContent).toEqual("3");
+    expect(result[2].textContent).toEqual("1");
+
+    expect(collect).toHaveBeenCalledWith({
+      meta: { personalization: { a: 1 } }
+    });
+  });
+
+  it("should rearrange elements when from > to", () => {
+    const collect = jasmine.createSpy();
+    const rearrange = createRearrange(collect);
+    const content = `
+      <li>1</li>
+      <li>2</li>
+      <li>3</li>
+    `;
+    const element = createNode(
+      "ul",
+      { id: "rearrange" },
+      { innerHTML: content }
+    );
+    const elements = [element];
+
+    appendNode(document.body, element);
+
+    const settings = { content: { from: 2, to: 0 }, meta: { a: 1 } };
+    const event = { elements, prehidingSelector: "#rearrange" };
+
+    rearrange(settings, event);
+
+    const result = selectNodes("li");
+
+    expect(result[0].textContent).toEqual("3");
+    expect(result[1].textContent).toEqual("1");
+    expect(result[2].textContent).toEqual("2");
+
+    expect(collect).toHaveBeenCalledWith({
+      meta: { personalization: { a: 1 } }
+    });
+  });
+});


### PR DESCRIPTION
Adding rearrange Target VEC action support

## Description

Adding rearrange Target VEC action support

## Related Issue

NONE

## Motivation and Context

In Target VEC there is a UI action named `rearange` that allows to drag and drop a particular element, by changing it's position within the children of a particular element.

For example if we have an HTML element like:
```html
<ul>
  <li>1</li>
  <li>2</li>
  <li>3</li>
</ul>
```
And we have a `rearrange` action that has these details:
```json
{
  "moduleType": "rearrange",
  "settings": {
      "content": {
        "from": 0,
        "to": 2
      }
  }
}
```
The the HTML would change to:
```html
<ul>
  <li>2</li>
  <li>3</li>
  <li>1</li>
</ul>
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
