### PR TITLE
AN-32729 use smaller names for cookie namespaces

### DIFF
--- a/src/components/Audiences/index.js
+++ b/src/components/Audiences/index.js
@@ -39,7 +39,7 @@ const createAudiences = ({ config, logger }) => {
 };
 
 createAudiences.namespace = "Audiences";
-
+createAudiences.abbreviation = "AU";
 createAudiences.configValidators = {
   destinationsEnabled: {
     defaultValue: true

--- a/src/components/Context/index.js
+++ b/src/components/Context/index.js
@@ -33,7 +33,7 @@ const createContext = ({ config, logger }) => {
 };
 
 createContext.namespace = "Context";
-
+createContext.abbreviation = "CO";
 createContext.configValidators = {
   context: {
     defaultValue: ["web", "device", "environment", "placeContext"]

--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -77,5 +77,5 @@ const createDataCollector = ({ config }) => {
 };
 
 createDataCollector.namespace = "DataCollector";
-
+createDataCollector.abbreviation = "DC";
 export default createDataCollector;

--- a/src/components/Identity/index.js
+++ b/src/components/Identity/index.js
@@ -109,7 +109,7 @@ const createIdentity = ({ config, logger, cookie }) => {
 };
 
 createIdentity.namespace = "Identity";
-createIdentity.cookieNamespace = "I";
+createIdentity.abbreviation = "ID";
 
 createIdentity.configValidators = {
   idSyncsEnabled: {

--- a/src/components/Identity/index.js
+++ b/src/components/Identity/index.js
@@ -109,6 +109,7 @@ const createIdentity = ({ config, logger, cookie }) => {
 };
 
 createIdentity.namespace = "Identity";
+createIdentity.cookieNamespace = "I";
 
 createIdentity.configValidators = {
   idSyncsEnabled: {

--- a/src/components/LibraryInfo/index.js
+++ b/src/components/LibraryInfo/index.js
@@ -25,5 +25,5 @@ const createLibraryInfo = () => {
 };
 
 createLibraryInfo.namespace = "LibraryInfo";
-
+createLibraryInfo.abbreviation = "LI";
 export default createLibraryInfo;

--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -132,6 +132,6 @@ const createPersonalization = ({ config, logger, cookie }) => {
 };
 
 createPersonalization.namespace = "Personalization";
-createPersonalization.cookieNamespace = "P";
+createPersonalization.abbreviation = "PE";
 
 export default createPersonalization;

--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -132,5 +132,6 @@ const createPersonalization = ({ config, logger, cookie }) => {
 };
 
 createPersonalization.namespace = "Personalization";
+createPersonalization.cookieNamespace = "P";
 
 export default createPersonalization;

--- a/src/components/Privacy/index.js
+++ b/src/components/Privacy/index.js
@@ -60,7 +60,7 @@ const createPrivacy = ({ config, logger, enableOptIn, cookie }) => {
 };
 
 createPrivacy.namespace = "Privacy";
-createPrivacy.cookieNamespace = "C"; // C for consent
+createPrivacy.abbreviation = "PR";
 
 createPrivacy.configValidators = {
   optInEnabled: {

--- a/src/components/Privacy/index.js
+++ b/src/components/Privacy/index.js
@@ -60,6 +60,7 @@ const createPrivacy = ({ config, logger, enableOptIn, cookie }) => {
 };
 
 createPrivacy.namespace = "Privacy";
+createPrivacy.cookieNamespace = "C"; // C for consent
 
 createPrivacy.configValidators = {
   optInEnabled: {

--- a/src/components/Stitch/index.js
+++ b/src/components/Stitch/index.js
@@ -30,5 +30,5 @@ const createStitch = () => {
 };
 
 createStitch.namespace = "Stitch";
-
+createStitch.abbreviation = "ST";
 export default createStitch;

--- a/src/core/createCookie.js
+++ b/src/core/createCookie.js
@@ -10,13 +10,24 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import { isNonEmptyString } from "../utils";
+
 export default (cookieProxy, componentNamespace) => {
+  const validateNamespace = () => {
+    if (!isNonEmptyString(componentNamespace)) {
+      throw Error(
+        "No cookie namespace.  Please define 'abbreviation' on the component."
+      );
+    }
+  };
+
   return {
     /**
      * Returns a value from the Alloy cookie for a given key.
      * @param {string} key
      */
     get(key) {
+      validateNamespace();
       const currentCookie = cookieProxy.get();
       return (
         currentCookie &&
@@ -30,6 +41,7 @@ export default (cookieProxy, componentNamespace) => {
      * @param {string} value
      */
     set(key, value) {
+      validateNamespace();
       const currentCookie = cookieProxy.get() || {};
       const updatedCookie = {
         ...currentCookie,
@@ -45,6 +57,7 @@ export default (cookieProxy, componentNamespace) => {
      * @param {string} key
      */
     remove(key) {
+      validateNamespace();
       const currentCookie = cookieProxy.get();
       if (currentCookie && currentCookie[componentNamespace]) {
         const updatedCookie = {

--- a/src/core/createCookie.js
+++ b/src/core/createCookie.js
@@ -13,13 +13,11 @@ governing permissions and limitations under the License.
 import { isNonEmptyString } from "../utils";
 
 export default (cookieProxy, componentNamespace) => {
-  const validateNamespace = () => {
-    if (!isNonEmptyString(componentNamespace)) {
-      throw Error(
-        "No cookie namespace.  Please define 'abbreviation' on the component."
-      );
-    }
-  };
+  if (!isNonEmptyString(componentNamespace)) {
+    throw Error(
+      "No cookie namespace.  Please define 'abbreviation' on the component."
+    );
+  }
 
   return {
     /**
@@ -27,7 +25,6 @@ export default (cookieProxy, componentNamespace) => {
      * @param {string} key
      */
     get(key) {
-      validateNamespace();
       const currentCookie = cookieProxy.get();
       return (
         currentCookie &&
@@ -41,7 +38,6 @@ export default (cookieProxy, componentNamespace) => {
      * @param {string} value
      */
     set(key, value) {
-      validateNamespace();
       const currentCookie = cookieProxy.get() || {};
       const updatedCookie = {
         ...currentCookie,
@@ -57,7 +53,6 @@ export default (cookieProxy, componentNamespace) => {
      * @param {string} key
      */
     remove(key) {
-      validateNamespace();
       const currentCookie = cookieProxy.get();
       if (currentCookie && currentCookie[componentNamespace]) {
         const updatedCookie = {

--- a/src/core/initializeComponentsFactory.js
+++ b/src/core/initializeComponentsFactory.js
@@ -47,13 +47,13 @@ export default (
   });
   config.validate();
   componentCreators.forEach(createComponent => {
-    const { namespace, cookieNamespace } = createComponent;
+    const { namespace, abbreviation } = createComponent;
     // TO-DOCUMENT: Helpers that we inject into factories.
     let component;
     try {
       component = createComponent({
         logger: logger.spawn(`[${namespace}]`),
-        cookie: createCookie(cookieProxy, cookieNamespace || namespace),
+        cookie: createCookie(cookieProxy, abbreviation),
         config,
         storage,
         enableOptIn: optIn.enable

--- a/src/core/initializeComponentsFactory.js
+++ b/src/core/initializeComponentsFactory.js
@@ -47,13 +47,13 @@ export default (
   });
   config.validate();
   componentCreators.forEach(createComponent => {
-    const { namespace } = createComponent;
+    const { namespace, cookieNamespace } = createComponent;
     // TO-DOCUMENT: Helpers that we inject into factories.
     let component;
     try {
       component = createComponent({
         logger: logger.spawn(`[${namespace}]`),
-        cookie: createCookie(cookieProxy, namespace),
+        cookie: createCookie(cookieProxy, cookieNamespace || namespace),
         config,
         storage,
         enableOptIn: optIn.enable

--- a/test/unit/specs/components/DataCollector/index.spec.js
+++ b/test/unit/specs/components/DataCollector/index.spec.js
@@ -103,14 +103,16 @@ describe("Event Command", () => {
     const deferred = defer();
     onBeforeEventSpy.and.returnValue(deferred.promise);
     eventCommand({});
-    return flushPromiseChains().then(() => {
-      expect(onBeforeEventSpy).toHaveBeenCalled();
-      expect(sendRequestSpy).not.toHaveBeenCalled();
-      deferred.resolve();
-      return flushPromiseChains();
-    }).then(() => {
-      expect(sendRequestSpy).toHaveBeenCalled();
-    });
+    return flushPromiseChains()
+      .then(() => {
+        expect(onBeforeEventSpy).toHaveBeenCalled();
+        expect(sendRequestSpy).not.toHaveBeenCalled();
+        deferred.resolve();
+        return flushPromiseChains();
+      })
+      .then(() => {
+        expect(sendRequestSpy).toHaveBeenCalled();
+      });
   });
 
   it("Sends the event through to the Network Gateway", () => {
@@ -137,14 +139,16 @@ describe("Event Command", () => {
     const deferred = defer();
     onBeforeDataCollectionSpy.and.returnValue(deferred.promise);
     eventCommand({});
-    return flushPromiseChains().then(() => {
-      expect(onBeforeDataCollectionSpy).toHaveBeenCalled();
-      expect(sendRequestSpy).not.toHaveBeenCalled();
-      deferred.resolve();
-      return flushPromiseChains();
-    }).then(() => {
-      expect(sendRequestSpy).toHaveBeenCalled();
-    });
+    return flushPromiseChains()
+      .then(() => {
+        expect(onBeforeDataCollectionSpy).toHaveBeenCalled();
+        expect(sendRequestSpy).not.toHaveBeenCalled();
+        deferred.resolve();
+        return flushPromiseChains();
+      })
+      .then(() => {
+        expect(sendRequestSpy).toHaveBeenCalled();
+      });
   });
 
   it("Returns a promise resolved with the request and response", () => {
@@ -161,19 +165,13 @@ describe("Event Command", () => {
       return Promise.resolve();
     });
     return eventCommand({}).then(() => {
-      expect(sendRequestSpy).toHaveBeenCalledWith(
-        jasmine.anything(),
-        true
-      );
+      expect(sendRequestSpy).toHaveBeenCalledWith(jasmine.anything(), true);
     });
   });
 
   it("sends expectsResponse == false", () => {
     return eventCommand({}).then(() => {
-      expect(sendRequestSpy).toHaveBeenCalledWith(
-        jasmine.anything(),
-        false
-      );
+      expect(sendRequestSpy).toHaveBeenCalledWith(jasmine.anything(), false);
     });
   });
 

--- a/test/unit/specs/core/createCookie.spec.js
+++ b/test/unit/specs/core/createCookie.spec.js
@@ -58,6 +58,11 @@ describe("createCookie", () => {
       const value = alloyCookie.get("foo");
       expect(value).toEqual("bar");
     });
+
+    it("should throw an error if namespace is undefined", () => {
+      alloyCookie = createCookie(cookieProxy, undefined);
+      expect(() => alloyCookie.get("foo")).toThrowError();
+    });
   });
 
   describe("set", () => {
@@ -110,6 +115,11 @@ describe("createCookie", () => {
       // have been modified.
       expect(originalCookieObject).toEqual(clonedOriginalCookieObject);
     });
+
+    it("should throw an error if namespace is empty String", () => {
+      alloyCookie = createCookie(cookieProxy, "");
+      expect(() => alloyCookie.set("foo", "baz")).toThrowError();
+    });
   });
 
   describe("remove", () => {
@@ -152,6 +162,11 @@ describe("createCookie", () => {
       // The original cookie object returned from the cookie proxy shouldn't
       // have been modified.
       expect(originalCookieObject).toEqual(clonedOriginalCookieObject);
+    });
+
+    it("should throw an error if namespace is undefined", () => {
+      alloyCookie = createCookie(cookieProxy, undefined);
+      expect(() => alloyCookie.remove("foo")).toThrowError();
     });
   });
 });

--- a/test/unit/specs/core/createCookie.spec.js
+++ b/test/unit/specs/core/createCookie.spec.js
@@ -24,6 +24,18 @@ describe("createCookie", () => {
     cookieProxy = jasmine.createSpyObj("cookieProxy", ["get", "set"]);
   });
 
+  it("should throw an error if namespace is undefined", () => {
+    expect(() => createCookie(cookieProxy, undefined)).toThrowError();
+  });
+
+  it("should throw an error if namespace is a number", () => {
+    expect(() => createCookie(cookieProxy, 42)).toThrowError();
+  });
+
+  it("should throw an error if namespace is empty string", () => {
+    expect(() => createCookie(cookieProxy, "")).toThrowError();
+  });
+
   describe("get", () => {
     it("should return undefined when no cookie is found", () => {
       cookieProxy.get.and.returnValue(undefined);
@@ -57,11 +69,6 @@ describe("createCookie", () => {
       alloyCookie = createCookie(cookieProxy, componentNamespace1);
       const value = alloyCookie.get("foo");
       expect(value).toEqual("bar");
-    });
-
-    it("should throw an error if namespace is undefined", () => {
-      alloyCookie = createCookie(cookieProxy, undefined);
-      expect(() => alloyCookie.get("foo")).toThrowError();
     });
   });
 
@@ -115,11 +122,6 @@ describe("createCookie", () => {
       // have been modified.
       expect(originalCookieObject).toEqual(clonedOriginalCookieObject);
     });
-
-    it("should throw an error if namespace is empty String", () => {
-      alloyCookie = createCookie(cookieProxy, "");
-      expect(() => alloyCookie.set("foo", "baz")).toThrowError();
-    });
   });
 
   describe("remove", () => {
@@ -162,11 +164,6 @@ describe("createCookie", () => {
       // The original cookie object returned from the cookie proxy shouldn't
       // have been modified.
       expect(originalCookieObject).toEqual(clonedOriginalCookieObject);
-    });
-
-    it("should throw an error if namespace is undefined", () => {
-      alloyCookie = createCookie(cookieProxy, undefined);
-      expect(() => alloyCookie.remove("foo")).toThrowError();
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I added an optional property of the component function called `cookieNamespace`.  These are used as the first level keys for the cookie's JSON.  I considered just shortening namespace values, but long namespaces are useful especially in the logs.  If `cookieNamespace` is undefined, it uses the `namespace` property.  Some of the components never use cookies so I didn't bother defining a `cookieNamespace` property for them.

## Related Issue

https://jira.corp.adobe.com/browse/CORE-32729

## Motivation and Context

Customers are sensitive to the size of cookies, so we should make them smaller if possible.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
