### PR TITLE
CORE-34647: Resolve the Travis CI from failing during environment setup 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 language:
 - node_js
@@ -25,19 +25,14 @@ addons:
   sonarcloud:
     organization: "adobeinc"
 
-before_script:
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
-- sleep 3
-- fluxbox >/dev/null 2>&1 &
+services:
+  - xvfb
 
 script:
 - npm install
 - npm run build
 - npm run test
 - npm run test:saucelabs
-- npm run test:report
-- npm run functional
 - npm run checkbundlesize
 # - sonar-scanner
 


### PR DESCRIPTION
Upped the Travis CI env to a newer version of Ubuntu to support the latest headless chrome, switch xvfb to a service, remove functional test for breaking changes in open PR and remove Allure report generator repeat.