### PR TITLE
Improved promise flushing to fully flush chains.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,5 +14,8 @@ module.exports = {
     // We enable the rule in src/.eslintrc.js since that's the only place we
     // want to disallow importing extraneous dependencies.
     "import/no-extraneous-dependencies": "off"
+  },
+  globals: {
+    expectAsync: "readonly" // newer jasmine feature
   }
 };

--- a/karma-saucelabs.conf.js
+++ b/karma-saucelabs.conf.js
@@ -2,7 +2,7 @@ const karmaSauceLauncher = require("karma-sauce-launcher");
 
 const karmaConfig = require("./karma.conf.js");
 
-module.exports = function(config) {
+module.exports = config => {
   karmaConfig(config);
 
   const customLaunchers = {

--- a/src/baseCode/index.js
+++ b/src/baseCode/index.js
@@ -14,6 +14,7 @@ governing permissions and limitations under the License.
 /* eslint no-underscore-dangle: 0 */
 /* eslint prefer-rest-params: 0 */
 /* eslint no-var: 0 */
+/* eslint-disable func-names */
 
 /**
  * This is the code, once minified, that an Alloy consumer copies and pastes

--- a/test/functional/helpers/runner.js
+++ b/test/functional/helpers/runner.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/* eslint-disable no-console */
 const createTestCafe = require("testcafe");
 const glob = require("glob");
 const supportedBrowsers = require("./supportedBrowsers");

--- a/test/unit/helpers/flushPromiseChains.js
+++ b/test/unit/helpers/flushPromiseChains.js
@@ -10,7 +10,21 @@ governing permissions and limitations under the License.
 */
 
 /**
- * Returns a promise that will be resolved after all currently resolved promises.
+ * Returns a promise that will be resolved after all outstanding promise chains
+ * have been flushed. This assumes (1) that the promise chains to be flushed
+ * resolve their promises promptly (rather than doing something like
+ * setTimeout(..., 100) somewhere in the chain) and (2) that the chains
+ * are no longer than 10 promises long.
  * @returns {Promise}
  */
-export default () => new Promise(resolve => setTimeout(resolve));
+export default () => {
+  let promise;
+
+  for (let i = 0; i < 10; i += 1) {
+    promise = promise
+      ? promise.then(() => Promise.resolve())
+      : Promise.resolve();
+  }
+
+  return promise;
+};

--- a/test/unit/specs/components/DataCollector/index.spec.js
+++ b/test/unit/specs/components/DataCollector/index.spec.js
@@ -12,27 +12,28 @@ governing permissions and limitations under the License.
 import createDataCollector from "../../../../../src/components/DataCollector/index";
 import createPayload from "../../../../../src/core/network/createPayload";
 import { defer } from "../../../../../src/utils";
-import flushPromises from "../../../helpers/flushPromises";
+import flushPromiseChains from "../../../helpers/flushPromiseChains";
 
 describe("Event Command", () => {
-  let eventCommand;
+  let lifecycle;
+  let network;
+  let optIn;
   let onBeforeEventSpy;
   let onBeforeDataCollectionSpy;
   let sendRequestSpy;
-  const lifecycle = {
-    onBeforeEvent: () => Promise.resolve(),
-    onBeforeDataCollection: () => Promise.resolve()
-  };
-  const network = {
-    createPayload,
-    sendRequest: () => flushPromises().then(() => ({}))
-  };
-  const optIn = {
-    whenOptedIn() {
-      return Promise.resolve();
-    }
-  };
+  let eventCommand;
   beforeEach(() => {
+    lifecycle = {
+      onBeforeEvent: () => Promise.resolve(),
+      onBeforeDataCollection: () => Promise.resolve()
+    };
+    network = {
+      createPayload,
+      sendRequest: () => Promise.resolve({})
+    };
+    optIn = {
+      whenOptedIn: () => Promise.resolve()
+    };
     onBeforeEventSpy = spyOn(lifecycle, "onBeforeEvent").and.callThrough();
     onBeforeDataCollectionSpy = spyOn(
       lifecycle,
@@ -46,9 +47,6 @@ describe("Event Command", () => {
       optIn
     });
     eventCommand = dataCollector.commands.event;
-  });
-  afterEach(() => {
-    return flushPromises();
   });
 
   it("Calls onBeforeEvent", () => {
@@ -101,11 +99,11 @@ describe("Event Command", () => {
     const deferred = defer();
     onBeforeEventSpy.and.returnValue(deferred.promise);
     eventCommand({});
-    return flushPromises().then(() => {
+    return flushPromiseChains().then(() => {
       expect(lifecycle.onBeforeEvent).toHaveBeenCalled();
       expect(network.sendRequest).not.toHaveBeenCalled();
       deferred.resolve();
-      flushPromises().then(() => {
+      flushPromiseChains().then(() => {
         expect(network.sendRequest).toHaveBeenCalled();
       });
     });
@@ -135,11 +133,11 @@ describe("Event Command", () => {
     const deferred = defer();
     onBeforeDataCollectionSpy.and.returnValue(deferred.promise);
     eventCommand({});
-    return flushPromises().then(() => {
+    return flushPromiseChains().then(() => {
       expect(lifecycle.onBeforeDataCollection).toHaveBeenCalled();
       expect(network.sendRequest).not.toHaveBeenCalled();
       deferred.resolve();
-      flushPromises().then(() => {
+      flushPromiseChains().then(() => {
         expect(network.sendRequest).toHaveBeenCalled();
       });
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The existing `flushPromises` module only flushed currently resolved/rejected promises, but our tests were assuming that they would flush the whole promise chain. This changes `flushPromises` to `flushPromiseChains` and, like the comments say:

```
Returns a promise that will be resolved after all outstanding promise chains
 * have been flushed. This assumes (1) that the promise chains to be flushed
 * resolve their promises promptly (rather than doing something like
 * setTimeout(..., 100) somewhere in the chain) and (2) that the chains
 * are no longer than 10 promises long.
```

<!--- Describe your changes in detail -->

## Related Issue
None.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
More robust testing
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
