### PR TITLE
allowing to pass declared ids from config

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -46,14 +46,7 @@
         // By checking this params we know we are in authoring mode
         authoringModeEnabled: document.location.href.indexOf("mboxEdit") !== -1,
         prehidingStyle: "section:nth-of-type(1) { opacity: 0 !important }",
-        idSyncContainerId: 81,
-        "customerIds": {
-          "email" : {
-          "id": "you@gmail.com",
-            "authState": 0,
-            "hash": false 
-          }
-         }
+        idSyncContainerId: 81, 
       });
 
       alloy("event", {
@@ -72,29 +65,21 @@
           "id": "me@gmail.com",
           "authState": 0,
           "hash": true //TODO: document customer ID hashing syntax
-        },
-        "crm" : {
+        },"crm" : {
           "id": "1234",
           "authState": 0
         }
       }).then(function() {
         console.log("Sandbox: Set customer IDs event has completed.");
       });
-
+      
       // For Testing multiple instances
       organizationTwo("configure", {
         // edgeDomain: "edgegateway.azurewebsites.net",
         propertyId: 8888888,
         imsOrgId: "53A16ACB5CC1D3760A495C99@AdobeOrg",
         logEnabled: true,
-  clickCollectionEnabled: false,
-  "customerIds": {
-          "email" : {
-          "id": "youtoo@gmail.com",
-            "authState": 0,
-            "hash": false 
-          }
-         }
+        clickCollectionEnabled: false, 
       });
     </script>
   </head>

--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -46,7 +46,14 @@
         // By checking this params we know we are in authoring mode
         authoringModeEnabled: document.location.href.indexOf("mboxEdit") !== -1,
         prehidingStyle: "section:nth-of-type(1) { opacity: 0 !important }",
