### PR TITLE
CORE-33593 Move event merge ID into XDM block

### DIFF
--- a/src/components/DataCollector/createEvent.js
+++ b/src/components/DataCollector/createEvent.js
@@ -18,9 +18,6 @@ export default () => {
   let expectsResponse = false;
 
   return {
-    set eventMergeId(eventMergeId) {
-      content.eventMergeId = eventMergeId;
-    },
     set data(data) {
       content.data = data;
     },

--- a/src/components/EventMerge/index.js
+++ b/src/components/EventMerge/index.js
@@ -25,7 +25,9 @@ const createEventMerge = ({ config }) => {
       onBeforeEvent(event, options) {
         return Promise.resolve(options.eventMergeId).then(eventMergeId => {
           if (eventMergeId !== undefined) {
-            event.eventMergeId = eventMergeId;
+            event.mergeXdm({
+              eventMergeId
+            });
           }
         });
       }

--- a/test/unit/specs/components/EventMerge/index.spec.js
+++ b/test/unit/specs/components/EventMerge/index.spec.js
@@ -17,6 +17,7 @@ const uuidv4Regex = /^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[
 describe("EventMerge", () => {
   let eventMerge;
   let reactorRegisterCreateEventMergeId;
+  let mockEvent;
 
   beforeAll(() => {
     reactorRegisterCreateEventMergeId = jasmine.createSpy();
@@ -27,36 +28,42 @@ describe("EventMerge", () => {
     });
   });
 
+  beforeEach(() => {
+    mockEvent = jasmine.createSpyObj("event", ["mergeXdm"]);
+  });
+
   describe("lifecycle", () => {
     describe("onBeforeEvent", () => {
-      it("applies an eventMergeId to the event when provided in options", done => {
-        const event = {};
+      it("applies an eventMergeId to the event when provided in options", () => {
         const options = {
           eventMergeId: "ABC123"
         };
-        eventMerge.lifecycle.onBeforeEvent(event, options).then(() => {
-          expect(event.eventMergeId).toBe("ABC123");
-          done();
-        });
+        return eventMerge.lifecycle
+          .onBeforeEvent(mockEvent, options)
+          .then(() => {
+            expect(mockEvent.mergeXdm).toHaveBeenCalledWith({
+              eventMergeId: "ABC123"
+            });
+          });
       });
 
-      it("applies an eventMergeId to the event when promise provided in options", done => {
-        const event = {};
+      it("applies an eventMergeId to the event when promise provided in options", () => {
         const options = {
           eventMergeId: Promise.resolve("ABC123")
         };
-        eventMerge.lifecycle.onBeforeEvent(event, options).then(() => {
-          expect(event.eventMergeId).toBe("ABC123");
-          done();
-        });
+        return eventMerge.lifecycle
+          .onBeforeEvent(mockEvent, options)
+          .then(() => {
+            expect(mockEvent.mergeXdm).toHaveBeenCalledWith({
+              eventMergeId: "ABC123"
+            });
+          });
       });
 
-      it("does not apply an eventMergeId to the event when not provided in options", done => {
-        const event = {};
+      it("does not apply an eventMergeId to the event when not provided in options", () => {
         const options = {};
-        eventMerge.lifecycle.onBeforeEvent(event, options).then(() => {
-          expect(event.eventMergeId).toBeUndefined();
-          done();
+        eventMerge.lifecycle.onBeforeEvent(mockEvent, options).then(() => {
+          expect(mockEvent.mergeXdm).not.toHaveBeenCalled();
         });
       });
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This probably should have been done as part of https://github.com/adobe/alloy/pull/186, but since @jfkhoury already reviewed that PR, I decided to keep this separate.

`eventMergeID` will be in the XDM schema itself, so it makes sense to send it to Konductor in the `xdm` block and not as a sibling to the `xdm` block. This is also what Konductor is expecting as outlined in http://konductor-docs-qe.apps-exp-edge-npe-va6.experience-edge.adobeinternal.net/ (although Konductor is still using the old `stitchId` name in the swagger docs).
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-33593
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
