### PR TITLE
CORE-33885 add beforeSend hook to network config

### DIFF
--- a/src/core/network/createPayload.js
+++ b/src/core/network/createPayload.js
@@ -39,7 +39,10 @@ export default () => {
       );
     },
     toJSON() {
-      return content;
+      return {
+        ...content,
+        events: (content.events || []).map(event => event.toJSON())
+      };
     }
   };
 };

--- a/test/unit/specs/components/DataCollector/index.spec.js
+++ b/test/unit/specs/components/DataCollector/index.spec.js
@@ -146,10 +146,7 @@ describe("Event Command", () => {
     });
     return eventCommand({ data: { a: 1 } }).then(() => {
       expect(
-        network.sendRequest.calls
-          .argsFor(0)[0]
-          .toJSON()
-          .events[0].toJSON().data
+        network.sendRequest.calls.argsFor(0)[0].toJSON().events[0].data
       ).toEqual({ a: "changed" });
     });
   });

--- a/test/unit/specs/core/network/createNetwork.spec.js
+++ b/test/unit/specs/core/network/createNetwork.spec.js
@@ -206,4 +206,25 @@ describe("createNetwork", () => {
       );
     });
   });
+
+  it("calls a configured beforeSend before sending the payload", () => {
+    const config2 = {
+      edgeDomain: "alloy.mysite.com",
+      propertyId: "mypropertyid",
+      beforeSend(payload) {
+        payload.b = "beforeSend2";
+        payload.c = "beforeSend3";
+        return payload;
+      }
+    };
+    network = createNetwork(config2, logger, lifecycle, networkStrategy);
+    return network.sendRequest({ a: "1", b: "2" }).then(() => {
+      expect(networkStrategy).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(networkStrategy.calls.argsFor(0)[1])).toEqual({
+        a: "1",
+        b: "beforeSend2",
+        c: "beforeSend3"
+      });
+    });
+  });
 });

--- a/test/unit/specs/core/network/createPayload.spec.js
+++ b/test/unit/specs/core/network/createPayload.spec.js
@@ -51,4 +51,32 @@ describe("Payload", () => {
     payload.addEvent(collectEvent);
     expect(payload.expectsResponse).toBe(false);
   });
+
+  it("converts to a JSON object", () => {
+    const payload = createPayload();
+    payload.addIdentity("MY", { id: "myid" });
+    const event = createEvent();
+    event.mergeData({ mykey: "myvalue" });
+    payload.addEvent(event);
+    payload.mergeMeta({ mymetakey: "mymetavalue" });
+    expect(payload.toJSON()).toEqual({
+      identityMap: {
+        MY: [
+          {
+            id: "myid"
+          }
+        ]
+      },
+      events: [
+        {
+          data: {
+            mykey: "myvalue"
+          }
+        }
+      ],
+      meta: {
+        mymetakey: "mymetavalue"
+      }
+    });
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The spec for this feature is very thin.  This PR is a starting point for discussion on how this feature should be implemented.  I'm starting here with the most simple and most broadly applicable implementation.

### beforeSend hook implemented in the network component (in this PR)
Pros
* User is able to edit the entire payload.
* Simple for a user to understand how the passed in JSON maps to the new payload.
* This hook will be called for all network ops even idSyncs.

Cons
* User can mess up the payload to the point where Konductor rejects it
* Can be difficult to use if only a part of the payload needs to be modified
* If Konductor changes its expected format and Alloy releases a new version, customers' beforeSend hooks would need to be modified.

### Other ideas:
* Provide a hook for just the event object
* Provide a hook for just the automatically collected values (i.e. the xdm part of the event before it is merged with the xdm part of the user's event)
* Provide all of these hooks

## Related Issue

https://jira.corp.adobe.com/browse/CORE-33885

## Motivation and Context

* We want the user to be able to change the data that is automatically collected in Alloy.
* We want the user to be able to modify the sent data in one place.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [ ] I have run the Sandbox successfully.
