### PR TITLE
CORE-21547 Separated createCookieProxy for dependency injection.

### DIFF
--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -16,7 +16,7 @@ import { hideContainers, showContainers, hideElements } from "./flicker";
 
 const PAGE_HANDLE = "personalization:page";
 const SESSION_ID_COOKIE = "SID";
-const SESSION_ID_TTL = 31 * 60 * 1000;
+const SESSION_ID_TTL_IN_DAYS = 31 * 60 * 1000;
 const EVENT_COMMAND = "event";
 
 const isElementExists = event => event.moduleType === "elementExists";
@@ -24,7 +24,7 @@ const isElementExists = event => event.moduleType === "elementExists";
 const getOrCreateSessionId = cookie => {
   let cookieValue = cookie.get(SESSION_ID_COOKIE);
   const now = Date.now();
-  const expires = now + SESSION_ID_TTL;
+  const expires = now + SESSION_ID_TTL_IN_DAYS;
 
   if (!cookieValue || now > cookieValue.expires) {
     cookieValue = { value: uuid(), expires };

--- a/src/constants/cookieDetails.js
+++ b/src/constants/cookieDetails.js
@@ -12,5 +12,5 @@ governing permissions and limitations under the License.
 
 export default {
   ALLOY_COOKIE_NAME: "adobe_alloy", // TODO: Rename this cookie
-  ALLOY_COOKIE_EXPIRES: 180
+  ALLOY_COOKIE_TTL_IN_DAYS: 180
 };

--- a/src/constants/cookieDetails.js
+++ b/src/constants/cookieDetails.js
@@ -12,5 +12,5 @@ governing permissions and limitations under the License.
 
 export default {
   ALLOY_COOKIE_NAME: "adobe_alloy", // TODO: Rename this cookie
-  ALLOY_COOKIE_TTL: 180
+  ALLOY_COOKIE_EXPIRES: 180
 };

--- a/src/core/createCookieProxy.js
+++ b/src/core/createCookieProxy.js
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import cookie from "../utils/cookie";
+import getTopLevelCookieDomain from "../utils/getTopLevelCookieDomain";
+
+const safeJSONParse = (object, cookieName) => {
+  try {
+    return JSON.parse(object);
+  } catch (error) {
+    throw new Error(`Invalid cookie format in ${cookieName} cookie`);
+  }
+};
+
+/**
+ * The purpose of this proxy is to cache the cookie so we don't have to
+ * read and deserialize it every time a piece of it is accessed. It assumes
+ * nothing outside of Alloy will be modifying the cookie.
+ */
+export default (name, expires, domain = "") => {
+  let deserializedCookie;
+  let cookieHasBeenRead = false;
+
+  return {
+    get() {
+      // We don't read the cookie right when the cookie proxy is created
+      // because we don't know if the user has opted in. If the user
+      // hasn't opted in, we're legally obligated to not read the cookie.
+      // If a component tries to read something off the cookie though,
+      // we assume that the component has received word that the user
+      // has opted-in. The responsibility is on the component.
+      if (cookieHasBeenRead) {
+        return deserializedCookie;
+      }
+
+      const serializedCookie = cookie.get(name);
+      deserializedCookie =
+        serializedCookie && safeJSONParse(serializedCookie, name);
+      cookieHasBeenRead = true;
+      return deserializedCookie;
+    },
+    set(updatedCookie) {
+      deserializedCookie = updatedCookie;
+      cookie.set(name, updatedCookie, {
+        expires,
+        domain: domain || getTopLevelCookieDomain(window, cookie)
+      });
+    }
+  };
+};

--- a/src/core/initializeComponentsFactory.js
+++ b/src/core/initializeComponentsFactory.js
@@ -10,20 +10,31 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import createLifecycle from "./createLifecycle";
-import createComponentRegistry from "./createComponentRegistry";
-import createNetwork from "./network";
 import { stackError } from "../utils";
-import createOptIn from "./createOptIn";
+import cookieDetails from "../constants/cookieDetails";
+
+const { ALLOY_COOKIE_NAME, ALLOY_COOKIE_EXPIRES } = cookieDetails;
 
 export default (
   componentCreators,
   logger,
   createNamespacedStorage,
-  cookie
+  createCookieProxy,
+  createCookie,
+  createLifecycle,
+  createComponentRegistry,
+  createNetwork,
+  createOptIn
 ) => config => {
   const componentRegistry = createComponentRegistry();
   const { imsOrgId, propertyId, cookieDomain } = config;
+  const cookieName = `${ALLOY_COOKIE_NAME}_${propertyId}`;
+  const cookieProxy = createCookieProxy(
+    cookieName,
+    ALLOY_COOKIE_EXPIRES,
+    cookieDomain
+  );
+
   // TODO: Should this storage be namespaced by property ID or org ID?
   const storage = createNamespacedStorage(imsOrgId);
   const optIn = createOptIn();
@@ -40,7 +51,7 @@ export default (
     try {
       component = createComponent({
         logger: logger.spawn(`[${namespace}]`),
-        cookie: cookie(namespace, propertyId, cookieDomain),
+        cookie: createCookie(cookieProxy, namespace),
         config,
         storage,
         enableOptIn: optIn.enable

--- a/src/core/initializeComponentsFactory.js
+++ b/src/core/initializeComponentsFactory.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 import { stackError } from "../utils";
 import cookieDetails from "../constants/cookieDetails";
 
-const { ALLOY_COOKIE_NAME, ALLOY_COOKIE_EXPIRES } = cookieDetails;
+const { ALLOY_COOKIE_NAME, ALLOY_COOKIE_TTL_IN_DAYS } = cookieDetails;
 
 export default (
   componentCreators,
@@ -31,7 +31,7 @@ export default (
   const cookieName = `${ALLOY_COOKIE_NAME}_${propertyId}`;
   const cookieProxy = createCookieProxy(
     cookieName,
-    ALLOY_COOKIE_EXPIRES,
+    ALLOY_COOKIE_TTL_IN_DAYS,
     cookieDomain
   );
 

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -15,8 +15,13 @@ import storageFactory from "../utils/storageFactory";
 import initializeComponentsFactory from "./initializeComponentsFactory";
 
 import createLogger from "./createLogger";
+import createCookieProxy from "./createCookieProxy";
 import createCookie from "./createCookie";
 import createLogController from "./createLogController";
+import createLifecycle from "./createLifecycle";
+import createComponentRegistry from "./createComponentRegistry";
+import createNetwork from "./network";
+import createOptIn from "./createOptIn";
 
 import createDataCollector from "../components/DataCollector";
 import createIdentity from "../components/Identity";
@@ -57,7 +62,12 @@ if (namespaces) {
       componentCreators,
       logger,
       createNamespacedStorage,
-      createCookie
+      createCookieProxy,
+      createCookie,
+      createLifecycle,
+      createComponentRegistry,
+      createNetwork,
+      createOptIn
     );
 
     const instance = createInstance(

--- a/test/unit/specs/core/createCookie.spec.js
+++ b/test/unit/specs/core/createCookie.spec.js
@@ -10,158 +10,148 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import createCookie, { clearProxies } from "../../../../src/core/createCookie";
-import cookie from "../../../../src/utils/cookie";
-import cookieDetails from "../../../../src/constants/cookieDetails";
+import createCookie from "../../../../src/core/createCookie";
+import { clone } from "../../../../src/utils";
 
 const componentNamespace1 = "component1";
 const componentNamespace2 = "component2";
-const propertyId1 = "property1";
-const propertyId2 = "property2";
-const COOKIE_NAME = cookieDetails.ALLOY_COOKIE_NAME;
-const removeCookie = name => {
-  document.cookie = `${name}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
-};
-
-const removeAllCookies = () => {
-  const cookies = document.cookie.split(";");
-  cookies.forEach(cookieName => {
-    removeCookie(cookieName.split("=")[0]);
-  });
-};
 
 describe("createCookie", () => {
+  let cookieProxy;
   let alloyCookie;
 
-  afterEach(() => {
-    clearProxies();
-    removeAllCookies();
-  });
   beforeEach(() => {
-    clearProxies();
-    removeAllCookies();
+    cookieProxy = jasmine.createSpyObj("cookieProxy", ["get", "set"]);
   });
 
-  it("should return an undefined object when no cookie is found", () => {
-    alloyCookie = createCookie(componentNamespace1);
-    const test1 = alloyCookie.get();
-    expect(test1).toEqual(undefined);
-    alloyCookie = createCookie(componentNamespace1, propertyId1);
-    const test2 = alloyCookie.get();
-    expect(test2).toEqual(undefined);
+  describe("get", () => {
+    it("should return undefined when no cookie is found", () => {
+      cookieProxy.get.and.returnValue(undefined);
+      alloyCookie = createCookie(cookieProxy, componentNamespace1);
+      const value = alloyCookie.get("foo");
+      expect(value).toEqual(undefined);
+    });
+
+    it("should return undefined if component namespace not found on cookie", () => {
+      cookieProxy.get.and.returnValue({});
+      alloyCookie = createCookie(cookieProxy, componentNamespace1);
+      const value = alloyCookie.get("foo");
+      expect(value).toEqual(undefined);
+    });
+
+    it("should return undefined if key not found on cookie within component namespace", () => {
+      cookieProxy.get.and.returnValue({
+        [componentNamespace1]: {}
+      });
+      alloyCookie = createCookie(cookieProxy, componentNamespace1);
+      const value = alloyCookie.get("foo");
+      expect(value).toEqual(undefined);
+    });
+
+    it("should return value if found on cookie", () => {
+      cookieProxy.get.and.returnValue({
+        [componentNamespace1]: {
+          foo: "bar"
+        }
+      });
+      alloyCookie = createCookie(cookieProxy, componentNamespace1);
+      const value = alloyCookie.get("foo");
+      expect(value).toEqual("bar");
+    });
   });
 
-  it("Should throw an error when an invalid format is set in cookie", () => {
-    alloyCookie = createCookie(componentNamespace1, propertyId1);
-    document.cookie = `${COOKIE_NAME}_${propertyId1}=abbc|jhjkh`;
-    expect(() => {
-      alloyCookie.get();
-    }).toThrow(
-      new Error(`Invalid cookie format in ${COOKIE_NAME}_${propertyId1} cookie`)
-    );
+  describe("set", () => {
+    it("should set value when cookie doesn't exist", () => {
+      cookieProxy.get.and.returnValue(undefined);
+      alloyCookie = createCookie(cookieProxy, componentNamespace1);
+      alloyCookie.set("foo", "bar");
+      expect(cookieProxy.set).toHaveBeenCalledWith({
+        [componentNamespace1]: {
+          foo: "bar"
+        }
+      });
+    });
+
+    it("should set value when namespace doesn't exist on cookie", () => {
+      cookieProxy.get.and.returnValue({});
+      alloyCookie = createCookie(cookieProxy, componentNamespace1);
+      alloyCookie.set("foo", "bar");
+      expect(cookieProxy.set).toHaveBeenCalledWith({
+        [componentNamespace1]: {
+          foo: "bar"
+        }
+      });
+    });
+
+    it("should set value when cookie already has a bunch of data", () => {
+      const originalCookieObject = {
+        [componentNamespace1]: {
+          foo: "bar",
+          tool: "sickle"
+        },
+        [componentNamespace2]: {
+          documentary: "First Face in America"
+        }
+      };
+      const clonedOriginalCookieObject = clone(originalCookieObject);
+      cookieProxy.get.and.returnValue(originalCookieObject);
+      alloyCookie = createCookie(cookieProxy, componentNamespace1);
+      alloyCookie.set("foo", "baz");
+      expect(cookieProxy.set).toHaveBeenCalledWith({
+        [componentNamespace1]: {
+          foo: "baz",
+          tool: "sickle"
+        },
+        [componentNamespace2]: {
+          documentary: "First Face in America"
+        }
+      });
+      // The original cookie object returned from the cookie proxy shouldn't
+      // have been modified.
+      expect(originalCookieObject).toEqual(clonedOriginalCookieObject);
+    });
   });
 
-  it("should create an object with component namespace for storing", () => {
-    alloyCookie = createCookie(componentNamespace1, propertyId1);
-    alloyCookie.set("key1", "val1");
-    expect(cookie.get(`${COOKIE_NAME}_${propertyId1}`)).toBe(
-      `{"${componentNamespace1}":{"key1":"val1"}}`
-    );
-  });
+  describe("remove", () => {
+    it("doesn't attempt to set cookie when cookie doesn't exist", () => {
+      cookieProxy.get.and.returnValue(undefined);
+      alloyCookie = createCookie(cookieProxy, componentNamespace1);
+      alloyCookie.remove("foo");
+      expect(cookieProxy.set).not.toHaveBeenCalled();
+    });
 
-  it("should only read the cookie from storage once (for optimization)", () => {
-    cookie.set(
-      `${COOKIE_NAME}_${propertyId1}`,
-      `{"${componentNamespace1}":{"key1":"val1"}}`
-    );
-    alloyCookie = createCookie(componentNamespace1, propertyId1);
-    expect(alloyCookie.get("key1")).toBe("val1");
-    removeAllCookies();
-    expect(alloyCookie.get("key1")).toBe("val1");
-    alloyCookie.set("key1", "val2");
-    removeAllCookies();
-    expect(alloyCookie.get("key1")).toBe("val2");
-  });
+    it("doesn't attempt to set cookie when namespace doesn't exist in cookie", () => {
+      cookieProxy.get.and.returnValue({});
+      alloyCookie = createCookie(cookieProxy, componentNamespace1);
+      alloyCookie.remove("foo");
+      expect(cookieProxy.set).not.toHaveBeenCalled();
+    });
 
-  // CORE-32658
-  it("should only create a single cookie cache per cookie", () => {
-    cookie.set(
-      `${COOKIE_NAME}_${propertyId1}`,
-      `{"${componentNamespace1}":{"key1":"val1"}}`
-    );
-    const alloyCookie1 = createCookie(componentNamespace1, propertyId1);
-    const alloyCookie2 = createCookie(componentNamespace1, propertyId1);
-    const alloyCookie3 = createCookie(componentNamespace1, propertyId2);
-    // Force alloyCookie1 to deserialize and cache the cookie
-    alloyCookie1.get("key1");
-    // Since alloyCookie1 and alloyCookie2 should be sharing the same cache,
-    // this change should be reflected in both.
-    alloyCookie2.set("key1", "val2");
-    expect(alloyCookie1.get("key1")).toBe("val2");
-    // alloyCookie3 should not share the same cache, since it's a
-    // different cookie (because it's a different property ID).
-    expect(alloyCookie3.get("key1")).toBeUndefined();
-  });
-
-  it("should update a stored value", () => {
-    alloyCookie = createCookie(componentNamespace1, propertyId1);
-
-    alloyCookie.set("key1", "val1");
-    expect(cookie.get(`${COOKIE_NAME}_${propertyId1}`)).toBe(
-      `{"${componentNamespace1}":{"key1":"val1"}}`
-    );
-
-    alloyCookie.set("key1", "valnew");
-    alloyCookie.set("key2", "val2");
-    expect(cookie.get(`${COOKIE_NAME}_${propertyId1}`)).toBe(
-      `{"${componentNamespace1}":{"key1":"valnew","key2":"val2"}}`
-    );
-  });
-
-  it("should remove a stored key value pair", () => {
-    alloyCookie = createCookie(componentNamespace1, propertyId1);
-
-    alloyCookie.set("key1", "val1");
-    expect(cookie.get(`${COOKIE_NAME}_${propertyId1}`)).toBe(
-      `{"${componentNamespace1}":{"key1":"val1"}}`
-    );
-
-    alloyCookie.set("key1", "valnew");
-    alloyCookie.set("key2", "val2");
-    expect(cookie.get(`${COOKIE_NAME}_${propertyId1}`)).toBe(
-      `{"${componentNamespace1}":{"key1":"valnew","key2":"val2"}}`
-    );
-
-    alloyCookie.remove("key2");
-    expect(cookie.get(`${COOKIE_NAME}_${propertyId1}`)).toBe(
-      `{"${componentNamespace1}":{"key1":"valnew"}}`
-    );
-  });
-
-  it("should remove a stored key value pair only when present", () => {
-    alloyCookie = createCookie(componentNamespace1, propertyId1);
-
-    alloyCookie.remove("key1");
-    expect(cookie.get(`${COOKIE_NAME}_${propertyId1}`)).toEqual(undefined);
-
-    alloyCookie.set("key1", "valnew");
-    alloyCookie.remove("key2");
-    expect(cookie.get(`${COOKIE_NAME}_${propertyId1}`)).toBe(
-      `{"${componentNamespace1}":{"key1":"valnew"}}`
-    );
-  });
-
-  it("should create new namespace for each component namespace", () => {
-    const alloyCookie1 = createCookie(componentNamespace1, propertyId1);
-    const alloyCookie2 = createCookie(componentNamespace2, propertyId1);
-    alloyCookie1.set("key1", "val1");
-    expect(cookie.get(`${COOKIE_NAME}_${propertyId1}`)).toBe(
-      `{"${componentNamespace1}":{"key1":"val1"}}`
-    );
-
-    alloyCookie2.set("key1", "val1");
-    expect(cookie.get(`${COOKIE_NAME}_${propertyId1}`)).toBe(
-      `{"${componentNamespace1}":{"key1":"val1"},"${componentNamespace2}":{"key1":"val1"}}`
-    );
+    it("should remove value when cookie already has a bunch of data", () => {
+      const originalCookieObject = {
+        [componentNamespace1]: {
+          foo: "bar",
+          tool: "sickle"
+        },
+        [componentNamespace2]: {
+          documentary: "First Face in America"
+        }
+      };
+      const clonedOriginalCookieObject = clone(originalCookieObject);
+      cookieProxy.get.and.returnValue(originalCookieObject);
+      alloyCookie = createCookie(cookieProxy, componentNamespace1);
+      alloyCookie.remove("foo");
+      expect(cookieProxy.set).toHaveBeenCalledWith({
+        [componentNamespace1]: {
+          tool: "sickle"
+        },
+        [componentNamespace2]: {
+          documentary: "First Face in America"
+        }
+      });
+      // The original cookie object returned from the cookie proxy shouldn't
+      // have been modified.
+      expect(originalCookieObject).toEqual(clonedOriginalCookieObject);
+    });
   });
 });

--- a/test/unit/specs/core/createCookieProxy.spec.js
+++ b/test/unit/specs/core/createCookieProxy.spec.js
@@ -26,7 +26,7 @@ const removeAllCookies = () => {
   });
 };
 
-describe("createCookie", () => {
+describe("createCookieProxy", () => {
   let cookieProxy;
 
   afterEach(() => {

--- a/test/unit/specs/core/createCookieProxy.spec.js
+++ b/test/unit/specs/core/createCookieProxy.spec.js
@@ -1,0 +1,77 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import createCookieProxy from "../../../../src/core/createCookieProxy";
+import cookie from "../../../../src/utils/cookie";
+
+const COOKIE_NAME = "testcookie";
+const COOKIE_EXPIRES = 180;
+const removeCookie = name => {
+  document.cookie = `${name}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
+};
+
+const removeAllCookies = () => {
+  const cookies = document.cookie.split(";");
+  cookies.forEach(cookieName => {
+    removeCookie(cookieName.split("=")[0]);
+  });
+};
+
+describe("createCookie", () => {
+  let cookieProxy;
+
+  afterEach(() => {
+    removeAllCookies();
+  });
+  beforeEach(() => {
+    removeAllCookies();
+    cookieProxy = createCookieProxy(COOKIE_NAME, COOKIE_EXPIRES);
+  });
+
+  describe("get", () => {
+    it("should return an undefined object when no cookie is found", () => {
+      expect(cookieProxy.get()).toEqual(undefined);
+    });
+
+    it("should throw an error when an invalid format is set in cookie", () => {
+      document.cookie = `${COOKIE_NAME}=abbc|jhjkh`;
+      expect(() => {
+        cookieProxy.get();
+      }).toThrow(new Error(`Invalid cookie format in ${COOKIE_NAME} cookie`));
+    });
+
+    it("should only read the cookie from storage once (for optimization)", () => {
+      cookie.set(`${COOKIE_NAME}`, '{"foo":"bar"}');
+      expect(cookieProxy.get()).toEqual({ foo: "bar" });
+      removeAllCookies();
+      expect(cookieProxy.get()).toEqual({ foo: "bar" });
+      cookieProxy.set({
+        foo: "baz"
+      });
+      removeAllCookies();
+      expect(cookieProxy.get()).toEqual({ foo: "baz" });
+    });
+  });
+
+  describe("set", () => {
+    it("should create a cookie if one doesn't exist", () => {
+      cookieProxy.set({ foo: "bar" });
+      expect(cookie.get(COOKIE_NAME)).toBe('{"foo":"bar"}');
+    });
+
+    it("should update a cookie if one does exist", () => {
+      document.cookie = `${COOKIE_NAME}={"foo":"bar"}`;
+      cookieProxy.set({ foo: "baz" });
+      expect(cookie.get(COOKIE_NAME)).toBe('{"foo":"baz"}');
+    });
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As discussed in https://github.com/adobe/alloy/pull/126#discussion_r308275505, I split out `createCookieProxy` from `createCookie`, primarily so we could eliminate the need for test-specific code and because the modules can be more effectively tested in isolation.

I'm planning on opening another pull request that eliminates the test-specific code from `getTopLevelDomain.js`.

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-32658

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Eliminate test-specific code so that the code we test will exactly match what we see in production.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
