### PR TITLE
TNT-33101 - ensure sessionId is passed in event for data fetching and data collection

### DIFF
--- a/src/utils/deepAssign.js
+++ b/src/utils/deepAssign.js
@@ -10,13 +10,13 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import isNil from "./isNil";
 import isObject from "./isObject";
 
 const deepAssignObject = (target, source) => {
   Object.keys(source).forEach(key => {
     if (isObject(target[key]) && isObject(source[key])) {
       deepAssignObject(target[key], source[key]);
-
       return;
     }
 
@@ -26,29 +26,20 @@ const deepAssignObject = (target, source) => {
 
 /**
  * Recursively copy the values of all enumerable own properties from a source item to a target item if the both items are objects
- * @private
  * @param {Object} target - a target object
- * @param {Object} source - a source object
+ * @param {...Object} source - an array of source objects
  * @example
  * deepAssign({ a: 'a', b: 'b' }, { b: 'B', c: 'c' });
  * // { a: 'a', b: 'B', c: 'c' }
  */
 export default (target, ...sources) => {
-  if (!isObject(target)) {
-    return {};
+  if (isNil(target)) {
+    throw new TypeError('deepAssign "target" cannot be null or undefined');
   }
 
-  const { length } = sources;
+  const result = Object(target);
 
-  for (let i = 0; i < length; i += 1) {
-    const source = sources[i];
+  sources.forEach(source => deepAssignObject(result, Object(source)));
 
-    if (!isObject(source)) {
-      break;
-    }
-
-    deepAssignObject(target, source);
-  }
-
-  return target;
+  return result;
 };

--- a/src/utils/deepAssign.js
+++ b/src/utils/deepAssign.js
@@ -1,0 +1,54 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import isObject from "./isObject";
+
+const deepAssignObject = (target, source) => {
+  Object.keys(source).forEach(key => {
+    if (isObject(target[key]) && isObject(source[key])) {
+      deepAssignObject(target[key], source[key]);
+
+      return;
+    }
+
+    target[key] = source[key];
+  });
+};
+
+/**
+ * Recursively copy the values of all enumerable own properties from a source item to a target item if the both items are objects
+ * @private
+ * @param {Object} target - a target object
+ * @param {Object} source - a source object
+ * @example
+ * deepAssign({ a: 'a', b: 'b' }, { b: 'B', c: 'c' });
+ * // { a: 'a', b: 'B', c: 'c' }
+ */
+export default (target, ...sources) => {
+  if (!isObject(target)) {
+    return {};
+  }
+
+  const { length } = sources;
+
+  for (let i = 0; i < length; i += 1) {
+    const source = sources[i];
+
+    if (!isObject(source)) {
+      break;
+    }
+
+    deepAssignObject(target, source);
+  }
+
+  return target;
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -20,6 +20,7 @@ export { default as cookie } from "./cookie";
 export { default as createMerger } from "./createMerger";
 export { default as crc32 } from "./crc32";
 export { default as defer } from "./defer";
+export { default as deepAssign } from "./deepAssign";
 export { default as executeWithRetry } from "./executeWithRetry";
 export { default as find } from "./find";
 export { default as fireDestinations } from "./fireDestinations";

--- a/test/unit/specs/utils/deepAssign.spec.js
+++ b/test/unit/specs/utils/deepAssign.spec.js
@@ -14,13 +14,59 @@ import deepAssign from "../../../../src/utils/deepAssign";
 import assign from "../../../../src/utils/assign";
 
 describe("deepAssign", () => {
-  it("should copy values like assign", () => {
-    expect(deepAssign({}, { a: 1 }, { b: 2 })).toEqual(
-      assign({}, { a: 1 }, { b: 2 })
-    );
+  it("should throw when target is null or unbdefined", () => {
+    expect(() => {
+      deepAssign(null, { a: 1 });
+    }).toThrow();
+
+    expect(() => {
+      deepAssign(undefined, { a: 1 });
+    }).toThrow();
   });
 
-  it("should copy values recursively assign", () => {
+  it("should assing when target is string", () => {
+    const result1 = deepAssign("foo", { a: 1 });
+    const result2 = assign("foo", { a: 1 });
+
+    expect(result1).toEqual(result2);
+  });
+
+  it("should assing when target is number", () => {
+    const result1 = deepAssign(1, { a: 1 });
+    const result2 = assign(1, { a: 1 });
+
+    expect(result1).toEqual(result2);
+  });
+
+  it("should assing when target is array", () => {
+    const result1 = deepAssign([1], { a: 1 });
+    const result2 = assign([1], { a: 1 });
+
+    expect(result1).toEqual(result2);
+  });
+
+  it("should assing when target is object and source is string", () => {
+    const result1 = deepAssign({}, "foo");
+    const result2 = assign({}, "foo");
+
+    expect(result1).toEqual(result2);
+  });
+
+  it("should assing when target is object and source is number", () => {
+    const result1 = deepAssign({}, 1);
+    const result2 = assign({}, 1);
+
+    expect(result1).toEqual(result2);
+  });
+
+  it("should assing when target is object and source is array", () => {
+    const result1 = deepAssign({}, [1]);
+    const result2 = assign({}, [1]);
+
+    expect(result1).toEqual(result2);
+  });
+
+  it("should assign values recursively", () => {
     const result = deepAssign(
       {},
       { a: { c: 1 } },

--- a/test/unit/specs/utils/deepAssign.spec.js
+++ b/test/unit/specs/utils/deepAssign.spec.js
@@ -10,17 +10,24 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import deepAssign from "./deepAssign";
+import deepAssign from "../../../../src/utils/deepAssign";
+import assign from "../../../../src/utils/assign";
 
-/**
- * Creates a function that, when passed an object of updates, will merge
- * the updates onto the current value of a payload property.
- * @param content
- * @param key
- * @returns {Function}
- */
-export default (content, key) => updates => {
-  // eslint-disable-next-line no-param-reassign
-  content[key] = content[key] || {};
-  deepAssign(content[key], updates);
-};
+describe("deepAssign", () => {
+  it("should copy values like assign", () => {
+    expect(deepAssign({}, { a: 1 }, { b: 2 })).toEqual(
+      assign({}, { a: 1 }, { b: 2 })
+    );
+  });
+
+  it("should copy values recursively assign", () => {
+    const result = deepAssign(
+      {},
+      { a: { c: 1 } },
+      { b: 2 },
+      { a: { c: 2, d: 3 } }
+    );
+
+    expect(result).toEqual({ a: { c: 2, d: 3 }, b: 2 });
+  });
+});

--- a/test/unit/specs/utils/deepAssign.spec.js
+++ b/test/unit/specs/utils/deepAssign.spec.js
@@ -14,7 +14,7 @@ import deepAssign from "../../../../src/utils/deepAssign";
 import assign from "../../../../src/utils/assign";
 
 describe("deepAssign", () => {
-  it("should throw when target is null or unbdefined", () => {
+  it("should throw when target is null or undefined", () => {
     expect(() => {
       deepAssign(null, { a: 1 });
     }).toThrow();
@@ -24,42 +24,42 @@ describe("deepAssign", () => {
     }).toThrow();
   });
 
-  it("should assing when target is string", () => {
+  it("should assign when target is string", () => {
     const result1 = deepAssign("foo", { a: 1 });
     const result2 = assign("foo", { a: 1 });
 
     expect(result1).toEqual(result2);
   });
 
-  it("should assing when target is number", () => {
+  it("should assign when target is number", () => {
     const result1 = deepAssign(1, { a: 1 });
     const result2 = assign(1, { a: 1 });
 
     expect(result1).toEqual(result2);
   });
 
-  it("should assing when target is array", () => {
+  it("should assign when target is array", () => {
     const result1 = deepAssign([1], { a: 1 });
     const result2 = assign([1], { a: 1 });
 
     expect(result1).toEqual(result2);
   });
 
-  it("should assing when target is object and source is string", () => {
+  it("should assign when target is object and source is string", () => {
     const result1 = deepAssign({}, "foo");
     const result2 = assign({}, "foo");
 
     expect(result1).toEqual(result2);
   });
 
-  it("should assing when target is object and source is number", () => {
+  it("should assign when target is object and source is number", () => {
     const result1 = deepAssign({}, 1);
     const result2 = assign({}, 1);
 
     expect(result1).toEqual(result2);
   });
 
-  it("should assing when target is object and source is array", () => {
+  it("should assign when target is object and source is array", () => {
     const result1 = deepAssign({}, [1]);
     const result2 = assign({}, [1]);
 


### PR DESCRIPTION
Personalization sessionId should be passed in event -> meta, to ensure data collection request is properly processed by our backend.

## Description

Session ID used to be passed at the request level and it was working OK for data fetching, but it was failing for data collection. To ensure that both data fetching and data collection requests have the session ID details, the session ID has been moved to `onBeforeEvent` and we make sure that both data fetching and data collection request have a session ID.

As part of this PR I have also added an utility named `deepAssign`. This utility was required since our `event.mergeMeta()` was misbehaving in situations like when we try to merge:
```json
{
  "meta": {
     "personalization": {
         "notification": {"a": 1, "b": 2}
     }
  }
}
```
And
```json
{
  "meta": {
     "personalization": {
         "sessionId": "......."
     }
  }
}
```
 
## Related Issue

NONE

## Motivation and Context

Ensure that data collection requests are not failing on our backend

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
