### PR TITLE
CORE-32658 Fixes issue where cookie proxies weren't sharing the same cookie cache.

### DIFF
--- a/rollup.test.config.js
+++ b/rollup.test.config.js
@@ -19,7 +19,11 @@ const minimist = require("minimist");
 
 const argv = minimist(process.argv.slice(2));
 const plugins = [
-  jscc(),
+  jscc({
+    values: {
+      _TEST: true
+    }
+  }),
   resolve({
     preferBuiltins: false,
     // Support the browser field in dependencies' package.json.

--- a/src/utils/getTopLevelCookieDomain.js
+++ b/src/utils/getTopLevelCookieDomain.js
@@ -45,6 +45,8 @@ export default function getTopLevelCookieDomain(window, cookie) {
   return topLevelCookieDomain;
 }
 
-export const testClearCachedValue = () => {
+// #if _TEST
+export const clearCachedValue = () => {
   topLevelCookieDomain = "";
 };
+// #endif

--- a/test/unit/specs/core/createCookie.spec.js
+++ b/test/unit/specs/core/createCookie.spec.js
@@ -10,12 +10,14 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import createCookie from "../../../../src/core/createCookie";
+import createCookie, { clearProxies } from "../../../../src/core/createCookie";
 import cookie from "../../../../src/utils/cookie";
 import cookieDetails from "../../../../src/constants/cookieDetails";
 
-const prefix = "testprefix";
-const testID1 = "ID1";
+const componentNamespace1 = "component1";
+const componentNamespace2 = "component2";
+const propertyId1 = "property1";
+const propertyId2 = "property2";
 const COOKIE_NAME = cookieDetails.ALLOY_COOKIE_NAME;
 const removeCookie = name => {
   document.cookie = `${name}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
@@ -32,42 +34,47 @@ describe("createCookie", () => {
   let alloyCookie;
 
   afterEach(() => {
+    clearProxies();
     removeAllCookies();
   });
   beforeEach(() => {
+    clearProxies();
     removeAllCookies();
   });
 
   it("should return an undefined object when no cookie is found", () => {
-    alloyCookie = createCookie(prefix);
+    alloyCookie = createCookie(componentNamespace1);
     const test1 = alloyCookie.get();
     expect(test1).toEqual(undefined);
-    alloyCookie = createCookie(prefix, testID1);
+    alloyCookie = createCookie(componentNamespace1, propertyId1);
     const test2 = alloyCookie.get();
     expect(test2).toEqual(undefined);
   });
 
   it("Should throw an error when an invalid format is set in cookie", () => {
-    alloyCookie = createCookie(prefix, testID1);
-    document.cookie = `${COOKIE_NAME}_${testID1}=abbc|jhjkh`;
+    alloyCookie = createCookie(componentNamespace1, propertyId1);
+    document.cookie = `${COOKIE_NAME}_${propertyId1}=abbc|jhjkh`;
     expect(() => {
       alloyCookie.get();
     }).toThrow(
-      new Error(`Invalid cookie format in ${COOKIE_NAME}_${testID1} cookie`)
+      new Error(`Invalid cookie format in ${COOKIE_NAME}_${propertyId1} cookie`)
     );
   });
 
-  it("should create an object with prefixed namespace for storing", () => {
-    alloyCookie = createCookie(prefix, testID1);
+  it("should create an object with component namespace for storing", () => {
+    alloyCookie = createCookie(componentNamespace1, propertyId1);
     alloyCookie.set("key1", "val1");
-    expect(cookie.get(`${COOKIE_NAME}_${testID1}`)).toBe(
-      `{"${prefix}":{"key1":"val1"}}`
+    expect(cookie.get(`${COOKIE_NAME}_${propertyId1}`)).toBe(
+      `{"${componentNamespace1}":{"key1":"val1"}}`
     );
   });
 
   it("should only read the cookie from storage once (for optimization)", () => {
-    cookie.set(`${COOKIE_NAME}_${testID1}`, `{"${prefix}":{"key1":"val1"}}`);
-    alloyCookie = createCookie(prefix, testID1);
+    cookie.set(
+      `${COOKIE_NAME}_${propertyId1}`,
+      `{"${componentNamespace1}":{"key1":"val1"}}`
+    );
+    alloyCookie = createCookie(componentNamespace1, propertyId1);
     expect(alloyCookie.get("key1")).toBe("val1");
     removeAllCookies();
     expect(alloyCookie.get("key1")).toBe("val1");
@@ -76,65 +83,85 @@ describe("createCookie", () => {
     expect(alloyCookie.get("key1")).toBe("val2");
   });
 
+  // CORE-32658
+  it("should only create a single cookie cache per cookie", () => {
+    cookie.set(
+      `${COOKIE_NAME}_${propertyId1}`,
+      `{"${componentNamespace1}":{"key1":"val1"}}`
+    );
+    const alloyCookie1 = createCookie(componentNamespace1, propertyId1);
+    const alloyCookie2 = createCookie(componentNamespace1, propertyId1);
+    const alloyCookie3 = createCookie(componentNamespace1, propertyId2);
+    // Force alloyCookie1 to deserialize and cache the cookie
+    alloyCookie1.get("key1");
+    // Since alloyCookie1 and alloyCookie2 should be sharing the same cache,
+    // this change should be reflected in both.
+    alloyCookie2.set("key1", "val2");
+    expect(alloyCookie1.get("key1")).toBe("val2");
+    // alloyCookie3 should not share the same cache, since it's a
+    // different cookie (because it's a different property ID).
+    expect(alloyCookie3.get("key1")).toBeUndefined();
+  });
+
   it("should update a stored value", () => {
-    alloyCookie = createCookie(prefix, testID1);
+    alloyCookie = createCookie(componentNamespace1, propertyId1);
 
     alloyCookie.set("key1", "val1");
-    expect(cookie.get(`${COOKIE_NAME}_${testID1}`)).toBe(
-      `{"${prefix}":{"key1":"val1"}}`
+    expect(cookie.get(`${COOKIE_NAME}_${propertyId1}`)).toBe(
+      `{"${componentNamespace1}":{"key1":"val1"}}`
     );
 
     alloyCookie.set("key1", "valnew");
     alloyCookie.set("key2", "val2");
-    expect(cookie.get(`${COOKIE_NAME}_${testID1}`)).toBe(
-      `{"${prefix}":{"key1":"valnew","key2":"val2"}}`
+    expect(cookie.get(`${COOKIE_NAME}_${propertyId1}`)).toBe(
+      `{"${componentNamespace1}":{"key1":"valnew","key2":"val2"}}`
     );
   });
 
   it("should remove a stored key value pair", () => {
-    alloyCookie = createCookie(prefix, testID1);
+    alloyCookie = createCookie(componentNamespace1, propertyId1);
 
     alloyCookie.set("key1", "val1");
-    expect(cookie.get(`${COOKIE_NAME}_${testID1}`)).toBe(
-      `{"${prefix}":{"key1":"val1"}}`
+    expect(cookie.get(`${COOKIE_NAME}_${propertyId1}`)).toBe(
+      `{"${componentNamespace1}":{"key1":"val1"}}`
     );
 
     alloyCookie.set("key1", "valnew");
     alloyCookie.set("key2", "val2");
-    expect(cookie.get(`${COOKIE_NAME}_${testID1}`)).toBe(
-      `{"${prefix}":{"key1":"valnew","key2":"val2"}}`
+    expect(cookie.get(`${COOKIE_NAME}_${propertyId1}`)).toBe(
+      `{"${componentNamespace1}":{"key1":"valnew","key2":"val2"}}`
     );
 
     alloyCookie.remove("key2");
-    expect(cookie.get(`${COOKIE_NAME}_${testID1}`)).toBe(
-      `{"${prefix}":{"key1":"valnew"}}`
+    expect(cookie.get(`${COOKIE_NAME}_${propertyId1}`)).toBe(
+      `{"${componentNamespace1}":{"key1":"valnew"}}`
     );
   });
 
   it("should remove a stored key value pair only when present", () => {
-    alloyCookie = createCookie(prefix, testID1);
+    alloyCookie = createCookie(componentNamespace1, propertyId1);
 
     alloyCookie.remove("key1");
-    expect(cookie.get(`${COOKIE_NAME}_${testID1}`)).toEqual(undefined);
+    expect(cookie.get(`${COOKIE_NAME}_${propertyId1}`)).toEqual(undefined);
 
     alloyCookie.set("key1", "valnew");
     alloyCookie.remove("key2");
-    expect(cookie.get(`${COOKIE_NAME}_${testID1}`)).toBe(
-      `{"${prefix}":{"key1":"valnew"}}`
+    expect(cookie.get(`${COOKIE_NAME}_${propertyId1}`)).toBe(
+      `{"${componentNamespace1}":{"key1":"valnew"}}`
     );
   });
 
-  it("should create new namespace for each prefix", () => {
-    const alloyCookie1 = createCookie(`${prefix}1`, testID1);
-    const alloyCookie2 = createCookie(`${prefix}2`, testID1);
+  it("should create new namespace for each component namespace", () => {
+    const alloyCookie1 = createCookie(componentNamespace1, propertyId1);
+    const alloyCookie2 = createCookie(componentNamespace2, propertyId1);
     alloyCookie1.set("key1", "val1");
-    expect(cookie.get(`${COOKIE_NAME}_${testID1}`)).toBe(
-      `{"${prefix}1":{"key1":"val1"}}`
+    expect(cookie.get(`${COOKIE_NAME}_${propertyId1}`)).toBe(
+      `{"${componentNamespace1}":{"key1":"val1"}}`
     );
 
     alloyCookie2.set("key1", "val1");
-    expect(cookie.get(`${COOKIE_NAME}_${testID1}`)).toBe(
-      `{"${prefix}1":{"key1":"val1"},"${prefix}2":{"key1":"val1"}}`
+    expect(cookie.get(`${COOKIE_NAME}_${propertyId1}`)).toBe(
+      `{"${componentNamespace1}":{"key1":"val1"},"${componentNamespace2}":{"key1":"val1"}}`
     );
   });
 });

--- a/test/unit/specs/utils/getTopLevelCookieDomain.spec.js
+++ b/test/unit/specs/utils/getTopLevelCookieDomain.spec.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import getTopLevelCookieDomain, {
-  testClearCachedValue
+  clearCachedValue
 } from "../../../../src/utils/getTopLevelCookieDomain";
 
 const mockWindowWithHostname = hostname => {
@@ -23,7 +23,7 @@ const mockWindowWithHostname = hostname => {
 };
 
 describe("getTld", () => {
-  afterEach(testClearCachedValue);
+  afterEach(clearCachedValue);
 
   it("returns an empty string when only one host part exists", () => {
     const window = mockWindowWithHostname("localhost");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently `createCookie`, found in `createCookie.js`, is called once per component. Each time `createCookie` is created, a new cookie proxy is created, which caches the deserialized cookie so that we're not reading the cookie from persistence every time we need a value. Because a cookie proxy is created for each component, we have multiple caches of the same alloy cookie, which means the caches don't stay up-to-date, which eventually results in a persisted cookie that doesn't contain all the latest data.

This fixes that problem by sharing the same cookie proxy for each property ID and therefore each cookie.

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-32658

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Corrupted cookies make sad users.

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
