### PR TITLE
CORE-32550 Allow onBeforeEvent run before opt-in.

### DIFF
--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -60,6 +60,7 @@ const createDataCollector = ({ config }) => {
 
     return lifecycle
       .onBeforeEvent(event, options, isViewStart)
+      .then(() => optIn.whenOptedIn())
       .then(() => makeServerCall(event));
   };
 
@@ -70,9 +71,7 @@ const createDataCollector = ({ config }) => {
       }
     },
     commands: {
-      event(options) {
-        return optIn.whenOptedIn().then(() => createEventHandler(options));
-      }
+      event: createEventHandler
     }
   };
 };

--- a/src/components/Identity/index.js
+++ b/src/components/Identity/index.js
@@ -62,7 +62,7 @@ const createIdentity = ({ config, logger, cookie }) => {
             logger.log("Delaying request while retrieving ECID from server.");
             promise = deferredForEcid.promise.then(() => {
               logger.log("Resuming previously delayed request.");
-              addIdsContext(payload, ecid);
+              addIdsContext(payload, getEcid());
             });
           } else {
             // We don't have an ECID and no request has gone out to fetch it.

--- a/test/unit/specs/components/DataCollector/index.spec.js
+++ b/test/unit/specs/components/DataCollector/index.spec.js
@@ -176,4 +176,22 @@ describe("Event Command", () => {
       );
     });
   });
+
+  describe("privacy", () => {
+    it("calls onBeforeEvent before consent and onBeforeDataCollection after", () => {
+      const deferred = defer();
+      optIn.whenOptedIn = () => deferred.promise;
+      eventCommand({});
+      return flushPromiseChains()
+        .then(() => {
+          expect(onBeforeEventSpy).toHaveBeenCalled();
+          expect(onBeforeDataCollectionSpy).not.toHaveBeenCalled();
+          deferred.resolve();
+          return flushPromiseChains();
+        })
+        .then(() => {
+          expect(onBeforeDataCollectionSpy).toHaveBeenCalled();
+        });
+    });
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We need to capture context data at the time the customer attempted to run an `event` command, not when the data is sent to the server after opt-in is received. In order to accomplish this, the data collector component needs to run the `onBeforeEvent` lifecycle method _before_ waiting for opt-in.

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-32550

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Users like data that was captured at the time they attempted to execute the command.

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
