### PR TITLE
CORE-32537 - ensure query -> personalization -> enabled if isViewStart

### DIFF
--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -85,14 +85,16 @@ const createPersonalization = ({ config, logger, cookie }) => {
         });
       },
       onBeforeEvent(event, options, isViewStart) {
-        if (isViewStart) {
-          // If isViewStart we enable personalization
-          event.mergeQuery({ personalization: { enabled: true } });
-          event.expectResponse();
-
-          // For viewStart we try to hide the personalization containers
-          hideContainers(prehidingId, prehidingStyle);
+        if (!isViewStart) {
+          // If NOT isViewStart disable personalization
+          event.mergeQuery({ personalization: { enabled: false } });
+          return;
         }
+
+        event.expectResponse();
+
+        // For viewStart we try to hide the personalization containers
+        hideContainers(prehidingId, prehidingStyle);
       },
       onResponse(response) {
         const fragment = response.getPayloadByType(PAGE_HANDLE) || {};

--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -86,9 +86,12 @@ const createPersonalization = ({ config, logger, cookie }) => {
       },
       onBeforeEvent(event, options, isViewStart) {
         if (isViewStart) {
+          // If isViewStart we enable personalization
+          event.mergeQuery({ personalization: { enabled: true } });
+          event.expectResponse();
+
           // For viewStart we try to hide the personalization containers
           hideContainers(prehidingId, prehidingStyle);
-          event.expectResponse();
         }
       },
       onResponse(response) {


### PR DESCRIPTION
Ensure event query contains personalization if event has "view start".

## Description

If event has "view start" we should ensure that request that is passed to backend has `query -> personalization -> enabled` set to `true`. Otherwise backend won't try to run the personalization decision engine.

## Related Issue

NONE

## Motivation and Context

We need to ensure that backend is instructed to return personalization content depending on event "view start".

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
