### PR TITLE
TNT-33045 - add notification handling for personalization component

### DIFF
--- a/src/components/Personalization/actions/appendHtml.js
+++ b/src/components/Personalization/actions/appendHtml.js
@@ -27,6 +27,6 @@ export default collect => {
     showElements(prehidingSelector);
 
     // make sure we send back the metadata after successful rendering
-    collect({ meta: { personalization: meta } });
+    collect(meta);
   };
 };

--- a/src/components/Personalization/actions/insertAfter.js
+++ b/src/components/Personalization/actions/insertAfter.js
@@ -27,6 +27,6 @@ export default collect => {
     showElements(prehidingSelector);
 
     // make sure we send back the metadata after successful rendering
-    collect({ meta: { personalization: meta } });
+    collect(meta);
   };
 };

--- a/src/components/Personalization/actions/insertBefore.js
+++ b/src/components/Personalization/actions/insertBefore.js
@@ -27,6 +27,6 @@ export default collect => {
     showElements(prehidingSelector);
 
     // make sure we send back the metadata after successful rendering
-    collect({ meta: { personalization: meta } });
+    collect(meta);
   };
 };

--- a/src/components/Personalization/actions/move.js
+++ b/src/components/Personalization/actions/move.js
@@ -28,6 +28,6 @@ export default collect => {
     showElements(prehidingSelector);
 
     // make sure we send back the metadata after successful rendering
-    collect({ meta: { personalization: meta } });
+    collect(meta);
   };
 };

--- a/src/components/Personalization/actions/prependHtml.js
+++ b/src/components/Personalization/actions/prependHtml.js
@@ -27,6 +27,6 @@ export default collect => {
     showElements(prehidingSelector);
 
     // make sure we send back the metadata after successful rendering
-    collect({ meta: { personalization: meta } });
+    collect(meta);
   };
 };

--- a/src/components/Personalization/actions/rearrange.js
+++ b/src/components/Personalization/actions/rearrange.js
@@ -49,6 +49,6 @@ export default collect => {
     showElements(prehidingSelector);
 
     // make sure we send back the metadata after successful rendering
-    collect({ meta: { personalization: meta } });
+    collect(meta);
   };
 };

--- a/src/components/Personalization/actions/remove.js
+++ b/src/components/Personalization/actions/remove.js
@@ -26,6 +26,6 @@ export default collect => {
     showElements(prehidingSelector);
 
     // make sure we send back the metadata after successful rendering
-    collect({ meta: { personalization: meta } });
+    collect(meta);
   };
 };

--- a/src/components/Personalization/actions/replaceHtml.js
+++ b/src/components/Personalization/actions/replaceHtml.js
@@ -28,6 +28,6 @@ export default collect => {
     showElements(prehidingSelector);
 
     // make sure we send back the metadata after successful rendering
-    collect({ meta: { personalization: meta } });
+    collect(meta);
   };
 };

--- a/src/components/Personalization/actions/resize.js
+++ b/src/components/Personalization/actions/resize.js
@@ -28,6 +28,6 @@ export default collect => {
     showElements(prehidingSelector);
 
     // make sure we send back the metadata after successful rendering
-    collect({ meta: { personalization: meta } });
+    collect(meta);
   };
 };

--- a/src/components/Personalization/actions/setAttribute.js
+++ b/src/components/Personalization/actions/setAttribute.js
@@ -28,6 +28,6 @@ export default collect => {
     showElements(prehidingSelector);
 
     // make sure we send back the metadata after successful rendering
-    collect({ meta: { personalization: meta } });
+    collect(meta);
   };
 };

--- a/src/components/Personalization/actions/setHtml.js
+++ b/src/components/Personalization/actions/setHtml.js
@@ -26,6 +26,6 @@ export default collect => {
     showElements(prehidingSelector);
 
     // make sure we send back the metadata after successful rendering
-    collect({ meta: { personalization: meta } });
+    collect(meta);
   };
 };

--- a/src/components/Personalization/actions/setImageSource.js
+++ b/src/components/Personalization/actions/setImageSource.js
@@ -40,6 +40,6 @@ export default collect => {
     showElements(prehidingSelector);
 
     // make sure we send back the metadata after successful rendering
-    collect({ meta: { personalization: meta } });
+    collect(meta);
   };
 };