-        idSyncContainerId: 81
+        idSyncContainerId: 81,
+        "customerIds": {
+          "email" : {
+          "id": "you@gmail.com",
+            "authState": 0,
+            "hash": false 
+          }
+         }
       });
 
       alloy("event", {
@@ -61,7 +68,7 @@
       });
 
       alloy("setCustomerIds", {
-        "emailHash" : {
+        "Email_LC_SHA256" : {
           "id": "me@gmail.com",
           "authState": 0,
           "hash": true //TODO: document customer ID hashing syntax
@@ -80,7 +87,14 @@
         propertyId: 8888888,
         imsOrgId: "53A16ACB5CC1D3760A495C99@AdobeOrg",
         logEnabled: true,
-	clickCollectionEnabled: false
+  clickCollectionEnabled: false,
+  "customerIds": {
+          "email" : {
+          "id": "youtoo@gmail.com",
+            "authState": 0,
+            "hash": false 
+          }
+         }
       });
     </script>
   </head>

--- a/src/components/Identity/addCustomerIdsToPayload.js
+++ b/src/components/Identity/addCustomerIdsToPayload.js
@@ -1,0 +1,24 @@
+import { assign } from "../../utils";
+import { validateCustomerIds } from "./util";
+import processCustomerIds from "./processCustomerIds";
+
+export default (ids, cookieJar, payload) => {
+  validateCustomerIds(ids);
+  const customerIds = assign({}, ids);
+  const customerIdsProcess = processCustomerIds(customerIds);
+  const customerIdChanged = customerIdsProcess.detectCustomerIdChange(
+    cookieJar
+  );
+  return customerIdsProcess
+    .getNormalizedAndHashedIds()
+    .then(normalizedAndHashedIds => {
+      const idNames = Object.keys(normalizedAndHashedIds);
+      idNames.forEach(idName => {
+        payload.addIdentity(idName, normalizedAndHashedIds[idName]);
+      });
+      payload.mergeMeta({ identity: { customerIdChanged } });
+      if (customerIdChanged) {
+        customerIdsProcess.updateChecksum(cookieJar);
+      }
+    });
+};

--- a/src/components/Identity/addCustomerIdsToPayload.js
+++ b/src/components/Identity/addCustomerIdsToPayload.js
@@ -1,24 +1,7 @@
-import { assign } from "../../utils";
-import { validateCustomerIds } from "./util";
-import processCustomerIds from "./processCustomerIds";
-
-export default (ids, cookieJar, payload) => {
-  validateCustomerIds(ids);
-  const customerIds = assign({}, ids);
-  const customerIdsProcess = processCustomerIds(customerIds);
-  const customerIdChanged = customerIdsProcess.detectCustomerIdChange(
-    cookieJar
-  );
-  return customerIdsProcess
-    .getNormalizedAndHashedIds()
-    .then(normalizedAndHashedIds => {
-      const idNames = Object.keys(normalizedAndHashedIds);
-      idNames.forEach(idName => {
-        payload.addIdentity(idName, normalizedAndHashedIds[idName]);
-      });
-      payload.mergeMeta({ identity: { customerIdChanged } });
-      if (customerIdChanged) {
-        customerIdsProcess.updateChecksum(cookieJar);
-      }
-    });
+export default (customerIdState, customerIdChanged, payload) => {
+  const idNames = Object.keys(customerIdState);
+  idNames.forEach(idName => {
+    payload.addIdentity(idName, customerIdState[idName]);
+  });
+  payload.mergeMeta({ identity: { customerIdChanged } });
 };

--- a/src/components/Identity/setCustomerIds.js
+++ b/src/components/Identity/setCustomerIds.js
@@ -1,21 +1,41 @@
 import createEvent from "../DataCollector/createEvent";
-import addCustomerIdsToPayload from "./addCustomerIdsToPayload";
+import { validateCustomerIds } from "./util";
+import processCustomerIds from "./processCustomerIds";
+import { assign } from "../../utils";
 
-const makeServerCall = (payload, lifecycle, network) => {
-  return lifecycle.onBeforeDataCollection(payload).then(() => {
+const makeServerCall = (payload, processedIds, lifecycle, network) => {
+  return lifecycle.onBeforeDataCollection(payload, processedIds).then(() => {
     return network.sendRequest(payload, payload.expectsResponse);
   });
 };
 
 export default (ids, cookieJar, lifecycle, network, optIn) => {
+  validateCustomerIds(ids);
   const event = createEvent(); // FIXME: We shouldn't need an event.
   event.mergeData({}); // FIXME: We shouldn't need an event.
   const payload = network.createPayload();
   payload.addEvent(event); // FIXME: We shouldn't need an event.
-  addCustomerIdsToPayload(ids, cookieJar, payload).then(() => {
-    return lifecycle
-      .onBeforeEvent(event, {}, false) // FIXME: We shouldn't need an event.
-      .then(() => optIn.whenOptedIn())
-      .then(() => makeServerCall(payload, lifecycle, network));
-  });
+  const customerIds = assign({}, ids);
+  const customerIdsProcess = processCustomerIds(customerIds);
+  const customerIdChanged = customerIdsProcess.detectCustomerIdChange(
+    cookieJar
+  );
+  if (customerIdChanged) {
+    customerIdsProcess.updateChecksum(cookieJar);
+  }
+  return customerIdsProcess
+    .getNormalizedAndHashedIds()
+    .then(normalizedAndHashedIds => {
+      lifecycle
+        .onBeforeEvent(event, {}, false) // FIXME: We shouldn't need an event.
+        .then(() => optIn.whenOptedIn())
+        .then(() =>
+          makeServerCall(
+            payload,
+            { normalizedAndHashedIds, customerIdChanged },
+            lifecycle,
+            network
+          )
+        );
+    });
 };

--- a/src/components/Identity/util.js
+++ b/src/components/Identity/util.js
@@ -43,4 +43,11 @@ const normalizeCustomerIds = customerIds => {
   }, {});
 };
 
-export { validateCustomerIds, normalizeCustomerIds };
+const updateCustomerIdState = (currentState, newState) => {
+  return {
+    ...currentState,
+    ...newState
+  };
+};
+
+export { validateCustomerIds, normalizeCustomerIds, updateCustomerIdState };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -35,6 +35,7 @@ export { default as getNestedObject } from "./getNestedObject";
 export { default as getTopLevelCookieDomain } from "./getTopLevelCookieDomain";
 export { default as includes } from "./includes";
 export { default as intersection } from "./intersection";
+export { default as isNil } from "./isNil";
 export { default as isBoolean } from "./isBoolean";
 export { default as isFunction } from "./isFunction";
 export { default as isInteger } from "./isInteger";

--- a/test/unit/specs/components/Identity/addCustomerIdsToPayload.spec.js
+++ b/test/unit/specs/components/Identity/addCustomerIdsToPayload.spec.js
@@ -1,56 +1,42 @@
 import addCustomerIdsToPayload from "../../../../../src/components/Identity/addCustomerIdsToPayload";
-import { COOKIE_NAMES } from "../../../../../src/components/Identity/constants";
-
-const { CUSTOMER_ID_HASH } = COOKIE_NAMES;
 
 describe("Identity::addCustomerIdsToPayload", () => {
   it("should call validate customerIds", () => {
     const idsWithHash = {
       Email_LC_SHA256: {
-        id: "me@gmail.com",
-        authState: 0,
-        hash: true // TODO: document customer ID hashing syntax
+        id: "81d1a7135b9722577fb4f094a2004296d6230512d37b68e64b73f050b919f7c4",
+        authState: 0
       },
       crm: {
         id: "1234",
         authState: 0
       }
     };
-
-    const cookieJar = {
-      get: jasmine.createSpy(),
-      set: jasmine.createSpy()
-    };
-
     const payload = {
       addIdentity: jasmine.createSpy(),
       mergeMeta: jasmine.createSpy()
     };
 
-    const test = addCustomerIdsToPayload(idsWithHash, cookieJar, payload);
-    test.then(() => {
-      expect(cookieJar.get).toHaveBeenCalledWith(CUSTOMER_ID_HASH);
-      expect(cookieJar.set).toHaveBeenCalledWith(CUSTOMER_ID_HASH, "807ct1");
-      expect(payload.addIdentity).toHaveBeenCalled();
-      expect(payload.addIdentity.calls.count()).toBe(2);
-      expect(payload.addIdentity).toHaveBeenCalledWith("Email_LC_SHA256", {
-        id: "81d1a7135b9722577fb4f094a2004296d6230512d37b68e64b73f050b919f7c4",
-        authState: 0
-      });
-      expect(payload.addIdentity).toHaveBeenCalledWith("crm", {
-        id: "1234",
-        authState: 0
-      });
-      expect(payload.mergeMeta).toHaveBeenCalled();
-      expect(payload.mergeMeta).toHaveBeenCalledWith({
-        identity: { customerIdChanged: true }
-      });
+    addCustomerIdsToPayload(idsWithHash, true, payload);
+    expect(payload.addIdentity).toHaveBeenCalled();
+    expect(payload.addIdentity.calls.count()).toBe(2);
+    expect(payload.addIdentity).toHaveBeenCalledWith("Email_LC_SHA256", {
+      id: "81d1a7135b9722577fb4f094a2004296d6230512d37b68e64b73f050b919f7c4",
+      authState: 0
+    });
+    expect(payload.addIdentity).toHaveBeenCalledWith("crm", {
+      id: "1234",
+      authState: 0
+    });
+    expect(payload.mergeMeta).toHaveBeenCalled();
+    expect(payload.mergeMeta).toHaveBeenCalledWith({
+      identity: { customerIdChanged: true }
     });
   });
 
   it("should set CUSTOMER_ID_HASH cookie and payload meta when same ids are passed again", () => {
     const idsWithoutHash = {
-      Email_LC_SHA256: {
+      email: {
         id: "me@gmail.com",
         authState: 0
       },
@@ -63,29 +49,21 @@ describe("Identity::addCustomerIdsToPayload", () => {
       addIdentity: jasmine.createSpy(),
       mergeMeta: jasmine.createSpy()
     };
-    const cookieJar = {
-      get: jasmine.createSpy().and.returnValue("807ct1"),
-      set: jasmine.createSpy()
-    };
 
-    const test = addCustomerIdsToPayload(idsWithoutHash, cookieJar, payload);
-    test.then(() => {
-      expect(cookieJar.get).toHaveBeenCalledWith(CUSTOMER_ID_HASH);
-      expect(cookieJar.set).not.toHaveBeenCalled();
-      expect(payload.addIdentity).toHaveBeenCalled();
-      expect(payload.addIdentity.calls.count()).toBe(2);
-      expect(payload.addIdentity).toHaveBeenCalledWith("Email_LC_SHA256", {
-        id: "me@gmail.com",
-        authState: 0
-      });
-      expect(payload.addIdentity).toHaveBeenCalledWith("crm", {
-        id: "1234",
-        authState: 0
-      });
-      expect(payload.mergeMeta).toHaveBeenCalled();
-      expect(payload.mergeMeta).toHaveBeenCalledWith({
-        identity: { customerIdChanged: false }
-      });
+    addCustomerIdsToPayload(idsWithoutHash, false, payload);
+    expect(payload.addIdentity).toHaveBeenCalled();
+    expect(payload.addIdentity.calls.count()).toBe(2);
+    expect(payload.addIdentity).toHaveBeenCalledWith("email", {
+      id: "me@gmail.com",
+      authState: 0
+    });
+    expect(payload.addIdentity).toHaveBeenCalledWith("crm", {
+      id: "1234",
+      authState: 0
+    });
+    expect(payload.mergeMeta).toHaveBeenCalled();
+    expect(payload.mergeMeta).toHaveBeenCalledWith({
+      identity: { customerIdChanged: false }
     });
   });
 });

--- a/test/unit/specs/components/Identity/addCustomerIdsToPayload.spec.js
+++ b/test/unit/specs/components/Identity/addCustomerIdsToPayload.spec.js
@@ -1,0 +1,91 @@
+import addCustomerIdsToPayload from "../../../../../src/components/Identity/addCustomerIdsToPayload";
+import { COOKIE_NAMES } from "../../../../../src/components/Identity/constants";
+
+const { CUSTOMER_ID_HASH } = COOKIE_NAMES;
+
+describe("Identity::addCustomerIdsToPayload", () => {
+  it("should call validate customerIds", () => {
+    const idsWithHash = {
+      Email_LC_SHA256: {
+        id: "me@gmail.com",
+        authState: 0,
+        hash: true // TODO: document customer ID hashing syntax
+      },
+      crm: {
+        id: "1234",
+        authState: 0
+      }
+    };
+
+    const cookieJar = {
+      get: jasmine.createSpy(),
+      set: jasmine.createSpy()
+    };
+
+    const payload = {
+      addIdentity: jasmine.createSpy(),
+      mergeMeta: jasmine.createSpy()
+    };
+
+    const test = addCustomerIdsToPayload(idsWithHash, cookieJar, payload);
+    test.then(() => {
+      expect(cookieJar.get).toHaveBeenCalledWith(CUSTOMER_ID_HASH);
+      expect(cookieJar.set).toHaveBeenCalledWith(CUSTOMER_ID_HASH, "807ct1");
+      expect(payload.addIdentity).toHaveBeenCalled();
+      expect(payload.addIdentity.calls.count()).toBe(2);
+      expect(payload.addIdentity).toHaveBeenCalledWith("Email_LC_SHA256", {
+        id: "81d1a7135b9722577fb4f094a2004296d6230512d37b68e64b73f050b919f7c4",
+        authState: 0
+      });
+      expect(payload.addIdentity).toHaveBeenCalledWith("crm", {
+        id: "1234",
+        authState: 0
+      });
+      expect(payload.mergeMeta).toHaveBeenCalled();
+      expect(payload.mergeMeta).toHaveBeenCalledWith({
+        identity: { customerIdChanged: true }
+      });
+    });
+  });
+
+  it("should set CUSTOMER_ID_HASH cookie and payload meta when same ids are passed again", () => {
+    const idsWithoutHash = {
+      Email_LC_SHA256: {
+        id: "me@gmail.com",
+        authState: 0
+      },
+      crm: {
+        id: "1234",
+        authState: 0
+      }
+    };
+    const payload = {
+      addIdentity: jasmine.createSpy(),
+      mergeMeta: jasmine.createSpy()
+    };
+    const cookieJar = {
+      get: jasmine.createSpy().and.returnValue("807ct1"),
+      set: jasmine.createSpy()
+    };
+
+    const test = addCustomerIdsToPayload(idsWithoutHash, cookieJar, payload);
+    test.then(() => {
+      expect(cookieJar.get).toHaveBeenCalledWith(CUSTOMER_ID_HASH);
+      expect(cookieJar.set).not.toHaveBeenCalled();
+      expect(payload.addIdentity).toHaveBeenCalled();
+      expect(payload.addIdentity.calls.count()).toBe(2);
+      expect(payload.addIdentity).toHaveBeenCalledWith("Email_LC_SHA256", {
+        id: "me@gmail.com",
+        authState: 0
+      });
+      expect(payload.addIdentity).toHaveBeenCalledWith("crm", {
+        id: "1234",
+        authState: 0
+      });
+      expect(payload.mergeMeta).toHaveBeenCalled();
+      expect(payload.mergeMeta).toHaveBeenCalledWith({
+        identity: { customerIdChanged: false }
+      });
+    });
+  });
+});

--- a/test/unit/specs/components/Identity/setCustomerIds.spec.js
+++ b/test/unit/specs/components/Identity/setCustomerIds.spec.js
@@ -1,0 +1,98 @@
+import setCustomerIds from "../../../../../src/components/Identity/setCustomerIds";
+import { COOKIE_NAMES } from "../../../../../src/components/Identity/constants";
+
+const { CUSTOMER_ID_HASH } = COOKIE_NAMES;
+
+const idsWithHash = {
+  Email_LC_SHA256: {
+    id: "me@gmail.com",
+    authState: 0,
+    hash: true
+  },
+  crm: {
+    id: "1234",
+    authState: 0
+  }
+};
+
+describe("Identity::setCustomerIds", () => {
+  let lifecycle;
+  let network;
+  let optIn;
+  let payload;
+  let cookieJar;
+  beforeEach(() => {
+    cookieJar = {
+      get: jasmine.createSpy(),
+      set: jasmine.createSpy()
+    };
+    lifecycle = {
+      onBeforeEvent: () => Promise.resolve(),
+      onBeforeDataCollection: () => Promise.resolve()
+    };
+    payload = {
+      addEvent: jasmine.createSpy(),
+      addIdentity: jasmine.createSpy(),
+      mergeMeta: jasmine.createSpy()
+    };
+    network = {
+      createPayload: jasmine.createSpy().and.returnValue(payload),
+      sendRequest: () => Promise.resolve({})
+    };
+    optIn = {
+      whenOptedIn: () => Promise.resolve()
+    };
+  });
+  it("should create a payload and add an event", () => {
+    setCustomerIds(idsWithHash, cookieJar, lifecycle, network, optIn);
+    expect(cookieJar.get).toHaveBeenCalledWith(CUSTOMER_ID_HASH);
+    expect(cookieJar.set).toHaveBeenCalled();
+    expect(network.createPayload).toHaveBeenCalled();
+    expect(payload.addEvent).toHaveBeenCalled();
+  });
+  it("should not set the cookie if the customerIds have not changed", () => {
+    cookieJar.get = jasmine.createSpy().and.returnValue("807ct1");
+    setCustomerIds(idsWithHash, cookieJar, lifecycle, network, optIn);
+    expect(cookieJar.get).toHaveBeenCalledWith(CUSTOMER_ID_HASH);
+    expect(cookieJar.set).not.toHaveBeenCalled();
+  });
+
+  it("should call onBeforeDataCollection with payload and customerIds", () => {
+    const normalizedAndHashedIds = {
+      Email_LC_SHA256: {
+        id: "81d1a7135b9722577fb4f094a2004296d6230512d37b68e64b73f050b919f7c4",
+        authState: 0
+      },
+      crm: {
+        id: "1234",
+        authState: 0
+      }
+    };
+    const test = setCustomerIds(
+      idsWithHash,
+      cookieJar,
+      lifecycle,
+      network,
+      optIn
+    );
+    test.then(() => {
+      expect(lifecycle.onBeforeEvent).toHaveBeenCalledWith();
+      expect(lifecycle.onBeforeDataCollection).toHaveBeenCalledWith(payload, {
+        normalizedAndHashedIds,
+        customerIdChanged: true
+      });
+    });
+  });
+  it("should send a network request", () => {
+    const test = setCustomerIds(
+      idsWithHash,
+      cookieJar,
+      lifecycle,
+      network,
+      optIn
+    );
+    test.then(() => {
+      expect(network.sendRequest).toHaveBeenCalled();
+    });
+  });
+});

--- a/test/unit/specs/components/Identity/util.spec.js
+++ b/test/unit/specs/components/Identity/util.spec.js
@@ -1,11 +1,22 @@
 import {
   validateCustomerIds,
-  normalizeCustomerIds
+  normalizeCustomerIds,
+  updateCustomerIdState
 } from "../../../../../src/components/Identity/util";
 import { AUTH_STATES } from "../../../../../src/components/Identity/constants";
 
 describe("Identity::identityUtil", () => {
   describe("validateCustomerIds", () => {
+    it("should throw an error when input is not an object", () => {
+      const idToTest = "email=qwerty@asdf.com";
+      expect(() => {
+        validateCustomerIds(idToTest);
+      }).toThrow(
+        new Error(
+          "Invalid customer ID format. Each namespace should be an object."
+        )
+      );
+    });
     it("should throw an error when each key is not an object", () => {
       const objToTest = {
         email: "qwerty@asdf.com",
@@ -99,5 +110,50 @@ describe("Identity::identityUtil", () => {
       };
       expect(normalizeCustomerIds(objToTest)).toEqual(normalizedObj);
     });
+  });
+
+  describe("update customerIdState", () => {
+    it("should return a new state", () => {
+      const state = {
+        email: {
+          id: "me@gmail.com",
+          authState: 0
+        }
+      };
+      const newState = updateCustomerIdState({}, state);
+      expect(newState).not.toBe(state);
+      expect(newState).toEqual(state);
+    });
+  });
+  it("should append values to an existing state", () => {
+    const state = {
+      email: {
+        id: "me@gmail.com",
+        authState: 0
+      }
+    };
+    const newState = {
+      email: {
+        id: "me@gmail.com",
+        authState: 1
+      },
+      crm: {
+        id: "1234"
+      }
+    };
+    const expectedState = {
+      email: {
+        id: "me@gmail.com",
+        authState: 1
+      },
+      crm: {
+        id: "1234"
+      }
+    };
+    const updatedState = updateCustomerIdState(state, newState);
+    expect(updatedState).not.toBe(state);
+    expect(updatedState).not.toBe(newState);
+
+    expect(updatedState).toEqual(expectedState);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Some customers might have users id info during config itself,
This change will allow to pass these IDs while config
```
alloy("configure", {
        propertyId: 9999999,
        imsOrgId: "53A16ACB5CC1D3760A495C99@AdobeOrg",
        customerIds: {
          email: {
            id: "you@gmail.com",
              "authState": 0,
              "hash": false 
            }
         }
      });
```
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/CORE-32507



## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
