### PR TITLE
CORE-32541 Fixed bug where getTopLevelCookieDomain wasn't testing all host segments.

### DIFF
--- a/src/utils/getTopLevelCookieDomain.js
+++ b/src/utils/getTopLevelCookieDomain.js
@@ -30,7 +30,7 @@ export default function getTopLevelCookieDomain(window, cookie) {
   const hostParts = window.location.hostname.toLowerCase().split(".");
   let i = 1;
 
-  while (i < hostParts.length - 1 && !cookie.get(cookieName)) {
+  while (i < hostParts.length && !cookie.get(cookieName)) {
     i += 1;
     topLevelCookieDomain = getLastArrayItems(hostParts, i).join(".");
     cookie.set(cookieName, cookieName, { domain: topLevelCookieDomain });

--- a/test/unit/specs/utils/getTopLevelCookieDomain.spec.js
+++ b/test/unit/specs/utils/getTopLevelCookieDomain.spec.js
@@ -49,4 +49,23 @@ describe("getTld", () => {
     expect(getTopLevelCookieDomain(window, cookie)).toBe("c.co.uk");
     expect(cookie.remove).toHaveBeenCalled();
   });
+
+  it("tries all segments of the hostname if necessary", () => {
+    const window = mockWindowWithHostname("10.30.34.68");
+    let storedValue;
+    const cookie = {
+      get() {
+        return storedValue;
+      },
+      set(name, value, options) {
+        if (options.domain === "10.30.34.68") {
+          storedValue = value;
+        }
+      },
+      remove: jasmine.createSpy()
+    };
+
+    expect(getTopLevelCookieDomain(window, cookie)).toBe("10.30.34.68");
+    expect(cookie.remove).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The logic wasn't testing all segments of the host.

<!--- Describe your changes in detail -->

## Related Issue
CORE-32541
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
As it turns out, customers like when their cookies are properly set.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
