### PR TITLE
TNT-32988 - move actions Personalization duplicate code to utils/dom …

### DIFF
--- a/src/components/Personalization/actions/appendHtml.js
+++ b/src/components/Personalization/actions/appendHtml.js
@@ -10,25 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import { append } from "../../../utils/dom";
 import { showElements } from "../flicker";
-
-const DIV_TAG = "DIV";
-
-const createFragment = content => {
-  const result = document.createElement(DIV_TAG);
-  result.innerHTML = content;
-
-  return result;
-};
-
-const appendHtml = (container, content) => {
-  const fragment = createFragment(content);
-  const elements = [].slice.call(fragment.children);
-
-  elements.forEach(element => {
-    container.appendChild(element);
-  });
-};
 
 export default collect => {
   return (settings, event) => {
@@ -37,7 +20,7 @@ export default collect => {
 
     // this is a very naive approach, we will expand later
     elements.forEach(element => {
-      appendHtml(element, content);
+      append(element, content);
     });
 
     // after rendering we should remove the flicker control styles

--- a/src/components/Personalization/actions/insertAfter.js
+++ b/src/components/Personalization/actions/insertAfter.js
@@ -10,25 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import { insertAfter } from "../../../utils/dom";
 import { showElements } from "../flicker";
-
-const DIV_TAG = "DIV";
-
-const createFragment = content => {
-  const result = document.createElement(DIV_TAG);
-  result.innerHTML = content;
-
-  return result;
-};
-
-const insertAfter = (container, content) => {
-  const fragment = createFragment(content);
-  const elements = [].slice.call(fragment.children);
-
-  elements.forEach(element => {
-    container.parentNode.insertBefore(element, container.nextElementSibling);
-  });
-};
 
 export default collect => {
   return (settings, event) => {

--- a/src/components/Personalization/actions/insertBefore.js
+++ b/src/components/Personalization/actions/insertBefore.js
@@ -10,25 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import { insertBefore } from "../../../utils/dom";
 import { showElements } from "../flicker";
-
-const DIV_TAG = "DIV";
-
-const createFragment = content => {
-  const result = document.createElement(DIV_TAG);
-  result.innerHTML = content;
-
-  return result;
-};
-
-const insertBefore = (container, content) => {
-  const fragment = createFragment(content);
-  const elements = [].slice.call(fragment.children);
-
-  elements.forEach(element => {
-    container.parentNode.insertBefore(element, container);
-  });
-};
 
 export default collect => {
   return (settings, event) => {

--- a/src/components/Personalization/actions/move.js
+++ b/src/components/Personalization/actions/move.js
@@ -10,6 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import { setStyle } from "../../../utils/dom";
 import { showElements } from "../flicker";
 
 export default collect => {
@@ -19,7 +20,7 @@ export default collect => {
 
     elements.forEach(element => {
       Object.keys(content).forEach(key => {
-        element.style.setProperty(key, content[key]);
+        setStyle(element, key, content[key]);
       });
     });
 

--- a/src/components/Personalization/actions/prependHtml.js
+++ b/src/components/Personalization/actions/prependHtml.js
@@ -10,32 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import { prepend } from "../../../utils/dom";
 import { showElements } from "../flicker";
-
-const DIV_TAG = "DIV";
-
-const createFragment = content => {
-  const result = document.createElement(DIV_TAG);
-  result.innerHTML = content;
-
-  return result;
-};
-
-const prependHtml = (container, content) => {
-  const fragment = createFragment(content);
-  const elements = [].slice.call(fragment.children);
-  const { length } = elements;
-  let i = length - 1;
-
-  // We are inserting elements in reverse order
-  while (i >= 0) {
-    const element = elements[i];
-
-    container.insertBefore(element, container.firstElementChild);
-
-    i -= 1;
-  }
-};
 
 export default collect => {
   return (settings, event) => {
@@ -44,7 +20,7 @@ export default collect => {
 
     // this is a very naive approach, we will expand later
     elements.forEach(element => {
-      prependHtml(element, content);
+      prepend(element, content);
     });
 
     // after rendering we should remove the flicker control styles

--- a/src/components/Personalization/actions/rearrange.js
+++ b/src/components/Personalization/actions/rearrange.js
@@ -10,15 +10,15 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import {
+  getChildren,
+  insertElementAfter,
+  insertElementBefore
+} from "../../../utils/dom";
 import { showElements } from "../flicker";
 
-const COMMENT_NODE = 8;
-
-const toArray = elements => [].slice.call(elements);
-const notComment = element => element.nodeType !== COMMENT_NODE;
-
 const rearrangeChildren = (element, from, to) => {
-  const children = toArray(element.children).filter(notComment);
+  const children = getChildren(element);
   const elementFrom = children[from];
   const elementTo = children[to];
 
@@ -29,9 +29,9 @@ const rearrangeChildren = (element, from, to) => {
   }
 
   if (from < to) {
-    element.insertBefore(elementFrom, elementTo.nextElementSibling);
+    insertElementAfter(elementTo, elementFrom);
   } else {
-    element.insertBefore(elementFrom, elementTo);
+    insertElementBefore(elementTo, elementFrom);
   }
 };
 

--- a/src/components/Personalization/actions/replaceHtml.js
+++ b/src/components/Personalization/actions/replaceHtml.js
@@ -10,26 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import { insertBefore, removeNode } from "../../../utils/dom";
 import { showElements } from "../flicker";
-import { removeNode } from "../../../utils/dom";
-
-const DIV_TAG = "DIV";
-
-const createFragment = content => {
-  const result = document.createElement(DIV_TAG);
-  result.innerHTML = content;
-
-  return result;
-};
-
-const insertBefore = (container, content) => {
-  const fragment = createFragment(content);
-  const elements = [].slice.call(fragment.children);
-
-  elements.forEach(element => {
-    container.parentNode.insertBefore(element, container);
-  });
-};
 
 export default collect => {
   return (settings, event) => {

--- a/src/components/Personalization/actions/resize.js
+++ b/src/components/Personalization/actions/resize.js
@@ -10,6 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import { setStyle } from "../../../utils/dom";
 import { showElements } from "../flicker";
 
 export default collect => {
@@ -19,7 +20,7 @@ export default collect => {
 
     elements.forEach(element => {
       Object.keys(content).forEach(key => {
-        element.style.setProperty(key, content[key]);
+        setStyle(element, key, content[key]);
       });
     });
 

--- a/src/components/Personalization/actions/setAttribute.js
+++ b/src/components/Personalization/actions/setAttribute.js
@@ -10,6 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import { setAttribute } from "../../../utils/dom";
 import { showElements } from "../flicker";
 
 export default collect => {
@@ -19,7 +20,7 @@ export default collect => {
 
     elements.forEach(element => {
       Object.keys(content).forEach(key => {
-        element.setAttribute(key, content[key]);
+        setAttribute(element, key, content[key]);
       });
     });
 

--- a/src/components/Personalization/actions/setImageSource.js
+++ b/src/components/Personalization/actions/setImageSource.js
@@ -10,16 +10,15 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import {
+  preloadImage,
+  setAttribute,
+  removeAttribute
+} from "../../../utils/dom";
+import { IMG, SRC } from "../../../utils/dom/constants";
 import { showElements } from "../flicker";
 
-const IMAGE_TAG = "IMG";
-const SRC = "src";
-
-const isImage = element => element.tagName === IMAGE_TAG;
-const loadImage = url => {
-  const image = document.createElement(IMAGE_TAG);
-  image.src = url;
-};
+const isImage = element => element.tagName === IMG;
 
 export default collect => {
   return (settings, event) => {
@@ -28,13 +27,13 @@ export default collect => {
 
     elements.filter(isImage).forEach(element => {
       // Start downloading the image
-      loadImage(url);
+      preloadImage(url);
 
       // Remove "src" so there is no flicker
-      element.removeAttribute(SRC);
+      removeAttribute(element, SRC);
 
       // Replace the image "src"
-      element.setAttribute(SRC, url);
+      setAttribute(element, SRC, url);
     });
 
     // after rendering we should remove the flicker control styles

--- a/src/components/Personalization/actions/setStyle.js
+++ b/src/components/Personalization/actions/setStyle.js
@@ -10,6 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import { setStyle } from "../../../utils/dom";
 import { showElements } from "../flicker";
 
 export default collect => {
@@ -20,7 +21,7 @@ export default collect => {
 
     elements.forEach(element => {
       Object.keys(style).forEach(key => {
-        element.style.setProperty(key, style[key], priority);
+        setStyle(element, key, style[key], priority);
       });
     });
 

--- a/src/utils/dom/append.js
+++ b/src/utils/dom/append.js
@@ -13,8 +13,8 @@ governing permissions and limitations under the License.
 import createFragment from "./createFragment";
 import getChildren from "./getChildren";
 
-export default (container, content) => {
-  const fragment = createFragment(content);
+export default (container, html) => {
+  const fragment = createFragment(html);
   const elements = getChildren(fragment);
 
   elements.forEach(element => {

--- a/src/utils/dom/append.js
+++ b/src/utils/dom/append.js
@@ -10,14 +10,14 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import toArray from "../toArray";
+import createFragment from "./createFragment";
+import getChildren from "./getChildren";
 
-/**
- * Returns an array of matched DOM nodes.
- * @param {String} selector
- * @param {Node} doc, defaults to document
- * @returns {Array} an array of DOM nodes
- */
-export default function selectNodes(selector, doc = document) {
-  return toArray(doc.querySelectorAll(selector));
-}
+export default (container, content) => {
+  const fragment = createFragment(content);
+  const elements = getChildren(fragment);
+
+  elements.forEach(element => {
+    container.appendChild(element);
+  });
+};

--- a/src/utils/dom/constants.js
+++ b/src/utils/dom/constants.js
@@ -10,14 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import toArray from "../toArray";
-
-/**
- * Returns an array of matched DOM nodes.
- * @param {String} selector
- * @param {Node} doc, defaults to document
- * @returns {Array} an array of DOM nodes
- */
-export default function selectNodes(selector, doc = document) {
-  return toArray(doc.querySelectorAll(selector));
-}
+export const IMG = "IMG";
+export const DIV = "DIV";
+export const SRC = "src";

--- a/src/utils/dom/createFragment.js
+++ b/src/utils/dom/createFragment.js
@@ -10,14 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import toArray from "../toArray";
+import { DIV } from "./constants";
+import createNode from "./createNode";
 
-/**
- * Returns an array of matched DOM nodes.
- * @param {String} selector
- * @param {Node} doc, defaults to document
- * @returns {Array} an array of DOM nodes
- */
-export default function selectNodes(selector, doc = document) {
-  return toArray(doc.querySelectorAll(selector));
-}
+export default content => {
+  return createNode(DIV, {}, { innerHTML: content });
+};

--- a/src/utils/dom/getChildren.js
+++ b/src/utils/dom/getChildren.js
@@ -12,12 +12,12 @@ governing permissions and limitations under the License.
 
 import toArray from "../toArray";
 
-/**
- * Returns an array of matched DOM nodes.
- * @param {String} selector
- * @param {Node} doc, defaults to document
- * @returns {Array} an array of DOM nodes
- */
-export default function selectNodes(selector, doc = document) {
-  return toArray(doc.querySelectorAll(selector));
-}
+export default element => {
+  const { children } = element;
+
+  if (children) {
+    return toArray(children);
+  }
+
+  return [];
+};

--- a/src/utils/dom/getFirstChild.js
+++ b/src/utils/dom/getFirstChild.js
@@ -10,14 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import toArray from "../toArray";
-
-/**
- * Returns an array of matched DOM nodes.
- * @param {String} selector
- * @param {Node} doc, defaults to document
- * @returns {Array} an array of DOM nodes
- */
-export default function selectNodes(selector, doc = document) {
-  return toArray(doc.querySelectorAll(selector));
-}
+export default element => {
+  return element.firstElementChild;
+};

--- a/src/utils/dom/getNextSibling.js
+++ b/src/utils/dom/getNextSibling.js
@@ -10,14 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import toArray from "../toArray";
-
-/**
- * Returns an array of matched DOM nodes.
- * @param {String} selector
- * @param {Node} doc, defaults to document
- * @returns {Array} an array of DOM nodes
- */
-export default function selectNodes(selector, doc = document) {
-  return toArray(doc.querySelectorAll(selector));
-}
+export default element => {
+  return element.nextElementSibling;
+};

--- a/src/utils/dom/getParent.js
+++ b/src/utils/dom/getParent.js
@@ -10,14 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import toArray from "../toArray";
+export default element => {
+  const result = element.parentNode;
 
-/**
- * Returns an array of matched DOM nodes.
- * @param {String} selector
- * @param {Node} doc, defaults to document
- * @returns {Array} an array of DOM nodes
- */
-export default function selectNodes(selector, doc = document) {
-  return toArray(doc.querySelectorAll(selector));
-}
+  if (result) {
+    return result;
+  }
+
+  return null;
+};

--- a/src/utils/dom/getParent.js
+++ b/src/utils/dom/getParent.js
@@ -11,11 +11,5 @@ governing permissions and limitations under the License.
 */
 
 export default element => {
-  const result = element.parentNode;
-
-  if (result) {
-    return result;
-  }
-
-  return null;
+  return element.parentNode;
 };

--- a/src/utils/dom/index.js
+++ b/src/utils/dom/index.js
@@ -12,8 +12,21 @@ governing permissions and limitations under the License.
 
 export { default as awaitSelector } from "./awaitSelector";
 export { default as createNode } from "./createNode";
+export { default as createFragment } from "./createFragment";
 export { default as appendNode } from "./appendNode";
 export { default as removeNode } from "./removeNode";
 export { default as selectNodes } from "./selectNodes";
 export { selectNodesWithEq } from "./selectNodesWithEq";
 export { default as findById } from "./findById";
+export { default as preloadImage } from "./preloadImage";
+export { default as setAttribute } from "./setAttribute";
+export { default as removeAttribute } from "./removeAttribute";
+export { default as setStyle } from "./setStyle";
+export { default as insertAfter } from "./insertAfter";
+export { default as insertElementAfter } from "./insertElementAfter";
+export { default as insertBefore } from "./insertBefore";
+export { default as insertElementBefore } from "./insertElementBefore";
+export { default as getNextSibling } from "./getNextSibling";
+export { default as getChildren } from "./getChildren";
+export { default as append } from "./append";
+export { default as prepend } from "./prepend";

--- a/src/utils/dom/insertAfter.js
+++ b/src/utils/dom/insertAfter.js
@@ -10,14 +10,15 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import toArray from "../toArray";
+import createFragment from "./createFragment";
+import getChildren from "./getChildren";
+import insertElementAfter from "./insertElementAfter";
 
-/**
- * Returns an array of matched DOM nodes.
- * @param {String} selector
- * @param {Node} doc, defaults to document
- * @returns {Array} an array of DOM nodes
- */
-export default function selectNodes(selector, doc = document) {
-  return toArray(doc.querySelectorAll(selector));
-}
+export default (container, html) => {
+  const fragment = createFragment(html);
+  const elements = getChildren(fragment);
+
+  elements.forEach(element => {
+    insertElementAfter(container, element);
+  });
+};

--- a/src/utils/dom/insertBefore.js
+++ b/src/utils/dom/insertBefore.js
@@ -10,14 +10,15 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import toArray from "../toArray";
+import createFragment from "./createFragment";
+import getChildren from "./getChildren";
+import insertElementBefore from "./insertElementBefore";
 
-/**
- * Returns an array of matched DOM nodes.
- * @param {String} selector
- * @param {Node} doc, defaults to document
- * @returns {Array} an array of DOM nodes
- */
-export default function selectNodes(selector, doc = document) {
-  return toArray(doc.querySelectorAll(selector));
-}
+export default (container, html) => {
+  const fragment = createFragment(html);
+  const elements = getChildren(fragment);
+
+  elements.forEach(element => {
+    insertElementBefore(container, element);
+  });
+};

--- a/src/utils/dom/insertElementAfter.js
+++ b/src/utils/dom/insertElementAfter.js
@@ -10,14 +10,17 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import toArray from "../toArray";
+import getParent from "./getParent";
+import getNextSibling from "./getNextSibling";
 
-/**
- * Returns an array of matched DOM nodes.
- * @param {String} selector
- * @param {Node} doc, defaults to document
- * @returns {Array} an array of DOM nodes
- */
-export default function selectNodes(selector, doc = document) {
-  return toArray(doc.querySelectorAll(selector));
-}
+export default (container, element) => {
+  if (!container) {
+    return;
+  }
+
+  const parent = getParent(container);
+
+  if (parent) {
+    parent.insertBefore(element, getNextSibling(container));
+  }
+};

--- a/src/utils/dom/insertElementBefore.js
+++ b/src/utils/dom/insertElementBefore.js
@@ -10,14 +10,16 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import toArray from "../toArray";
+import getParent from "./getParent";
 
-/**
- * Returns an array of matched DOM nodes.
- * @param {String} selector
- * @param {Node} doc, defaults to document
- * @returns {Array} an array of DOM nodes
- */
-export default function selectNodes(selector, doc = document) {
-  return toArray(doc.querySelectorAll(selector));
-}
+export default (container, element) => {
+  if (!container) {
+    return;
+  }
+
+  const parent = getParent(container);
+
+  if (parent) {
+    parent.insertBefore(element, container);
+  }
+};

--- a/src/utils/dom/preloadImage.js
+++ b/src/utils/dom/preloadImage.js
@@ -10,14 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import toArray from "../toArray";
+import { IMG } from "./constants";
+import createNode from "./createNode";
 
-/**
- * Returns an array of matched DOM nodes.
- * @param {String} selector
- * @param {Node} doc, defaults to document
- * @returns {Array} an array of DOM nodes
- */
-export default function selectNodes(selector, doc = document) {
-  return toArray(doc.querySelectorAll(selector));
-}
+export default url => {
+  return createNode(IMG, { src: url });
+};

--- a/src/utils/dom/prepend.js
+++ b/src/utils/dom/prepend.js
@@ -10,14 +10,23 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import toArray from "../toArray";
+import createFragment from "./createFragment";
+import getChildren from "./getChildren";
+import getFirstChild from "./getFirstChild";
+import insertElementBefore from "./insertElementBefore";
 
-/**
- * Returns an array of matched DOM nodes.
- * @param {String} selector
- * @param {Node} doc, defaults to document
- * @returns {Array} an array of DOM nodes
- */
-export default function selectNodes(selector, doc = document) {
-  return toArray(doc.querySelectorAll(selector));
-}
+export default (container, content) => {
+  const fragment = createFragment(content);
+  const elements = getChildren(fragment);
+  const { length } = elements;
+  let i = length - 1;
+
+  // We are inserting elements in reverse order
+  while (i >= 0) {
+    const element = elements[i];
+
+    insertElementBefore(getFirstChild(container), element);
+
+    i -= 1;
+  }
+};

--- a/src/utils/dom/prepend.js
+++ b/src/utils/dom/prepend.js
@@ -15,8 +15,8 @@ import getChildren from "./getChildren";
 import getFirstChild from "./getFirstChild";
 import insertElementBefore from "./insertElementBefore";
 
-export default (container, content) => {
-  const fragment = createFragment(content);
+export default (container, html) => {
+  const fragment = createFragment(html);
   const elements = getChildren(fragment);
   const { length } = elements;
   let i = length - 1;

--- a/src/utils/dom/removeAttribute.js
+++ b/src/utils/dom/removeAttribute.js
@@ -10,14 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import toArray from "../toArray";
-
-/**
- * Returns an array of matched DOM nodes.
- * @param {String} selector
- * @param {Node} doc, defaults to document
- * @returns {Array} an array of DOM nodes
- */
-export default function selectNodes(selector, doc = document) {
-  return toArray(doc.querySelectorAll(selector));
-}
+export default (element, name) => {
+  element.removeAttribute(name);
+};

--- a/src/utils/dom/setAttribute.js
+++ b/src/utils/dom/setAttribute.js
@@ -10,14 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import toArray from "../toArray";
-
-/**
- * Returns an array of matched DOM nodes.
- * @param {String} selector
- * @param {Node} doc, defaults to document
- * @returns {Array} an array of DOM nodes
- */
-export default function selectNodes(selector, doc = document) {
-  return toArray(doc.querySelectorAll(selector));
-}
+export default (element, name, value) => {
+  element.setAttribute(name, value);
+};

--- a/src/utils/dom/setStyle.js
+++ b/src/utils/dom/setStyle.js
@@ -10,14 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import toArray from "../toArray";
-
-/**
- * Returns an array of matched DOM nodes.
- * @param {String} selector
- * @param {Node} doc, defaults to document
- * @returns {Array} an array of DOM nodes
- */
-export default function selectNodes(selector, doc = document) {
-  return toArray(doc.querySelectorAll(selector));
-}
+export default (element, name, value, priority) => {
+  element.style.setProperty(name, value, priority);
+};

--- a/src/utils/dom/setStyle.js
+++ b/src/utils/dom/setStyle.js
@@ -11,5 +11,13 @@ governing permissions and limitations under the License.
 */
 
 export default (element, name, value, priority) => {
-  element.style.setProperty(name, value, priority);
+  let css;
+
+  if (priority) {
+    css = `${name}:${value} !${priority};`;
+  } else {
+    css = `${name}:${value};`;
+  }
+
+  element.style.cssText += `;${css}`;
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -39,6 +39,7 @@ export { default as setNestedObject } from "./setNestedObject";
 export { default as stackError } from "./stackError";
 export { default as storageFactory } from "./storageFactory";
 export { default as stringToBoolean } from "./stringToBoolean";
+export { default as toArray } from "./toArray";
 export { default as toError } from "./toError";
 export { default as uuid } from "./uuid";
 export { default as values } from "./values";

--- a/src/utils/toArray.js
+++ b/src/utils/toArray.js
@@ -10,14 +10,4 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import toArray from "../toArray";
-
-/**
- * Returns an array of matched DOM nodes.
- * @param {String} selector
- * @param {Node} doc, defaults to document
- * @returns {Array} an array of DOM nodes
- */
-export default function selectNodes(selector, doc = document) {
-  return toArray(doc.querySelectorAll(selector));
-}
+export default value => (value == null ? [] : [].slice.call(value));

--- a/test/unit/helpers/cleanUpDomChanges.js
+++ b/test/unit/helpers/cleanUpDomChanges.js
@@ -1,0 +1,25 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { selectNodes, removeNode } from "../../../src/utils/dom";
+
+/**
+ * Removes container DOM nodes used for all the
+ * personalization actions
+ */
+export default id => {
+  selectNodes(`#${id}`).forEach(removeNode);
+  selectNodes("style").forEach(node => {
+    if (node.textContent.indexOf(id) !== -1) {
+      removeNode(node);
+    }
+  });
+};

--- a/test/unit/specs/components/Personalization/actions/appendHtml.spec.js
+++ b/test/unit/specs/components/Personalization/actions/appendHtml.spec.js
@@ -1,27 +1,18 @@
 import {
   selectNodes,
-  removeNode,
   appendNode,
   createNode
 } from "../../../../../../src/utils/dom";
 import createAppendHtml from "../../../../../../src/components/Personalization/actions/appendHtml";
-
-const cleanUp = () => {
-  selectNodes("ul#appendHtml").forEach(removeNode);
-  selectNodes("style").forEach(node => {
-    if (node.textContent.indexOf("appendHtml") !== -1) {
-      removeNode(node);
-    }
-  });
-};
+import cleanUpDomChanges from "../../../../helpers/cleanUpDomChanges";
 
 describe("Personalization::actions::appendHtml", () => {
   beforeEach(() => {
-    cleanUp();
+    cleanUpDomChanges("appendHtml");
   });
 
   afterEach(() => {
-    cleanUp();
+    cleanUpDomChanges("appendHtml");
   });
 
   it("should append personalized content", () => {

--- a/test/unit/specs/components/Personalization/actions/insertAfter.spec.js
+++ b/test/unit/specs/components/Personalization/actions/insertAfter.spec.js
@@ -1,27 +1,18 @@
 import {
   selectNodes,
-  removeNode,
   appendNode,
   createNode
 } from "../../../../../../src/utils/dom";
 import createInsertAfter from "../../../../../../src/components/Personalization/actions/insertAfter";
-
-const cleanUp = () => {
-  selectNodes("div#insertAfter").forEach(removeNode);
-  selectNodes("style").forEach(node => {
-    if (node.textContent.indexOf("insertAfter") !== -1) {
-      removeNode(node);
-    }
-  });
-};
+import cleanUpDomChanges from "../../../../helpers/cleanUpDomChanges";
 
 describe("Personalization::actions::insertAfter", () => {
   beforeEach(() => {
-    cleanUp();
+    cleanUpDomChanges("insertAfter");
   });
 
   afterEach(() => {
-    cleanUp();
+    cleanUpDomChanges("insertAfter");
   });
 
   it("should inser after personalized content", () => {

--- a/test/unit/specs/components/Personalization/actions/insertBefore.spec.js
+++ b/test/unit/specs/components/Personalization/actions/insertBefore.spec.js
@@ -1,27 +1,18 @@
 import {
   selectNodes,
-  removeNode,
   appendNode,
   createNode
 } from "../../../../../../src/utils/dom";
 import createInsertBefore from "../../../../../../src/components/Personalization/actions/insertBefore";
-
-const cleanUp = () => {
-  selectNodes("div#insertBefore").forEach(removeNode);
-  selectNodes("style").forEach(node => {
-    if (node.textContent.indexOf("insertBefore") !== -1) {
-      removeNode(node);
-    }
-  });
-};
+import cleanUpDomChanges from "../../../../helpers/cleanUpDomChanges";
 
 describe("Personalization::actions::insertBefore", () => {
   beforeEach(() => {
-    cleanUp();
+    cleanUpDomChanges("insertBefore");
   });
 
   afterEach(() => {
-    cleanUp();
+    cleanUpDomChanges("insertBefore");
   });
 
   it("should inser before personalized content", () => {

--- a/test/unit/specs/components/Personalization/actions/move.spec.js
+++ b/test/unit/specs/components/Personalization/actions/move.spec.js
@@ -24,7 +24,7 @@ describe("Personalization::actions::move", () => {
     cleanUp();
   });
 
-  it("should set personalized content", done => {
+  it("should set personalized content", () => {
     const collect = jasmine.createSpy();
     const move = createMove(collect);
     const element = createNode("div", { id: "move" });
@@ -40,13 +40,14 @@ describe("Personalization::actions::move", () => {
 
     move(settings, event);
 
-    setTimeout(() => {
-      done();
-      expect(elements[0].style.left).toEqual("100px");
-      expect(elements[0].style.top).toEqual("100px");
-      expect(collect).toHaveBeenCalledWith({
-        meta: { personalization: { a: 1 } }
-      });
+    /* eslint-disable no-unused-vars */
+    const forceRerender = elements[0].offsetLeft;
+    /* eslint-enable no-unused-vars */
+
+    expect(elements[0].style.left).toEqual("100px");
+    expect(elements[0].style.top).toEqual("100px");
+    expect(collect).toHaveBeenCalledWith({
+      meta: { personalization: { a: 1 } }
     });
   });
 });

--- a/test/unit/specs/components/Personalization/actions/move.spec.js
+++ b/test/unit/specs/components/Personalization/actions/move.spec.js
@@ -15,12 +15,6 @@ const cleanUp = () => {
   });
 };
 
-const invalidateIfRequired = element => {
-  if (element.style.setAttribute) {
-    element.style.setAttribute("background", "red");
-  }
-};
-
 describe("Personalization::actions::move", () => {
   beforeEach(() => {
     cleanUp();
@@ -45,8 +39,6 @@ describe("Personalization::actions::move", () => {
     const event = { elements, prehidingSelector: "#move" };
 
     move(settings, event);
-
-    invalidateIfRequired(elements[0]);
 
     expect(elements[0].style.left).toEqual("100px");
     expect(elements[0].style.top).toEqual("100px");

--- a/test/unit/specs/components/Personalization/actions/move.spec.js
+++ b/test/unit/specs/components/Personalization/actions/move.spec.js
@@ -40,10 +40,12 @@ describe("Personalization::actions::move", () => {
 
     move(settings, event);
 
-    const result = window.getComputedStyle(element, null);
+    /* eslint-disable no-unused-vars */
+    const forceRerender = elements[0].offsetLeft;
+    /* eslint-enable no-unused-vars */
 
-    expect(result.left).toEqual("100px");
-    expect(result.top).toEqual("100px");
+    expect(elements[0].style.left).toEqual("100px");
+    expect(elements[0].style.top).toEqual("100px");
     expect(collect).toHaveBeenCalledWith({
       meta: { personalization: { a: 1 } }
     });

--- a/test/unit/specs/components/Personalization/actions/move.spec.js
+++ b/test/unit/specs/components/Personalization/actions/move.spec.js
@@ -24,7 +24,7 @@ describe("Personalization::actions::move", () => {
     cleanUp();
   });
 
-  it("should set personalized content", () => {
+  it("should set personalized content", done => {
     const collect = jasmine.createSpy();
     const move = createMove(collect);
     const element = createNode("div", { id: "move" });
@@ -40,14 +40,13 @@ describe("Personalization::actions::move", () => {
 
     move(settings, event);
 
-    /* eslint-disable no-unused-vars */
-    const forceRerender = elements[0].offsetLeft;
-    /* eslint-enable no-unused-vars */
-
-    expect(elements[0].style.left).toEqual("100px");
-    expect(elements[0].style.top).toEqual("100px");
-    expect(collect).toHaveBeenCalledWith({
-      meta: { personalization: { a: 1 } }
+    setTimeout(() => {
+      done();
+      expect(elements[0].style.left).toEqual("100px");
+      expect(elements[0].style.top).toEqual("100px");
+      expect(collect).toHaveBeenCalledWith({
+        meta: { personalization: { a: 1 } }
+      });
     });
   });
 });

--- a/test/unit/specs/components/Personalization/actions/move.spec.js
+++ b/test/unit/specs/components/Personalization/actions/move.spec.js
@@ -40,8 +40,10 @@ describe("Personalization::actions::move", () => {
 
     move(settings, event);
 
-    expect(elements[0].style.left).toEqual("100px");
-    expect(elements[0].style.top).toEqual("100px");
+    const result = window.getComputedStyle(element, null);
+
+    expect(result.left).toEqual("100px");
+    expect(result.top).toEqual("100px");
     expect(collect).toHaveBeenCalledWith({
       meta: { personalization: { a: 1 } }
     });

--- a/test/unit/specs/components/Personalization/actions/move.spec.js
+++ b/test/unit/specs/components/Personalization/actions/move.spec.js
@@ -1,27 +1,14 @@
-import {
-  selectNodes,
-  removeNode,
-  appendNode,
-  createNode
-} from "../../../../../../src/utils/dom";
+import { appendNode, createNode } from "../../../../../../src/utils/dom";
 import createMove from "../../../../../../src/components/Personalization/actions/move";
-
-const cleanUp = () => {
-  selectNodes("div#move").forEach(removeNode);
-  selectNodes("style").forEach(node => {
-    if (node.textContent.indexOf("move") !== -1) {
-      removeNode(node);
-    }
-  });
-};
+import cleanUpDomChanges from "../../../../helpers/cleanUpDomChanges";
 
 describe("Personalization::actions::move", () => {
   beforeEach(() => {
-    cleanUp();
+    cleanUpDomChanges("move");
   });
 
   afterEach(() => {
-    cleanUp();
+    cleanUpDomChanges("move");
   });
 
   it("should set personalized content", () => {

--- a/test/unit/specs/components/Personalization/actions/move.spec.js
+++ b/test/unit/specs/components/Personalization/actions/move.spec.js
@@ -15,6 +15,12 @@ const cleanUp = () => {
   });
 };
 
+const invalidateIfRequired = element => {
+  if (element.style.setAttribute) {
+    element.style.setAttribute("background", "red");
+  }
+};
+
 describe("Personalization::actions::move", () => {
   beforeEach(() => {
     cleanUp();
@@ -40,9 +46,7 @@ describe("Personalization::actions::move", () => {
 
     move(settings, event);
 
-    /* eslint-disable no-unused-vars */
-    const forceRerender = elements[0].offsetLeft;
-    /* eslint-enable no-unused-vars */
+    invalidateIfRequired(elements[0]);
 
     expect(elements[0].style.left).toEqual("100px");
     expect(elements[0].style.top).toEqual("100px");

--- a/test/unit/specs/components/Personalization/actions/move.spec.js
+++ b/test/unit/specs/components/Personalization/actions/move.spec.js
@@ -27,7 +27,7 @@ describe("Personalization::actions::move", () => {
   it("should set personalized content", () => {
     const collect = jasmine.createSpy();
     const move = createMove(collect);
-    const element = createNode("div", { id: "setAttribute" });
+    const element = createNode("div", { id: "move" });
     const elements = [element];
 
     appendNode(document.body, element);
@@ -36,7 +36,7 @@ describe("Personalization::actions::move", () => {
       content: { left: "100px", top: "100px" },
       meta: { a: 1 }
     };
-    const event = { elements, prehidingSelector: "#setAttribute" };
+    const event = { elements, prehidingSelector: "#move" };
 
     move(settings, event);
 

--- a/test/unit/specs/components/Personalization/actions/prependHtml.spec.js
+++ b/test/unit/specs/components/Personalization/actions/prependHtml.spec.js
@@ -1,27 +1,18 @@
 import {
   selectNodes,
-  removeNode,
   appendNode,
   createNode
 } from "../../../../../../src/utils/dom";
 import createPrependHtml from "../../../../../../src/components/Personalization/actions/prependHtml";
-
-const cleanUp = () => {
-  selectNodes("ul#prependHtml").forEach(removeNode);
-  selectNodes("style").forEach(node => {
-    if (node.textContent.indexOf("prependHtml") !== -1) {
-      removeNode(node);
-    }
-  });
-};
+import cleanUpDomChanges from "../../../../helpers/cleanUpDomChanges";
 
 describe("Personalization::actions::prependHtml", () => {
   beforeEach(() => {
-    cleanUp();
+    cleanUpDomChanges("prependHtml");
   });
 
   afterEach(() => {
-    cleanUp();
+    cleanUpDomChanges("prependHtml");
   });
 
   it("should prepend personalized content", () => {

--- a/test/unit/specs/components/Personalization/actions/rearrange.spec.js
+++ b/test/unit/specs/components/Personalization/actions/rearrange.spec.js
@@ -1,27 +1,18 @@
 import {
   selectNodes,
-  removeNode,
   appendNode,
   createNode
 } from "../../../../../../src/utils/dom";
 import createRearrange from "../../../../../../src/components/Personalization/actions/rearrange";
-
-const cleanUp = () => {
-  selectNodes("ul#rearrange").forEach(removeNode);
-  selectNodes("style").forEach(node => {
-    if (node.textContent.indexOf("rearrange") !== -1) {
-      removeNode(node);
-    }
-  });
-};
+import cleanUpDomChanges from "../../../../helpers/cleanUpDomChanges";
 
 describe("Presonalization::actions::rearrange", () => {
   beforeEach(() => {
-    cleanUp();
+    cleanUpDomChanges("rearrange");
   });
 
   afterEach(() => {
-    cleanUp();
+    cleanUpDomChanges("rearrange");
   });
 
   it("should rearrange elements when from < to", () => {

--- a/test/unit/specs/components/Personalization/actions/remove.spec.js
+++ b/test/unit/specs/components/Personalization/actions/remove.spec.js
@@ -1,27 +1,18 @@
 import {
   selectNodes,
-  removeNode,
   appendNode,
   createNode
 } from "../../../../../../src/utils/dom";
 import createRemove from "../../../../../../src/components/Personalization/actions/remove";
-
-const cleanUp = () => {
-  selectNodes("div#remove").forEach(removeNode);
-  selectNodes("style").forEach(node => {
-    if (node.textContent.indexOf("remove") !== -1) {
-      removeNode(node);
-    }
-  });
-};
+import cleanUpDomChanges from "../../../../helpers/cleanUpDomChanges";
 
 describe("Presonalization::actions::remove", () => {
   beforeEach(() => {
-    cleanUp();
+    cleanUpDomChanges("remove");
   });
 
   afterEach(() => {
-    cleanUp();
+    cleanUpDomChanges("remove");
   });
 
   it("should remove element", () => {

--- a/test/unit/specs/components/Personalization/actions/replaceHtml.spec.js
+++ b/test/unit/specs/components/Personalization/actions/replaceHtml.spec.js
@@ -1,27 +1,18 @@
 import {
   selectNodes,
-  removeNode,
   appendNode,
   createNode
 } from "../../../../../../src/utils/dom";
 import createReplaceHtml from "../../../../../../src/components/Personalization/actions/replaceHtml";
-
-const cleanUp = () => {
-  selectNodes("div#replaceHtml").forEach(removeNode);
-  selectNodes("style").forEach(node => {
-    if (node.textContent.indexOf("replaceHtml") !== -1) {
-      removeNode(node);
-    }
-  });
-};
+import cleanUpDomChanges from "../../../../helpers/cleanUpDomChanges";
 
 describe("Personalization::actions::replaceHtml", () => {
   beforeEach(() => {
-    cleanUp();
+    cleanUpDomChanges("replaceHtml");
   });
 
   afterEach(() => {
-    cleanUp();
+    cleanUpDomChanges("replaceHtml");
   });
 
   it("should replace element with personalized content", () => {

--- a/test/unit/specs/components/Personalization/actions/resize.spec.js
+++ b/test/unit/specs/components/Personalization/actions/resize.spec.js
@@ -40,10 +40,12 @@ describe("Personalization::actions::resize", () => {
 
     resize(settings, event);
 
-    const result = window.getComputedStyle(element, null);
+    /* eslint-disable no-unused-vars */
+    const forceRerender = elements[0].offsetLeft;
+    /* eslint-enable no-unused-vars */
 
-    expect(result.width).toEqual("100px");
-    expect(result.height).toEqual("100px");
+    expect(elements[0].style.width).toEqual("100px");
+    expect(elements[0].style.height).toEqual("100px");
     expect(collect).toHaveBeenCalledWith({
       meta: { personalization: { a: 1 } }
     });

--- a/test/unit/specs/components/Personalization/actions/resize.spec.js
+++ b/test/unit/specs/components/Personalization/actions/resize.spec.js
@@ -15,12 +15,6 @@ const cleanUp = () => {
   });
 };
 
-const invalidateIfRequired = element => {
-  if (element.style.setAttribute) {
-    element.style.setAttribute("background", "red");
-  }
-};
-
 describe("Personalization::actions::resize", () => {
   beforeEach(() => {
     cleanUp();
@@ -45,8 +39,6 @@ describe("Personalization::actions::resize", () => {
     const event = { elements, prehidingSelector: "#resize" };
 
     resize(settings, event);
-
-    invalidateIfRequired(elements[0]);
 
     expect(elements[0].style.width).toEqual("100px");
     expect(elements[0].style.height).toEqual("100px");

--- a/test/unit/specs/components/Personalization/actions/resize.spec.js
+++ b/test/unit/specs/components/Personalization/actions/resize.spec.js
@@ -40,8 +40,10 @@ describe("Personalization::actions::resize", () => {
 
     resize(settings, event);
 
-    expect(elements[0].style.width).toEqual("100px");
-    expect(elements[0].style.height).toEqual("100px");
+    const result = window.getComputedStyle(element, null);
+
+    expect(result.width).toEqual("100px");
+    expect(result.height).toEqual("100px");
     expect(collect).toHaveBeenCalledWith({
       meta: { personalization: { a: 1 } }
     });

--- a/test/unit/specs/components/Personalization/actions/resize.spec.js
+++ b/test/unit/specs/components/Personalization/actions/resize.spec.js
@@ -1,27 +1,14 @@
-import {
-  selectNodes,
-  removeNode,
-  appendNode,
-  createNode
-} from "../../../../../../src/utils/dom";
+import { appendNode, createNode } from "../../../../../../src/utils/dom";
 import createResize from "../../../../../../src/components/Personalization/actions/resize";
-
-const cleanUp = () => {
-  selectNodes("div#resize").forEach(removeNode);
-  selectNodes("style").forEach(node => {
-    if (node.textContent.indexOf("resize") !== -1) {
-      removeNode(node);
-    }
-  });
-};
+import cleanUpDomChanges from "../../../../helpers/cleanUpDomChanges";
 
 describe("Personalization::actions::resize", () => {
   beforeEach(() => {
-    cleanUp();
+    cleanUpDomChanges("resize");
   });
 
   afterEach(() => {
-    cleanUp();
+    cleanUpDomChanges("resize");
   });
 
   it("should set personalized content", () => {

--- a/test/unit/specs/components/Personalization/actions/resize.spec.js
+++ b/test/unit/specs/components/Personalization/actions/resize.spec.js
@@ -15,6 +15,12 @@ const cleanUp = () => {
   });
 };
 
+const invalidateIfRequired = element => {
+  if (element.style.setAttribute) {
+    element.style.setAttribute("background", "red");
+  }
+};
+
 describe("Personalization::actions::resize", () => {
   beforeEach(() => {
     cleanUp();
@@ -40,9 +46,7 @@ describe("Personalization::actions::resize", () => {
 
     resize(settings, event);
 
-    /* eslint-disable no-unused-vars */
-    const forceRerender = elements[0].offsetLeft;
-    /* eslint-enable no-unused-vars */
+    invalidateIfRequired(elements[0]);
 
     expect(elements[0].style.width).toEqual("100px");
     expect(elements[0].style.height).toEqual("100px");

--- a/test/unit/specs/components/Personalization/actions/setAttribute.spec.js
+++ b/test/unit/specs/components/Personalization/actions/setAttribute.spec.js
@@ -1,27 +1,14 @@
-import {
-  selectNodes,
-  removeNode,
-  appendNode,
-  createNode
-} from "../../../../../../src/utils/dom";
+import { appendNode, createNode } from "../../../../../../src/utils/dom";
 import createSetAttribute from "../../../../../../src/components/Personalization/actions/setAttribute";
-
-const cleanUp = () => {
-  selectNodes("div#setAttribute").forEach(removeNode);
-  selectNodes("style").forEach(node => {
-    if (node.textContent.indexOf("setAttribute") !== -1) {
-      removeNode(node);
-    }
-  });
-};
+import cleanUpDomChanges from "../../../../helpers/cleanUpDomChanges";
 
 describe("Personalization::actions::setAttribute", () => {
   beforeEach(() => {
-    cleanUp();
+    cleanUpDomChanges("setAttribute");
   });
 
   afterEach(() => {
-    cleanUp();
+    cleanUpDomChanges("setAttribute");
   });
 
   it("should set personalized content", () => {

--- a/test/unit/specs/components/Personalization/actions/setHtml.spec.js
+++ b/test/unit/specs/components/Personalization/actions/setHtml.spec.js
@@ -1,27 +1,14 @@
-import {
-  selectNodes,
-  removeNode,
-  appendNode,
-  createNode
-} from "../../../../../../src/utils/dom";
+import { appendNode, createNode } from "../../../../../../src/utils/dom";
 import createSetHtml from "../../../../../../src/components/Personalization/actions/setHtml";
-
-const cleanUp = () => {
-  selectNodes("div#setHtml").forEach(removeNode);
-  selectNodes("style").forEach(node => {
-    if (node.textContent.indexOf("setHtml") !== -1) {
-      removeNode(node);
-    }
-  });
-};
+import cleanUpDomChanges from "../../../../helpers/cleanUpDomChanges";
 
 describe("Personalization::actions::setHtml", () => {
   beforeEach(() => {
-    cleanUp();
+    cleanUpDomChanges("setHtml");
   });
 
   afterEach(() => {
-    cleanUp();
+    cleanUpDomChanges("setHtml");
   });
 
   it("should set personalized content", () => {

--- a/test/unit/specs/components/Personalization/actions/setImageSource.spec.js
+++ b/test/unit/specs/components/Personalization/actions/setImageSource.spec.js
@@ -1,27 +1,14 @@
-import {
-  selectNodes,
-  removeNode,
-  appendNode,
-  createNode
-} from "../../../../../../src/utils/dom";
+import { appendNode, createNode } from "../../../../../../src/utils/dom";
 import createSetImageSource from "../../../../../../src/components/Personalization/actions/setImageSource";
-
-const cleanUp = () => {
-  selectNodes("div#setImageSource").forEach(removeNode);
-  selectNodes("style").forEach(node => {
-    if (node.textContent.indexOf("setImageSource") !== -1) {
-      removeNode(node);
-    }
-  });
-};
+import cleanUpDomChanges from "../../../../helpers/cleanUpDomChanges";
 
 describe("Personalization::actions::setImageSource", () => {
   beforeEach(() => {
-    cleanUp();
+    cleanUpDomChanges("setImageSource");
   });
 
   afterEach(() => {
-    cleanUp();
+    cleanUpDomChanges("setImageSource");
   });
 
   it("should set personalized content", () => {

--- a/test/unit/specs/components/Personalization/actions/setStyle.spec.js
+++ b/test/unit/specs/components/Personalization/actions/setStyle.spec.js
@@ -1,27 +1,14 @@
-import {
-  selectNodes,
-  removeNode,
-  appendNode,
-  createNode
-} from "../../../../../../src/utils/dom";
+import { appendNode, createNode } from "../../../../../../src/utils/dom";
 import createSetStyle from "../../../../../../src/components/Personalization/actions/setStyle";
-
-const cleanUp = () => {
-  selectNodes("div#setStyle").forEach(removeNode);
-  selectNodes("style").forEach(node => {
-    if (node.textContent.indexOf("setStyle") !== -1) {
-      removeNode(node);
-    }
-  });
-};
+import cleanUpDomChanges from "../../../../helpers/cleanUpDomChanges";
 
 describe("Presonalization::actions::setStyle", () => {
   beforeEach(() => {
-    cleanUp();
+    cleanUpDomChanges("setStyle");
   });
 
   afterEach(() => {
-    cleanUp();
+    cleanUpDomChanges("setStyle");
   });
 
   it("should set personalized content", () => {
@@ -40,9 +27,7 @@ describe("Presonalization::actions::setStyle", () => {
 
     setStyle(settings, event);
 
-    const result = window.getComputedStyle(element, null);
-
-    expect(result.getPropertyValue("font-size")).toEqual("33px");
+    expect(elements[0].style.getPropertyValue("font-size")).toEqual("33px");
     expect(collect).toHaveBeenCalledWith({
       meta: { personalization: { a: 1 } }
     });

--- a/test/unit/specs/components/Personalization/actions/setText.spec.js
+++ b/test/unit/specs/components/Personalization/actions/setText.spec.js
@@ -1,27 +1,14 @@
-import {
-  selectNodes,
-  removeNode,
-  appendNode,
-  createNode
-} from "../../../../../../src/utils/dom";
+import { appendNode, createNode } from "../../../../../../src/utils/dom";
 import createSetText from "../../../../../../src/components/Personalization/actions/setText";
-
-const cleanUp = () => {
-  selectNodes("div#setText").forEach(removeNode);
-  selectNodes("style").forEach(node => {
-    if (node.textContent.indexOf("setText") !== -1) {
-      removeNode(node);
-    }
-  });
-};
+import cleanUpDomChanges from "../../../../helpers/cleanUpDomChanges";
 
 describe("Personalization::actions::setText", () => {
   beforeEach(() => {
-    cleanUp();
+    cleanUpDomChanges("setHtml");
   });
 
   afterEach(() => {
-    cleanUp();
+    cleanUpDomChanges("setHtml");
   });
 
   it("should set personalized content", () => {


### PR DESCRIPTION
Moving actions Personalization duplicate code to utils/dom and utils 

## Description

Moving actions Personalization duplicate code to utils/dom and utils 

## Related Issue

NONE

## Motivation and Context

Currently Personalization component has a lot of duplications. The intent of this patch is to move code to DOM utils utilities or other utils folders if required.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
