### PR TITLE
CORE-33593 Restructured payload to consolidate XDM

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -11,7 +11,7 @@
             script-src 'self' 'unsafe-inline' assets.adobedtm.com cdn.tt.omtrdc.net;
             style-src 'self' 'unsafe-inline' cdn.tt.omtrdc.net;
             img-src * data:;
-            connect-src 'self' unifiedjslab.tt.omtrdc.net *.demdex.net http://localhost:8080 https://alpha.konductor.adobedc.net https://edgegateway.azurewebsites.net "/>
+            connect-src 'self' unifiedjslab.tt.omtrdc.net *.demdex.net http://localhost:8080 https://alpha.konductor.adobedc.net https://edgegateway.azurewebsites.net konductor-qe.apps-exp-edge-npe-va6.experience-edge.adobeinternal.net"/>
 
     <title>Mock website hosting Alloy</title>
 
@@ -37,6 +37,7 @@
       // https://git.corp.adobe.com/Activation/edge-gateway-mock
       alloy("configure", {
         // edgeDomain: "edgegateway.azurewebsites.net",
+        // edgeDomain: "konductor-qe.apps-exp-edge-npe-va6.experience-edge.adobeinternal.net",
         // optInEnabled: true,
         // errorsEnabled: false,
         propertyId: 9999999,
@@ -51,10 +52,19 @@
 
       alloy("event", {
         viewStart: true,
+        xdm: {
+          "_myorg": {
+            "type": "page-view",
+            "url": location.href,
+            "name": location.pathname.substring(1) || "home"
+          },
+          // Demonstrates overriding automatically collected data
+          "device": {
+            screenHeight: 1
+          }
+        },
         data: {
-          "type": "page-view",
-          "url": location.href,
-          "name": location.pathname.substring(1) || "home"
+          "nonXdmKey": "nonXdmValue"
         }
       }).then(function(data) {
         console.log("Sandbox: View start event has completed.", data);
@@ -80,7 +90,7 @@
         propertyId: 8888888,
         imsOrgId: "53A16ACB5CC1D3760A495C99@AdobeOrg",
         logEnabled: true,
-	clickCollectionEnabled: false
+        clickCollectionEnabled: false
       });
     </script>
   </head>

--- a/sandbox/src/EventMerge.js
+++ b/sandbox/src/EventMerge.js
@@ -5,7 +5,7 @@ export default function EventMerge() {
 
   useEffect(() => {
     window.alloy("event", {
-      data: {
+      xdm: {
         "key1": "value1"
       },
       eventMergeId: eventMergeId.current
@@ -13,7 +13,7 @@ export default function EventMerge() {
 
     setTimeout(() => {
       window.alloy("event", {
-        data: {
+        xdm: {
           "key2": "value2"
         },
         eventMergeId: eventMergeId.current

--- a/sandbox/src/Home.js
+++ b/sandbox/src/Home.js
@@ -9,7 +9,7 @@ function HomeWithHistory({ history }) {
       const instanceName = loc.pathname.includes("orgTwo") ? "organizationTwo" : "alloy";
       window[instanceName]("event", {
         viewStart: true,
-        data: {
+        xdm: {
           "eventType": "page-view",
           "url": window.location.href,
           "name": loc.pathname.substring(1)
@@ -21,7 +21,7 @@ function HomeWithHistory({ history }) {
 
   const visitDoc = ev => {
     window.alloy("event", {
-      data: {
+      xdm: {
         "eventType": "visit-doc",
         "activitystreams:href": ev.target.href,
         "activitystreams:name": ev.target.name,
@@ -32,7 +32,7 @@ function HomeWithHistory({ history }) {
 
   const copyBaseCode = ev => {
     window.alloy("event", {
-      data: {
+      xdm: {
         "eventType": "copy-base-code",
         "activitystreams:href": "https://launch.gitbook.io/adobe-experience-platform-web-sdk/",
         "activitystreams:name": "copyBaseCode",
@@ -49,14 +49,14 @@ function HomeWithHistory({ history }) {
 
   return (
       <div>
-        <section>  
+        <section>
           <div className="container">
             <h2>Some awesome default content</h2>
             <br/>
           </div>
         </section>
 
-        <section> 
+        <section>
           <div>
             <h1>Alloy: Getting Started</h1>
             <h3>Installation</h3>

--- a/sandbox/src/LargePayload.js
+++ b/sandbox/src/LargePayload.js
@@ -8,7 +8,7 @@ export default function LargePayload() {
       const payload = new Uint8Array(size * 1024);
       window.alloy("event", {
         documentUnloading: true,
-        data: {
+        xdm: {
           payload
         }
       });

--- a/sandbox/src/LargePayload.js
+++ b/sandbox/src/LargePayload.js
@@ -8,7 +8,7 @@ export default function LargePayload() {
       const payload = new Uint8Array(size * 1024);
       window.alloy("event", {
         documentUnloading: true,
-        xdm: {
+        data: {
           payload
         }
       });

--- a/sandbox/src/Links.js
+++ b/sandbox/src/Links.js
@@ -5,7 +5,7 @@ export default function Links() {
   const adobeLink = () => {
     window.alloy("event", {
       documentUnloading: true,
-      data: {
+      xdm: {
         "activitystreams:href": "http://www.adobe.com"
       }
     });
@@ -14,8 +14,8 @@ export default function Links() {
   return (
     <div>
       <h2>Links</h2>
-      <p>This page tests collecting events on link clicking.  For example, this link: 
-      <a onClick={adobeLink} href="http://www.adobe.com">Adobe</a> should trigger a sendBeacon call 
+      <p>This page tests collecting events on link clicking.  For example, this link:
+      <a onClick={adobeLink} href="http://www.adobe.com">Adobe</a> should trigger a sendBeacon call
       in browsers that support beacons</p>
     </div>
   );

--- a/src/components/Context/deviceFactory.js
+++ b/src/components/Context/deviceFactory.js
@@ -59,6 +59,8 @@ export default window => {
     if (orientation) {
       device.screenOrientation = orientation;
     }
-    return event.mergeDevice(device);
+    event.mergeXdm({
+      device
+    });
   };
 };

--- a/src/components/Context/environmentFactory.js
+++ b/src/components/Context/environmentFactory.js
@@ -28,6 +28,8 @@ export default window => {
     ) {
       environment.connectionType = navigator.connection.effectiveType;
     }
-    event.mergeEnvironment(environment);
+    event.mergeXdm({
+      environment
+    });
   };
 };

--- a/src/components/Context/placeContextFactory.js
+++ b/src/components/Context/placeContextFactory.js
@@ -18,6 +18,8 @@ export default dateProvider => {
       localTime: toISOStringLocal(date),
       localTimezoneOffset: date.getTimezoneOffset()
     };
-    event.mergePlaceContext(placeContext);
+    event.mergeXdm({
+      placeContext
+    });
   };
 };

--- a/src/components/Context/timestampFactory.js
+++ b/src/components/Context/timestampFactory.js
@@ -13,6 +13,8 @@ governing permissions and limitations under the License.
 export default dateProvider => {
   return event => {
     const date = dateProvider();
-    event.timestamp = date.toISOString();
+    event.mergeXdm({
+      timestamp: date.toISOString()
+    });
   };
 };

--- a/src/components/Context/webFactory.js
+++ b/src/components/Context/webFactory.js
@@ -16,12 +16,14 @@ export default (window, topFrameSetProvider) => {
   return event => {
     topFrameSet = topFrameSet || topFrameSetProvider();
 
-    event.mergeWeb({
-      webPageDetails: {
-        URL: window.location.href || window.location
-      },
-      webReferrer: {
-        URL: topFrameSet.document.referrer
+    event.mergeXdm({
+      web: {
+        webPageDetails: {
+          URL: window.location.href || window.location
+        },
+        webReferrer: {
+          URL: topFrameSet.document.referrer
+        }
       }
     });
   };

--- a/src/components/DataCollector/activity/click.js
+++ b/src/components/DataCollector/activity/click.js
@@ -31,7 +31,7 @@ const createClickHandler = (window, logger, collect) => {
     if (linkUrl && isSupportedAnchorElement(clickedObj)) {
       // TODO: Update name (link name) and support exit, other, and download link types
       collect({
-        data: {
+        xdm: {
           eventType: "web.webinteraction.linkClicks",
           web: {
             webinteraction: {

--- a/src/components/DataCollector/createEvent.js
+++ b/src/components/DataCollector/createEvent.js
@@ -21,16 +21,12 @@ export default () => {
     set eventMergeId(eventMergeId) {
       content.eventMergeId = eventMergeId;
     },
-    mergeData: createMerger(content, "data"),
+    set data(data) {
+      content.data = data;
+    },
+    mergeXdm: createMerger(content, "xdm"),
     mergeMeta: createMerger(content, "meta"),
     mergeQuery: createMerger(content, "query"),
-    mergeWeb: createMerger(content, "web"),
-    mergeDevice: createMerger(content, "device"),
-    mergeEnvironment: createMerger(content, "environment"),
-    mergePlaceContext: createMerger(content, "placeContext"),
-    set timestamp(timestamp) {
-      content.timestamp = timestamp;
-    },
     expectResponse() {
       expectsResponse = true;
     },

--- a/src/components/Identity/setCustomerIds.js
+++ b/src/components/Identity/setCustomerIds.js
@@ -12,7 +12,6 @@ const makeServerCall = (payload, lifecycle, network) => {
 export default (ids, cookieJar, lifecycle, network, optIn) => {
   validateCustomerIds(ids);
   const event = createEvent(); // FIXME: We shouldn't need an event.
-  event.mergeData({}); // FIXME: We shouldn't need an event.
   const payload = network.createPayload();
   payload.addEvent(event); // FIXME: We shouldn't need an event.
   const customerIds = assign({}, ids);

--- a/test/unit/specs/components/Context/deviceFactory.spec.js
+++ b/test/unit/specs/components/Context/deviceFactory.spec.js
@@ -11,26 +11,30 @@ describe("Context::deviceFactory", () => {
         height: 800
       }
     };
-    event = jasmine.createSpyObj("event", ["mergeDevice"]);
+    event = jasmine.createSpyObj("event", ["mergeXdm"]);
   });
 
   it("handles the happy path", () => {
     window.screen.orientation = { type: "landscape-primary" };
     deviceFactory(window)(event);
-    expect(event.mergeDevice).toHaveBeenCalledWith({
-      screenHeight: 800,
-      screenWidth: 600,
-      screenOrientation: "landscape"
+    expect(event.mergeXdm).toHaveBeenCalledWith({
+      device: {
+        screenHeight: 800,
+        screenWidth: 600,
+        screenOrientation: "landscape"
+      }
     });
   });
 
   it("handles portrait orientation type", () => {
     window.screen.orientation = { type: "portrait-secondary" };
     deviceFactory(window)(event);
-    expect(event.mergeDevice).toHaveBeenCalledWith({
-      screenHeight: 800,
-      screenWidth: 600,
-      screenOrientation: "portrait"
+    expect(event.mergeXdm).toHaveBeenCalledWith({
+      device: {
+        screenHeight: 800,
+        screenWidth: 600,
+        screenOrientation: "portrait"
+      }
     });
   });
 
@@ -39,10 +43,12 @@ describe("Context::deviceFactory", () => {
       matches: query === "(orientation: portrait)"
     });
     deviceFactory(window)(event);
-    expect(event.mergeDevice).toHaveBeenCalledWith({
-      screenHeight: 800,
-      screenWidth: 600,
-      screenOrientation: "portrait"
+    expect(event.mergeXdm).toHaveBeenCalledWith({
+      device: {
+        screenHeight: 800,
+        screenWidth: 600,
+        screenOrientation: "portrait"
+      }
     });
   });
 
@@ -51,10 +57,12 @@ describe("Context::deviceFactory", () => {
       matches: query === "(orientation: landscape)"
     });
     deviceFactory(window)(event);
-    expect(event.mergeDevice).toHaveBeenCalledWith({
-      screenHeight: 800,
-      screenWidth: 600,
-      screenOrientation: "landscape"
+    expect(event.mergeXdm).toHaveBeenCalledWith({
+      device: {
+        screenHeight: 800,
+        screenWidth: 600,
+        screenOrientation: "landscape"
+      }
     });
   });
 
@@ -74,9 +82,11 @@ describe("Context::deviceFactory", () => {
       }
       window.matchMedia = () => ({ matches: false });
       deviceFactory(window)(event);
-      expect(event.mergeDevice).toHaveBeenCalledWith({
-        screenHeight: 800,
-        screenWidth: 600
+      expect(event.mergeXdm).toHaveBeenCalledWith({
+        device: {
+          screenHeight: 800,
+          screenWidth: 600
+        }
       });
     });
   });

--- a/test/unit/specs/components/Context/environmentFactory.spec.js
+++ b/test/unit/specs/components/Context/environmentFactory.spec.js
@@ -10,7 +10,7 @@ describe("Context::environmentFactory", () => {
   let event;
 
   beforeEach(() => {
-    event = jasmine.createSpyObj("event", ["mergeEnvironment"]);
+    event = jasmine.createSpyObj("event", ["mergeXdm"]);
   });
 
   it("works", () => {
@@ -19,13 +19,15 @@ describe("Context::environmentFactory", () => {
       return date;
     };
     environmentFactory(mywindow, dateProvider)(event);
-    expect(event.mergeEnvironment).toHaveBeenCalledWith({
-      type: "browser",
-      browserDetails: {
-        viewportWidth: 1003,
-        viewportHeight: 1004
-      },
-      connectionType: "myConnectionType"
+    expect(event.mergeXdm).toHaveBeenCalledWith({
+      environment: {
+        type: "browser",
+        browserDetails: {
+          viewportWidth: 1003,
+          viewportHeight: 1004
+        },
+        connectionType: "myConnectionType"
+      }
     });
   });
 
@@ -41,11 +43,13 @@ describe("Context::environmentFactory", () => {
       return date;
     };
     environmentFactory(ieWindow, dateProvider)(event);
-    expect(event.mergeEnvironment).toHaveBeenCalledWith({
-      type: "browser",
-      browserDetails: {
-        viewportWidth: 1003,
-        viewportHeight: 1004
+    expect(event.mergeXdm).toHaveBeenCalledWith({
+      environment: {
+        type: "browser",
+        browserDetails: {
+          viewportWidth: 1003,
+          viewportHeight: 1004
+        }
       }
     });
   });

--- a/test/unit/specs/components/Context/placeContextFactory.spec.js
+++ b/test/unit/specs/components/Context/placeContextFactory.spec.js
@@ -6,7 +6,7 @@ describe("Context::placeContextFactory", () => {
   const date = new Date("March 25, 2019 21:56:18");
 
   beforeEach(() => {
-    event = jasmine.createSpyObj("event", ["mergePlaceContext"]);
+    event = jasmine.createSpyObj("event", ["mergeXdm"]);
     dateProvider = () => {
       return date;
     };
@@ -15,9 +15,11 @@ describe("Context::placeContextFactory", () => {
   it("adds placeContext", () => {
     spyOn(date, "getTimezoneOffset").and.returnValue(7 * 60);
     placeContextFactory(dateProvider)(event);
-    expect(event.mergePlaceContext).toHaveBeenCalledWith({
-      localTime: "2019-03-25T21:56:18.000-07:00",
-      localTimezoneOffset: 7 * 60
+    expect(event.mergeXdm).toHaveBeenCalledWith({
+      placeContext: {
+        localTime: "2019-03-25T21:56:18.000-07:00",
+        localTimezoneOffset: 7 * 60
+      }
     });
   });
 });

--- a/test/unit/specs/components/Context/webFactory.spec.js
+++ b/test/unit/specs/components/Context/webFactory.spec.js
@@ -10,17 +10,19 @@ describe("Context::webFactory", () => {
   let event;
 
   beforeEach(() => {
-    event = jasmine.createSpyObj("event", ["mergeWeb"]);
+    event = jasmine.createSpyObj("event", ["mergeXdm"]);
   });
 
   it("works", () => {
     webFactory(window, topFrameSetProvider)(event);
-    expect(event.mergeWeb).toHaveBeenCalledWith({
-      webPageDetails: {
-        URL: "http://mylocation.com"
-      },
-      webReferrer: {
-        URL: "http://myreferrer.com"
+    expect(event.mergeXdm).toHaveBeenCalledWith({
+      web: {
+        webPageDetails: {
+          URL: "http://mylocation.com"
+        },
+        webReferrer: {
+          URL: "http://myreferrer.com"
+        }
       }
     });
   });

--- a/test/unit/specs/components/DataCollector/index.spec.js
+++ b/test/unit/specs/components/DataCollector/index.spec.js
@@ -141,7 +141,7 @@ describe("Event Command", () => {
 
   it("Allows other components to modify the event", () => {
     onBeforeEventSpy.and.callFake(event => {
-      event.mergeData({ a: "changed" });
+      event.mergeXdm({ a: "changed" });
       return Promise.resolve();
     });
     return eventCommand({ data: { a: 1 } }).then(() => {
@@ -149,7 +149,7 @@ describe("Event Command", () => {
         network.sendRequest.calls
           .argsFor(0)[0]
           .toJSON()
-          .events[0].toJSON().data
+          .events[0].toJSON().xdm
       ).toEqual({ a: "changed" });
     });
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Conslidates XDM data (both customer XDM data and automatically collected data) inso a single `xdm` key on the event object. XDM data can be provided by the customer through the `xdm` option, while non-XDM data can be provided through the `data` option. XDM data provided by the customer is deeply merged on top of automatically collected data.

## Related Issue
https://jira.corp.adobe.com/browse/CORE-33593
https://jira.corp.adobe.com/browse/EXEG-215
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
* Users can more easily understand how the payload data maps to the schema they've created in AEP.
* Customers easily override or add to automatically collected data.
* Customers can more easily indicate which data is XDM vs non-XDM.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] (I will pronto!) I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
