### PR TITLE
Flatten the response fragments.

### DIFF
--- a/src/components/Audiences/index.js
+++ b/src/components/Audiences/index.js
@@ -11,7 +11,6 @@ governing permissions and limitations under the License.
 */
 
 import processDestinations from "./processDestinations";
-import { flatMap } from "../../utils";
 
 const createAudiences = ({ config, logger }) => {
   return {
@@ -22,10 +21,7 @@ const createAudiences = ({ config, logger }) => {
         }
       },
       onResponse(response) {
-        const destinations = flatMap(
-          response.getPayloadsByType("activation:push"),
-          payloads => payloads
-        );
+        const destinations = response.getPayloadsByType("activation:push");
 
         processDestinations({
           destinations,

--- a/src/components/Identity/index.js
+++ b/src/components/Identity/index.js
@@ -134,7 +134,10 @@ const createIdentity = ({ config, logger, cookieJar }) => {
       // Waiting for opt-in because we'll be writing the ECID to a cookie
       onResponse(response) {
         return optIn.whenOptedIn().then(() => {
-          const ecidPayloads = response.getPayloadsByType("identity:persist");
+          const ecidPayloads = flatMap(
+            response.getPayloadsByType("identity:persist"),
+            fragment => fragment
+          );
 
           if (ecidPayloads.length > 0) {
             cookieJar.set(EXPERIENCE_CLOUD_ID, ecidPayloads[0].id);

--- a/src/components/Identity/index.js
+++ b/src/components/Identity/index.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { defer, assign, flatMap, crc32 } from "../../utils";
+import { defer, assign, crc32 } from "../../utils";
 import { nonNegativeInteger } from "../../utils/configValidators";
 import createIdSyncs from "./createIdSyncs";
 import createEvent from "../DataCollector/createEvent";
@@ -134,10 +134,7 @@ const createIdentity = ({ config, logger, cookieJar }) => {
       // Waiting for opt-in because we'll be writing the ECID to a cookie
       onResponse(response) {
         return optIn.whenOptedIn().then(() => {
-          const ecidPayloads = flatMap(
-            response.getPayloadsByType("identity:persist"),
-            fragment => fragment
-          );
+          const ecidPayloads = response.getPayloadsByType("identity:persist");
 
           if (ecidPayloads.length > 0) {
             cookieJar.set(EXPERIENCE_CLOUD_ID, ecidPayloads[0].id);
@@ -147,12 +144,7 @@ const createIdentity = ({ config, logger, cookieJar }) => {
             }
           }
 
-          return idSyncs.process(
-            flatMap(
-              response.getPayloadsByType("identity:exchange"),
-              fragment => fragment
-            )
-          );
+          idSyncs.process(response.getPayloadsByType("identity:exchange"));
         });
       }
     },

--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { isNonEmptyArray, uuid } from "../../utils";
+import { isNonEmptyArray, uuid, flatMap } from "../../utils";
 import { initRuleComponentModules, executeRules } from "./turbine";
 import { hideContainers, showContainers, hideElements } from "./flicker";
 import { eitherNilOrNonEmpty, boolean } from "../../utils/configValidators";
@@ -129,7 +129,10 @@ const createPersonalization = ({ config, logger, cookieJar }) => {
           return;
         }
 
-        const fragments = response.getPayloadsByType(PAGE_HANDLE);
+        const fragments = flatMap(
+          response.getPayloadsByType(PAGE_HANDLE),
+          fragment => fragment
+        );
 
         // On response we first hide all the elements for
         // personalization:page handle

--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { isNonEmptyArray, uuid, flatMap } from "../../utils";
+import { isNonEmptyArray, uuid } from "../../utils";
 import { initRuleComponentModules, executeRules } from "./turbine";
 import { hideContainers, showContainers, hideElements } from "./flicker";
 import { eitherNilOrNonEmpty, boolean } from "../../utils/configValidators";
@@ -129,10 +129,7 @@ const createPersonalization = ({ config, logger, cookieJar }) => {
           return;
         }
 
-        const fragments = flatMap(
-          response.getPayloadsByType(PAGE_HANDLE),
-          fragment => fragment
-        );
+        const fragments = response.getPayloadsByType(PAGE_HANDLE);
 
         // On response we first hide all the elements for
         // personalization:page handle

--- a/src/core/network/createResponse.js
+++ b/src/core/network/createResponse.js
@@ -10,6 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import { flatMap } from "../../utils";
+
 /**
  * Represents a gateway response with the addition to helper methods.
  *
@@ -33,9 +35,10 @@ export default (content = { requestId: "", handle: [] }) => {
   return {
     getPayloadsByType(type) {
       const { handle = [] } = content;
-      return handle
-        .filter(fragment => fragment.type === type)
-        .map(fragment => fragment.payload);
+      return flatMap(
+        handle.filter(fragment => fragment.type === type),
+        fragment => fragment.payload
+      );
     },
     toJSON() {
       return content;


### PR DESCRIPTION
The `getPayloadsByType` returns an array of payloads, which in term are arrays.

We needed to flatten them in the Components; which brings up the question: should we flatten them in the Response object instead?

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X ] All tests pass and I've made any necessary test changes.
- [ X ] I have run the Sandbox successfully.
