### PR TITLE
Id sync query fix & refactor processIdSyncs

### DIFF
--- a/src/components/Identity/createIdSyncs.js
+++ b/src/components/Identity/createIdSyncs.js
@@ -36,7 +36,7 @@ const setControlObject = (controlObject, cookieJar) => {
   cookieJar.set(ID_SYNC_CONTROL, arr.join("_"));
 };
 
-export default ({ destinations, config, logger, cookieJar }) => {
+const createProcessor = (config, logger, cookieJar) => destinations => {
   if (!config.idSyncsEnabled) {
     return;
   }
@@ -89,4 +89,21 @@ export default ({ destinations, config, logger, cookieJar }) => {
       );
     });
   }
+};
+
+const createExpiryChecker = cookieJar => () => {
+  const nowInHours = Math.round(
+    convertTimes(MILLISECOND, HOUR, new Date().getTime())
+  );
+  const timestamp = parseInt(cookieJar.get(ID_SYNC_TIMESTAMP) || 0, 36);
+
+  return nowInHours > timestamp;
+};
+
+export default (config, logger, cookieJar) => {
+
+  return {
+    process: createProcessor(config, logger, cookieJar),
+    hasExpired: createExpiryChecker(cookieJar)
+  };
 };

--- a/src/components/Identity/index.js
+++ b/src/components/Identity/index.js
@@ -39,6 +39,7 @@ const createIdentity = ({ config, logger, cookieJar }) => {
   let network;
   let lifecycle;
   const customerIds = {};
+  let alreadyQueriedForIdSyncs = false;
 
   const makeServerCall = payload => {
     return lifecycle.onBeforeDataCollection(payload).then(() => {
@@ -88,7 +89,8 @@ const createIdentity = ({ config, logger, cookieJar }) => {
           );
           const timestamp = parseInt(cookieJar.get(ID_SYNC_TIMESTAMP) || 0, 36);
 
-          if (config.idSyncsEnabled && nowInHours > timestamp) {
+          if (!alreadyQueriedForIdSyncs && config.idSyncsEnabled && nowInHours > timestamp) {
+            alreadyQueriedForIdSyncs = true;
             event.mergeQuery({
               identity: {
                 exchange: true

--- a/test/unit/specs/components/Identity/createIdSyncs.spec.js
+++ b/test/unit/specs/components/Identity/createIdSyncs.spec.js
@@ -1,4 +1,4 @@
-import processIdSyncs from "../../../../../src/components/Identity/processIdSyncs";
+import createIdSyncs from "../../../../../src/components/Identity/createIdSyncs";
 import createCookieProxy from "../../../../../src/core/createCookieProxy";
 import createComponentNamespacedCookieJar from "../../../../../src/core/createComponentNamespacedCookieJar";
 
@@ -9,7 +9,7 @@ const cookieJar = createComponentNamespacedCookieJar(
 );
 const ID_SYNC_CONTROL = "idSyncControl";
 
-describe("Identity::processIdSyncs", () => {
+describe("Identity::createIdSyncs", () => {
   const config = {
     idSyncsEnabled: true
   };
@@ -33,7 +33,7 @@ describe("Identity::processIdSyncs", () => {
   };
 
   it("tracks id syncs", done => {
-    const idSyncs = [
+    const idsToSync = [
       {
         type: "url",
         id: 411,
@@ -55,7 +55,8 @@ describe("Identity::processIdSyncs", () => {
     let obj = getControlObject();
 
     expect(obj[123]).toBeDefined();
-    processIdSyncs({ destinations: idSyncs, config, logger, cookieJar });
+    const idSyncs = createIdSyncs(config, logger, cookieJar);
+    idSyncs.process(idsToSync);
 
     const checkCookie = () => {
       obj = getControlObject();


### PR DESCRIPTION
## Description

Stop querying for ID Syncs on every event, and multiple times per lifecycle hook.

Refactor processIdSyncs to make it an object:

Add a process and hasExpired APIs; this way we move all the logic inside that object instead of make Identity be aware of those details. Tell don't ask! (Great catch @Aaronius)

## Related Issue

https://jira.corp.adobe.com/browse/CORE-33129

## Motivation and Context

Querying for ID Syncs multiple times was causing lots of `interact` requests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] All tests pass and I've made any necessary test changes.
- [ x ] I have run the Sandbox successfully.
