### PR TITLE
TNT-32994 - fix personalization response fragment handling

### DIFF
--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -18,34 +18,30 @@ const PAGE_HANDLE = "personalization:page";
 const EVENT_COMMAND = "event";
 const isElementExists = event => event.moduleType === "elementExists";
 
-const hideElementsForPage = fragments => {
-  fragments.forEach(fragment => {
-    const { rules = [] } = fragment;
+const hideElementsForPage = fragment => {
+  const { rules = [] } = fragment;
 
-    rules.forEach(rule => {
-      const { events = [] } = rule;
-      const filteredEvents = events.filter(isElementExists);
+  rules.forEach(rule => {
+    const { events = [] } = rule;
+    const filteredEvents = events.filter(isElementExists);
 
-      filteredEvents.forEach(event => {
-        const { settings = {} } = event;
-        const { prehidingSelector } = settings;
+    filteredEvents.forEach(event => {
+      const { settings = {} } = event;
+      const { prehidingSelector } = settings;
 
-        if (prehidingSelector) {
-          hideElements(prehidingSelector);
-        }
-      });
+      if (prehidingSelector) {
+        hideElements(prehidingSelector);
+      }
     });
   });
 };
 
-const executeFragments = (fragments, modules, logger) => {
-  fragments.forEach(fragment => {
-    const { rules = [] } = fragment;
+const executeFragment = (fragment, modules, logger) => {
+  const { rules = [] } = fragment;
 
-    if (isNonEmptyArray(rules)) {
-      executeRules(rules, modules, logger);
-    }
-  });
+  if (isNonEmptyArray(rules)) {
+    executeRules(rules, modules, logger);
+  }
 };
 
 const createPersonalization = ({ config, logger }) => {
@@ -68,17 +64,17 @@ const createPersonalization = ({ config, logger }) => {
         }
       },
       onResponse(response) {
-        const fragments = response.getPayloadByType(PAGE_HANDLE) || [];
+        const fragment = response.getPayloadByType(PAGE_HANDLE) || {};
 
         // On response we first hide all the elements for
         // personalization:page handle
-        hideElementsForPage(fragments);
+        hideElementsForPage(fragment);
 
         // Once the all element are hidden
         // we have to show the containers
         showContainers(prehidingId);
 
-        executeFragments(fragments, ruleComponentModules, logger);
+        executeFragment(fragment, ruleComponentModules, logger);
       },
       onResponseError() {
         showContainers(prehidingId);


### PR DESCRIPTION
Edge personalization feature response was handled incorrectly by personalization component.

## Description

Personlization component was expecting an array of fragments while edge would return an object with decisions, components and rules for different types like `page`, `views`, etc.

## Related Issue

NONE

## Motivation and Context

Bug fix

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
