### PR TITLE
Adding defaults and validation for errorsEnabled and logEnabled

### DIFF
--- a/src/core/createInstance.js
+++ b/src/core/createInstance.js
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import { isFunction, toError, stringToBoolean, queryString } from "../utils";
 import createConfig from "./createConfig";
 import logQueryParam from "../constants/logQueryParam";
+import { boolean } from "../utils/configValidators";
 
 export default (
   namespace,
@@ -29,23 +30,33 @@ export default (
     logController.logEnabled = enabled;
   };
 
+  const coreConfigValidators = {
+    errorsEnabled: {
+      validate: boolean,
+      defaultValue: true
+    },
+    logEnabled: {
+      validate: boolean,
+      defaultValue: false
+    }
+  };
+
   const configureCommand = options => {
     // We wrap this code in a promise, so that if there are any errors
     // in any of it, the promise returned from this function
     // will be properly rejected.
     return new Promise((resolve, reject) => {
-      ({ errorsEnabled = true } = options);
-      if (options.logEnabled !== undefined) {
-        logCommand({ enabled: options.logEnabled });
-      }
+      const config = createConfig(options);
+      config.addValidators(coreConfigValidators);
+      config.validate();
+      ({ errorsEnabled } = config);
+      logCommand({ enabled: config.logEnabled });
       const parsedQueryString = queryString.parse(window.location.search);
       if (parsedQueryString[logQueryParam] !== undefined) {
         logCommand({
           enabled: stringToBoolean(parsedQueryString[logQueryParam])
         });
       }
-      const config = createConfig(options);
-
       initializeComponents(config).then(resolve, reject);
     });
   };


### PR DESCRIPTION
Adding some more configuration validations

## Description

Adding defaults and validation for errorsEnabled and logEnabled

## Related Issue

CORE-32996

## Motivation and Context

Makes sure default logging and error reporting is honored.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
