### PR TITLE
Include `data` property on event while Konductor still requires it.

### DIFF
--- a/src/components/DataCollector/createEvent.js
+++ b/src/components/DataCollector/createEvent.js
@@ -14,7 +14,9 @@ governing permissions and limitations under the License.
 import { createMerger } from "../../utils";
 
 export default () => {
-  const content = {};
+  const content = {
+    data: {} // FIXME: Remove once Konductor makes it optional.
+  };
   let expectsResponse = false;
 
   return {

--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -63,8 +63,12 @@ const createDataCollector = ({ config, logger }) => {
         // it overlays on top of any data Alloy automatically
         // provides. This allows the user to override the
         // automatically collected data.
-        event.mergeXdm(xdm);
-        event.data = data;
+        if (xdm) {
+          event.mergeXdm(xdm);
+        }
+        if (data) {
+          event.data = data;
+        }
         return optIn.whenOptedIn();
       })
       .then(() => makeServerCall(event, documentUnloading));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Temporarily resolves an issue where Konductor was throwing errors because we weren't including `data` on `event`.
<!--- Describe your changes in detail -->

## Related Issue
None.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Server errors are bad.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