--- a/src/components/Personalization/actions/setStyle.js
+++ b/src/components/Personalization/actions/setStyle.js
@@ -29,6 +29,6 @@ export default collect => {
     showElements(prehidingSelector);
 
     // make sure we send back the metadata after successful rendering
-    collect({ meta: { personalization: meta } });
+    collect(meta);
   };
 };

--- a/src/components/Personalization/actions/setText.js
+++ b/src/components/Personalization/actions/setText.js
@@ -25,6 +25,6 @@ export default collect => {
     showElements(prehidingSelector);
 
     // make sure we send back the metadata after successful rendering
-    collect({ meta: { personalization: meta } });
+    collect(meta);
   };
 };

--- a/src/components/Personalization/events/elementExists.js
+++ b/src/components/Personalization/events/elementExists.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { awaitSelector } from "../../../utils/dom";
+import { awaitSelector, selectNodesWithEq } from "../../../utils/dom";
 import { hideElements, showElements } from "../flicker";
 
 export default (settings, trigger) => {
@@ -18,7 +18,7 @@ export default (settings, trigger) => {
 
   hideElements(prehidingSelector);
 
-  awaitSelector(selector)
+  awaitSelector(selector, selectNodesWithEq)
     .then(elements => {
       trigger({ elements, prehidingSelector });
     })

--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -37,6 +37,7 @@ const getOrCreateSessionId = cookie => {
 
   return cookieValue.value;
 };
+
 const hideElementsForPage = fragment => {
   const { rules = [] } = fragment;
 
@@ -63,6 +64,17 @@ const executeFragment = (fragment, modules, logger) => {
   }
 };
 
+const createCollect = collect => {
+  return payload => {
+    const id = uuid();
+    const timestamp = Date.now();
+    const notification = Object.assign({}, payload, { id, timestamp });
+    const personalization = { notification };
+
+    collect({ meta: { personalization } });
+  };
+};
+
 const createPersonalization = ({ config, logger, cookie }) => {
   const { prehidingId, prehidingStyle } = config;
   let ruleComponentModules;
@@ -73,9 +85,8 @@ const createPersonalization = ({ config, logger, cookie }) => {
       onComponentsRegistered(tools) {
         const { componentRegistry } = tools;
         ({ optIn } = tools);
-        ruleComponentModules = initRuleComponentModules(
-          componentRegistry.getCommand(EVENT_COMMAND)
-        );
+        const collect = componentRegistry.getCommand(EVENT_COMMAND);
+        ruleComponentModules = initRuleComponentModules(createCollect(collect));
       },
       onBeforeDataCollection(payload) {
         return optIn.whenOptedIn().then(() => {

--- a/test/unit/specs/components/Personalization/actions/appendHtml.spec.js
+++ b/test/unit/specs/components/Personalization/actions/appendHtml.spec.js
@@ -28,9 +28,10 @@ describe("Personalization::actions::appendHtml", () => {
 
     appendNode(document.body, element);
 
+    const meta = { a: 1 };
     const settings = {
       content: `<li>2</li><li>3</li>`,
-      meta: { a: 1 }
+      meta
     };
     const event = { elements, prehidingSelector: "#appendHtml" };
 
@@ -42,8 +43,6 @@ describe("Personalization::actions::appendHtml", () => {
     expect(result[0].innerHTML).toEqual("1");
     expect(result[1].innerHTML).toEqual("2");
     expect(result[2].innerHTML).toEqual("3");
-    expect(collect).toHaveBeenCalledWith({
-      meta: { personalization: { a: 1 } }
-    });
+    expect(collect).toHaveBeenCalledWith(meta);
   });
 });

--- a/test/unit/specs/components/Personalization/actions/insertAfter.spec.js
+++ b/test/unit/specs/components/Personalization/actions/insertAfter.spec.js
@@ -28,9 +28,10 @@ describe("Personalization::actions::insertAfter", () => {
 
     appendNode(document.body, element);
 
+    const meta = { a: 1 };
     const settings = {
       content: `<div id="b" class="ia">BBB</div>`,
-      meta: { a: 1 }
+      meta
     };
     const event = { elements, prehidingSelector: "#a" };
 
@@ -40,8 +41,6 @@ describe("Personalization::actions::insertAfter", () => {
 
     expect(result[0].innerHTML).toEqual("AAA");
     expect(result[1].innerHTML).toEqual("BBB");
-    expect(collect).toHaveBeenCalledWith({
-      meta: { personalization: { a: 1 } }
-    });
+    expect(collect).toHaveBeenCalledWith(meta);
   });
 });

--- a/test/unit/specs/components/Personalization/actions/insertBefore.spec.js
+++ b/test/unit/specs/components/Personalization/actions/insertBefore.spec.js
@@ -28,9 +28,10 @@ describe("Personalization::actions::insertBefore", () => {
 
     appendNode(document.body, element);
 
+    const meta = { a: 1 };
     const settings = {
       content: `<div id="b" class="ib">BBB</div>`,
-      meta: { a: 1 }
+      meta
     };
     const event = { elements, prehidingSelector: "#a" };
 
@@ -40,8 +41,6 @@ describe("Personalization::actions::insertBefore", () => {
 
     expect(result[0].innerHTML).toEqual("BBB");
     expect(result[1].innerHTML).toEqual("AAA");
-    expect(collect).toHaveBeenCalledWith({
-      meta: { personalization: { a: 1 } }
-    });
+    expect(collect).toHaveBeenCalledWith(meta);
   });
 });

--- a/test/unit/specs/components/Personalization/actions/move.spec.js
+++ b/test/unit/specs/components/Personalization/actions/move.spec.js
@@ -19,9 +19,10 @@ describe("Personalization::actions::move", () => {
 
     appendNode(document.body, element);
 
+    const meta = { a: 1 };
     const settings = {
       content: { left: "100px", top: "100px" },
-      meta: { a: 1 }
+      meta
     };
     const event = { elements, prehidingSelector: "#move" };
 
@@ -29,8 +30,6 @@ describe("Personalization::actions::move", () => {
 
     expect(elements[0].style.left).toEqual("100px");
     expect(elements[0].style.top).toEqual("100px");
-    expect(collect).toHaveBeenCalledWith({
-      meta: { personalization: { a: 1 } }
-    });
+    expect(collect).toHaveBeenCalledWith(meta);
   });
 });

--- a/test/unit/specs/components/Personalization/actions/prependHtml.spec.js
+++ b/test/unit/specs/components/Personalization/actions/prependHtml.spec.js
@@ -28,9 +28,10 @@ describe("Personalization::actions::prependHtml", () => {
 
     appendNode(document.body, element);
 
+    const meta = { a: 1 };
     const settings = {
       content: `<li>1</li><li>2</li>`,
-      meta: { a: 1 }
+      meta
     };
     const event = { elements, prehidingSelector: "#prependHtml" };
 
@@ -42,8 +43,6 @@ describe("Personalization::actions::prependHtml", () => {
     expect(result[0].innerHTML).toEqual("1");
     expect(result[1].innerHTML).toEqual("2");
     expect(result[2].innerHTML).toEqual("3");
-    expect(collect).toHaveBeenCalledWith({
-      meta: { personalization: { a: 1 } }
-    });
+    expect(collect).toHaveBeenCalledWith(meta);
   });
 });

--- a/test/unit/specs/components/Personalization/actions/rearrange.spec.js
+++ b/test/unit/specs/components/Personalization/actions/rearrange.spec.js
@@ -32,7 +32,8 @@ describe("Presonalization::actions::rearrange", () => {
 
     appendNode(document.body, element);
 
-    const settings = { content: { from: 0, to: 2 }, meta: { a: 1 } };
+    const meta = { a: 1 };
+    const settings = { content: { from: 0, to: 2 }, meta };
     const event = { elements, prehidingSelector: "#rearrange" };
 
     rearrange(settings, event);
@@ -43,9 +44,7 @@ describe("Presonalization::actions::rearrange", () => {
     expect(result[1].textContent).toEqual("3");
     expect(result[2].textContent).toEqual("1");
 
-    expect(collect).toHaveBeenCalledWith({
-      meta: { personalization: { a: 1 } }
-    });
+    expect(collect).toHaveBeenCalledWith(meta);
   });
 
   it("should rearrange elements when from > to", () => {
@@ -65,7 +64,8 @@ describe("Presonalization::actions::rearrange", () => {
 
     appendNode(document.body, element);
 
-    const settings = { content: { from: 2, to: 0 }, meta: { a: 1 } };
+    const meta = { a: 1 };
+    const settings = { content: { from: 2, to: 0 }, meta };
     const event = { elements, prehidingSelector: "#rearrange" };
 
     rearrange(settings, event);
@@ -76,8 +76,6 @@ describe("Presonalization::actions::rearrange", () => {
     expect(result[1].textContent).toEqual("1");
     expect(result[2].textContent).toEqual("2");
 
-    expect(collect).toHaveBeenCalledWith({
-      meta: { personalization: { a: 1 } }
-    });
+    expect(collect).toHaveBeenCalledWith(meta);
   });
 });

--- a/test/unit/specs/components/Personalization/actions/remove.spec.js
+++ b/test/unit/specs/components/Personalization/actions/remove.spec.js
@@ -24,7 +24,8 @@ describe("Presonalization::actions::remove", () => {
 
     appendNode(document.body, element);
 
-    const settings = { meta: { a: 1 } };
+    const meta = { a: 1 };
+    const settings = { meta };
     const event = { elements, prehidingSelector: "#remove" };
 
     remove(settings, event);
@@ -32,8 +33,6 @@ describe("Presonalization::actions::remove", () => {
     const result = selectNodes("#child");
 
     expect(result.length).toEqual(0);
-    expect(collect).toHaveBeenCalledWith({
-      meta: { personalization: { a: 1 } }
-    });
+    expect(collect).toHaveBeenCalledWith(meta);
   });
 });

--- a/test/unit/specs/components/Personalization/actions/replaceHtml.spec.js
+++ b/test/unit/specs/components/Personalization/actions/replaceHtml.spec.js
@@ -28,9 +28,10 @@ describe("Personalization::actions::replaceHtml", () => {
 
     appendNode(document.body, element);
 
+    const meta = { a: 1 };
     const settings = {
       content: `<div id="b" class="rh">BBB</div>`,
-      meta: { a: 1 }
+      meta
     };
     const event = { elements, prehidingSelector: "#a" };
 
@@ -40,8 +41,6 @@ describe("Personalization::actions::replaceHtml", () => {
 
     expect(result.length).toEqual(1);
     expect(result[0].innerHTML).toEqual("BBB");
-    expect(collect).toHaveBeenCalledWith({
-      meta: { personalization: { a: 1 } }
-    });
+    expect(collect).toHaveBeenCalledWith(meta);
   });
 });

--- a/test/unit/specs/components/Personalization/actions/resize.spec.js
+++ b/test/unit/specs/components/Personalization/actions/resize.spec.js
@@ -19,9 +19,10 @@ describe("Personalization::actions::resize", () => {
 
     appendNode(document.body, element);
 
+    const meta = { a: 1 };
     const settings = {
       content: { width: "100px", height: "100px" },
-      meta: { a: 1 }
+      meta
     };
     const event = { elements, prehidingSelector: "#resize" };
 
@@ -29,8 +30,6 @@ describe("Personalization::actions::resize", () => {
 
     expect(elements[0].style.width).toEqual("100px");
     expect(elements[0].style.height).toEqual("100px");
-    expect(collect).toHaveBeenCalledWith({
-      meta: { personalization: { a: 1 } }
-    });
+    expect(collect).toHaveBeenCalledWith(meta);
   });
 });

--- a/test/unit/specs/components/Personalization/actions/setAttribute.spec.js
+++ b/test/unit/specs/components/Personalization/actions/setAttribute.spec.js
@@ -19,14 +19,13 @@ describe("Personalization::actions::setAttribute", () => {
 
     appendNode(document.body, element);
 
-    const settings = { content: { "data-test": "bar" }, meta: { a: 1 } };
+    const meta = { a: 1 };
+    const settings = { content: { "data-test": "bar" }, meta };
     const event = { elements, prehidingSelector: "#setAttribute" };
 
     setAttribute(settings, event);
 
     expect(elements[0].getAttribute("data-test")).toEqual("bar");
-    expect(collect).toHaveBeenCalledWith({
-      meta: { personalization: { a: 1 } }
-    });
+    expect(collect).toHaveBeenCalledWith(meta);
   });
 });

--- a/test/unit/specs/components/Personalization/actions/setHtml.spec.js
+++ b/test/unit/specs/components/Personalization/actions/setHtml.spec.js
@@ -20,14 +20,13 @@ describe("Personalization::actions::setHtml", () => {
 
     appendNode(document.body, element);
 
-    const settings = { content: "bar", meta: { a: 1 } };
+    const meta = { a: 1 };
+    const settings = { content: "bar", meta };
     const event = { elements, prehidingSelector: "#setHtml" };
 
     setHtml(settings, event);
 
     expect(elements[0].innerHTML).toEqual("bar");
-    expect(collect).toHaveBeenCalledWith({
-      meta: { personalization: { a: 1 } }
-    });
+    expect(collect).toHaveBeenCalledWith(meta);
   });
 });

--- a/test/unit/specs/components/Personalization/actions/setImageSource.spec.js
+++ b/test/unit/specs/components/Personalization/actions/setImageSource.spec.js
@@ -20,14 +20,13 @@ describe("Personalization::actions::setImageSource", () => {
 
     appendNode(document.body, element);
 
-    const settings = { content: "http://foo.com/b.png", meta: { a: 1 } };
+    const meta = { a: 1 };
+    const settings = { content: "http://foo.com/b.png", meta };
     const event = { elements, prehidingSelector: "#setImageSource" };
 
     setImageSource(settings, event);
 
     expect(elements[0].getAttribute("src")).toEqual("http://foo.com/b.png");
-    expect(collect).toHaveBeenCalledWith({
-      meta: { personalization: { a: 1 } }
-    });
+    expect(collect).toHaveBeenCalledWith(meta);
   });
 });

--- a/test/unit/specs/components/Personalization/actions/setStyle.spec.js
+++ b/test/unit/specs/components/Personalization/actions/setStyle.spec.js
@@ -19,17 +19,16 @@ describe("Presonalization::actions::setStyle", () => {
 
     appendNode(document.body, element);
 
+    const meta = { a: 1 };
     const settings = {
       content: { "font-size": "33px", priority: "important" },
-      meta: { a: 1 }
+      meta
     };
     const event = { elements, prehidingSelector: "#setStyle" };
 
     setStyle(settings, event);
 
     expect(elements[0].style.getPropertyValue("font-size")).toEqual("33px");
-    expect(collect).toHaveBeenCalledWith({
-      meta: { personalization: { a: 1 } }
-    });
+    expect(collect).toHaveBeenCalledWith(meta);
   });
 });

--- a/test/unit/specs/components/Personalization/actions/setText.spec.js
+++ b/test/unit/specs/components/Personalization/actions/setText.spec.js
@@ -20,14 +20,13 @@ describe("Personalization::actions::setText", () => {
 
     appendNode(document.body, element);
 
-    const settings = { content: "bar", meta: { a: 1 } };
+    const meta = { a: 1 };
+    const settings = { content: "bar", meta };
     const event = { elements, prehidingSelector: "#setText" };
 
     setText(settings, event);
 
     expect(elements[0].textContent).toEqual("bar");
-    expect(collect).toHaveBeenCalledWith({
-      meta: { personalization: { a: 1 } }
-    });
+    expect(collect).toHaveBeenCalledWith(meta);
   });
 });


### PR DESCRIPTION
Personalization component has to add additional details to collect payload to ensure our backend can properly process it and forward to the right downstream services.

## Description

Personalization component has been enhanced by moving all the data collection logic to component itself and ensuring that actions after successfully rendering the content are just passing the `meta` details without packaging the data in any special way.

## Related Issue

NONE

## Motivation and Context

Make sure that whenever a fragment of an experience is rendered data is collected and backend is notified.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
