### PR TITLE
TNT-32924 - adding Target VEC appendHtml action support

### DIFF
--- a/src/components/Personalization/actions/appendHtml.js
+++ b/src/components/Personalization/actions/appendHtml.js
@@ -1,0 +1,49 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { showElements } from "../flicker";
+
+const DIV_TAG = "DIV";
+
+const createFragment = content => {
+  const result = document.createElement(DIV_TAG);
+  result.innerHTML = content;
+
+  return result;
+};
+
+const appendHtml = (container, content) => {
+  const fragment = createFragment(content);
+  const elements = [].slice.call(fragment.children);
+
+  elements.forEach(element => {
+    container.appendChild(element);
+  });
+};
+
+export default collect => {
+  return (settings, event) => {
+    const { elements, prehidingSelector } = event;
+    const { content, meta } = settings;
+
+    // this is a very naive approach, we will expand later
+    elements.forEach(element => {
+      appendHtml(element, content);
+    });
+
+    // after rendering we should remove the flicker control styles
+    showElements(prehidingSelector);
+
+    // make sure we send back the metadata after successful rendering
+    collect({ meta: { personalization: meta } });
+  };
+};

--- a/src/components/Personalization/turbine/initRuleComponentModules.js
+++ b/src/components/Personalization/turbine/initRuleComponentModules.js
@@ -24,6 +24,7 @@ import createInsertAfter from "../actions/insertAfter";
 import createInsertBefore from "../actions/insertBefore";
 import createReplaceHtml from "../actions/replaceHtml";
 import createPrependHtml from "../actions/prependHtml";
+import createAppendHtml from "../actions/appendHtml";
 
 export default collect => {
   const setHtml = createSetHtml(collect);
@@ -39,6 +40,7 @@ export default collect => {
   const insertBefore = createInsertBefore(collect);
   const replaceHtml = createReplaceHtml(collect);
   const prependHtml = createPrependHtml(collect);
+  const appendHtml = createAppendHtml(collect);
 
   return {
     elementExists,
@@ -54,6 +56,7 @@ export default collect => {
     insertAfter,
     insertBefore,
     replaceHtml,
-    prependHtml
+    prependHtml,
+    appendHtml
   };
 };

--- a/test/unit/specs/components/Personalization/actions/appendHtml.spec.js
+++ b/test/unit/specs/components/Personalization/actions/appendHtml.spec.js
@@ -38,18 +38,19 @@ describe("Personalization::actions::appendHtml", () => {
     appendNode(document.body, element);
 
     const settings = {
-      content: `<li>2</li>`,
+      content: `<li>2</li><li>3</li>`,
       meta: { a: 1 }
     };
     const event = { elements, prehidingSelector: "#appendHtml" };
 
     appendHtml(settings, event);
 
-    const result = selectNodes("li");
+    const result = selectNodes("ul#appendHtml li");
 
-    expect(result.length).toEqual(2);
+    expect(result.length).toEqual(3);
     expect(result[0].innerHTML).toEqual("1");
     expect(result[1].innerHTML).toEqual("2");
+    expect(result[2].innerHTML).toEqual("3");
     expect(collect).toHaveBeenCalledWith({
       meta: { personalization: { a: 1 } }
     });

--- a/test/unit/specs/components/Personalization/actions/appendHtml.spec.js
+++ b/test/unit/specs/components/Personalization/actions/appendHtml.spec.js
@@ -1,0 +1,57 @@
+import {
+  selectNodes,
+  removeNode,
+  appendNode,
+  createNode
+} from "../../../../../../src/utils/dom";
+import createAppendHtml from "../../../../../../src/components/Personalization/actions/appendHtml";
+
+const cleanUp = () => {
+  selectNodes("ul#appendHtml").forEach(removeNode);
+  selectNodes("style").forEach(node => {
+    if (node.textContent.indexOf("appendHtml") !== -1) {
+      removeNode(node);
+    }
+  });
+};
+
+describe("Personalization::actions::appendHtml", () => {
+  beforeEach(() => {
+    cleanUp();
+  });
+
+  afterEach(() => {
+    cleanUp();
+  });
+
+  it("should append personalized content", () => {
+    const collect = jasmine.createSpy();
+    const appendHtml = createAppendHtml(collect);
+    const content = `<li>1</li>`;
+    const element = createNode(
+      "ul",
+      { id: "appendHtml" },
+      { innerHTML: content }
+    );
+    const elements = [element];
+
+    appendNode(document.body, element);
+
+    const settings = {
+      content: `<li>2</li>`,
+      meta: { a: 1 }
+    };
+    const event = { elements, prehidingSelector: "#appendHtml" };
+
+    appendHtml(settings, event);
+
+    const result = selectNodes("li");
+
+    expect(result.length).toEqual(2);
+    expect(result[0].innerHTML).toEqual("1");
+    expect(result[1].innerHTML).toEqual("2");
+    expect(collect).toHaveBeenCalledWith({
+      meta: { personalization: { a: 1 } }
+    });
+  });
+});


### PR DESCRIPTION
Adding Target VEC appendHtml action support

## Description

Adding Target VEC appendHtml action support

## Related Issue

NONE

## Motivation and Context

In Target VEC there is a way to append some HTML content as a last element of another HTML element identified by selector.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
