### PR TITLE
TNT-32923 - adding Target VEC prependHtml action support

### DIFF
--- a/src/components/Personalization/actions/prependHtml.js
+++ b/src/components/Personalization/actions/prependHtml.js
@@ -24,10 +24,17 @@ const createFragment = content => {
 const prependHtml = (container, content) => {
   const fragment = createFragment(content);
   const elements = [].slice.call(fragment.children);
+  const { length } = elements;
+  let i = length - 1;
 
-  elements.forEach(element => {
+  // We are inserting elements in reverse order
+  while (i >= 0) {
+    const element = elements[i];
+
     container.insertBefore(element, container.firstElementChild);
-  });
+
+    i -= 1;
+  }
 };
 
 export default collect => {

--- a/src/components/Personalization/actions/prependHtml.js
+++ b/src/components/Personalization/actions/prependHtml.js
@@ -1,0 +1,49 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { showElements } from "../flicker";
+
+const DIV_TAG = "DIV";
+
+const createFragment = content => {
+  const result = document.createElement(DIV_TAG);
+  result.innerHTML = content;
+
+  return result;
+};
+
+const prependHtml = (container, content) => {
+  const fragment = createFragment(content);
+  const elements = [].slice.call(fragment.children);
+
+  elements.forEach(element => {
+    container.insertBefore(element, container.firstElementChild);
+  });
+};
+
+export default collect => {
+  return (settings, event) => {
+    const { elements, prehidingSelector } = event;
+    const { content, meta } = settings;
+
+    // this is a very naive approach, we will expand later
+    elements.forEach(element => {
+      prependHtml(element, content);
+    });
+
+    // after rendering we should remove the flicker control styles
+    showElements(prehidingSelector);
+
+    // make sure we send back the metadata after successful rendering
+    collect({ meta: { personalization: meta } });
+  };
+};

--- a/src/components/Personalization/turbine/initRuleComponentModules.js
+++ b/src/components/Personalization/turbine/initRuleComponentModules.js
@@ -23,6 +23,7 @@ import createRemove from "../actions/remove";
 import createInsertAfter from "../actions/insertAfter";
 import createInsertBefore from "../actions/insertBefore";
 import createReplaceHtml from "../actions/replaceHtml";
+import createPrependHtml from "../actions/prependHtml";
 
 export default collect => {
   const setHtml = createSetHtml(collect);
@@ -37,6 +38,7 @@ export default collect => {
   const insertAfter = createInsertAfter(collect);
   const insertBefore = createInsertBefore(collect);
   const replaceHtml = createReplaceHtml(collect);
+  const prependHtml = createPrependHtml(collect);
 
   return {
     elementExists,
@@ -51,6 +53,7 @@ export default collect => {
     remove,
     insertAfter,
     insertBefore,
-    replaceHtml
+    replaceHtml,
+    prependHtml
   };
 };

--- a/test/unit/specs/components/Personalization/actions/prependHtml.spec.js
+++ b/test/unit/specs/components/Personalization/actions/prependHtml.spec.js
@@ -1,0 +1,57 @@
+import {
+  selectNodes,
+  removeNode,
+  appendNode,
+  createNode
+} from "../../../../../../src/utils/dom";
+import createPrependHtml from "../../../../../../src/components/Personalization/actions/prependHtml";
+
+const cleanUp = () => {
+  selectNodes("ul#prependHtml").forEach(removeNode);
+  selectNodes("style").forEach(node => {
+    if (node.textContent.indexOf("prependHtml") !== -1) {
+      removeNode(node);
+    }
+  });
+};
+
+describe("Personalization::actions::prependHtml", () => {
+  beforeEach(() => {
+    cleanUp();
+  });
+
+  afterEach(() => {
+    cleanUp();
+  });
+
+  it("should prepend personalized content", () => {
+    const collect = jasmine.createSpy();
+    const prependHtml = createPrependHtml(collect);
+    const content = `<li>1</li>`;
+    const element = createNode(
+      "ul",
+      { id: "prependHtml" },
+      { innerHTML: content }
+    );
+    const elements = [element];
+
+    appendNode(document.body, element);
+
+    const settings = {
+      content: `<li>2</li>`,
+      meta: { a: 1 }
+    };
+    const event = { elements, prehidingSelector: "#prependHtml" };
+
+    prependHtml(settings, event);
+
+    const result = selectNodes("li");
+
+    expect(result.length).toEqual(2);
+    expect(result[0].innerHTML).toEqual("2");
+    expect(result[1].innerHTML).toEqual("1");
+    expect(collect).toHaveBeenCalledWith({
+      meta: { personalization: { a: 1 } }
+    });
+  });
+});

--- a/test/unit/specs/components/Personalization/actions/prependHtml.spec.js
+++ b/test/unit/specs/components/Personalization/actions/prependHtml.spec.js
@@ -27,7 +27,7 @@ describe("Personalization::actions::prependHtml", () => {
   it("should prepend personalized content", () => {
     const collect = jasmine.createSpy();
     const prependHtml = createPrependHtml(collect);
-    const content = `<li>1</li>`;
+    const content = `<li>3</li>`;
     const element = createNode(
       "ul",
       { id: "prependHtml" },
@@ -38,18 +38,19 @@ describe("Personalization::actions::prependHtml", () => {
     appendNode(document.body, element);
 
     const settings = {
-      content: `<li>2</li>`,
+      content: `<li>1</li><li>2</li>`,
       meta: { a: 1 }
     };
     const event = { elements, prehidingSelector: "#prependHtml" };
 
     prependHtml(settings, event);
 
-    const result = selectNodes("li");
+    const result = selectNodes("ul#prependHtml li");
 
-    expect(result.length).toEqual(2);
-    expect(result[0].innerHTML).toEqual("2");
-    expect(result[1].innerHTML).toEqual("1");
+    expect(result.length).toEqual(3);
+    expect(result[0].innerHTML).toEqual("1");
+    expect(result[1].innerHTML).toEqual("2");
+    expect(result[2].innerHTML).toEqual("3");
     expect(collect).toHaveBeenCalledWith({
       meta: { personalization: { a: 1 } }
     });


### PR DESCRIPTION
Adding Target VEC prependHtml action support

## Description

Adding Target VEC prependHtml action support

## Related Issue

NONE

## Motivation and Context

In Target VEC we can insert a piece of HTML as first element inside an HTML element. This action is called `prepend HTML` or `prepend content`, this PR adds support for this VEC action.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
