### PR TITLE
AN-32319 use isViewStart boolean instead of type

### DIFF
--- a/sandbox/src/Home.js
+++ b/sandbox/src/Home.js
@@ -8,8 +8,9 @@ function HomeWithHistory({ history }) {
     if (loc.pathname !== previousPath) {
       const instanceName = loc.pathname.includes("orgTwo") ? "organizationTwo" : "alloy";
       window[instanceName]("event", {
-        isViewStart: true,
+        viewStart: true,
         data: {
+          "eventType": "page-view",
           "url": window.location.href,
           "name": loc.pathname.substring(1)
         }
@@ -20,8 +21,8 @@ function HomeWithHistory({ history }) {
 
   const visitDoc = ev => {
     window.alloy("event", {
-      type: "visit-doc",
       data: {
+        "eventType": "visit-doc",
         "activitystreams:href": ev.target.href,
         "activitystreams:name": ev.target.name,
         "activitystreams:mediaType": "text/html",
@@ -31,8 +32,8 @@ function HomeWithHistory({ history }) {
 
   const copyBaseCode = ev => {
     window.alloy("event", {
-      type: "copy-base-code",
       data: {
+        "eventType": "copy-base-code",
         "activitystreams:href": "https://launch.gitbook.io/adobe-experience-platform-web-sdk/",
         "activitystreams:name": "copyBaseCode",
         "activitystreams:mediaType": "text/html",

--- a/sandbox/src/Home.js
+++ b/sandbox/src/Home.js
@@ -8,7 +8,7 @@ function HomeWithHistory({ history }) {
     if (loc.pathname !== previousPath) {
       const instanceName = loc.pathname.includes("orgTwo") ? "organizationTwo" : "alloy";
       window[instanceName]("event", {
-        type: "viewStart",
+        isViewStart: true,
         data: {
           "url": window.location.href,
           "name": loc.pathname.substring(1)

--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -13,8 +13,6 @@ governing permissions and limitations under the License.
 import createEvent from "./createEvent";
 import { clone } from "../../utils";
 
-const VIEW_START_EVENT = "viewStart";
-
 const createDataCollector = ({ config }) => {
   const { imsOrgId } = config;
   let lifecycle;
@@ -50,10 +48,10 @@ const createDataCollector = ({ config }) => {
 
   const createEventHandler = options => {
     const event = createEvent();
-    const isViewStart = options.type === VIEW_START_EVENT;
+    const { isViewStart = false, data, meta } = options;
 
-    event.mergeData(options.data);
-    event.mergeMeta(options.meta);
+    event.mergeData(data);
+    event.mergeMeta(meta);
 
     return lifecycle
       .onBeforeEvent(event, options, isViewStart)

--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -48,13 +48,13 @@ const createDataCollector = ({ config }) => {
 
   const createEventHandler = options => {
     const event = createEvent();
-    const { isViewStart = false, data, meta } = options;
+    const { viewStart = false, data, meta } = options;
 
     event.mergeData(data);
     event.mergeMeta(meta);
 
     return lifecycle
-      .onBeforeEvent(event, options, isViewStart)
+      .onBeforeEvent(event, options, viewStart)
       .then(() => optIn.whenOptedIn())
       .then(() => makeServerCall(event));
   };

--- a/test/unit/specs/components/DataCollector/index.spec.js
+++ b/test/unit/specs/components/DataCollector/index.spec.js
@@ -64,7 +64,7 @@ describe("Event Command", () => {
     });
   });
   it("Extracts isViewStart for onBeforeEvent", () => {
-    const options = { type: "viewStart" };
+    const options = { isViewStart: true };
     return eventCommand(options).then(() => {
       expect(onBeforeEventSpy).toHaveBeenCalledWith(
         jasmine.anything(),

--- a/test/unit/specs/components/DataCollector/index.spec.js
+++ b/test/unit/specs/components/DataCollector/index.spec.js
@@ -63,8 +63,8 @@ describe("Event Command", () => {
       );
     });
   });
-  it("Extracts isViewStart for onBeforeEvent", () => {
-    const options = { isViewStart: true };
+  it("Extracts viewStart for onBeforeEvent", () => {
+    const options = { viewStart: true };
     return eventCommand(options).then(() => {
       expect(onBeforeEventSpy).toHaveBeenCalledWith(
         jasmine.anything(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Change `type: "viewStart"` to `isViewStart: true` within the data collector options.

## Related Issue

https://jira.corp.adobe.com/browse/CORE-32319

## Motivation and Context

We made the decision that customer can set event types in their data, instead of top level on the event, especially that XDM already has an `eventType` property, with 20 built-in values.

Since the view start concept is important to Personalization, and probably few other components as well, we will convert the `type: viewStart` to a boolean: `isViewStart: true|false`. (false by default)

The components will still receive this boolean in the lifecycle hooks.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
