### PR TITLE
CORE-31911 add requestId to queryString

### DIFF
--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 import createEvent from "./createEvent";
 import createConfigValidators from "./createConfigValidators";
-import { clone } from "../../utils";
+import { clone, uuid } from "../../utils";
 
 import createClickActivityCollector from "./activity/click";
 
@@ -31,11 +31,14 @@ const createDataCollector = ({ config, logger }) => {
       }
     });
 
+    const requestId = uuid();
+
     return lifecycle
-      .onBeforeDataCollection({ payload })
+      .onBeforeDataCollection({ payload, requestId })
       .then(() => {
         return network.sendRequest(
           payload,
+          requestId,
           payload.expectsResponse,
           documentUnloading
         );

--- a/src/components/Identity/customerIds/createCustomerIds.js
+++ b/src/components/Identity/customerIds/createCustomerIds.js
@@ -3,7 +3,8 @@ import {
   crc32,
   convertBufferToHex,
   convertStringToSha256Buffer,
-  clone
+  clone,
+  uuid
 } from "../../../utils";
 import { COOKIE_NAMES } from "../constants";
 import createEvent from "../../DataCollector/createEvent";
@@ -35,8 +36,9 @@ export default (cookieJar, lifecycle, network, optIn) => {
   };
 
   const makeServerCall = payload => {
-    return lifecycle.onBeforeDataCollection({ payload }).then(() => {
-      return network.sendRequest(payload, payload.expectsResponse);
+    const requestId = uuid();
+    return lifecycle.onBeforeDataCollection({ payload, requestId }).then(() => {
+      return network.sendRequest(payload, requestId, payload.expectsResponse);
     });
   };
 

--- a/src/core/network/createNetwork.js
+++ b/src/core/network/createNetwork.js
@@ -31,7 +31,7 @@ export default (config, logger, lifecycle, networkStrategy) => {
 
     const response = createResponse(parsedBody);
 
-    return lifecycle.onResponse({ response }).then(() => response);
+    return lifecycle.onResponse({ response, requestId }).then(() => response);
   };
 
   const { edgeDomain, propertyId } = config;
@@ -56,8 +56,12 @@ export default (config, logger, lifecycle, networkStrategy) => {
      * completely processed.  If expectsResponse==false, the promise will be resolved
      * with undefined.
      */
-    sendRequest(payload, expectsResponse = true, documentUnloading = false) {
-      const requestId = uuid();
+    sendRequest(
+      payload,
+      requestId = uuid(),
+      expectsResponse = true,
+      documentUnloading = false
+    ) {
       if (documentUnloading) {
         logger.log(`No response requested due to document unloading.`);
       }
@@ -74,7 +78,7 @@ export default (config, logger, lifecycle, networkStrategy) => {
           }
           // #endif
 
-          const url = `${baseUrl}/${apiVersion}/${action}?propertyId=${propertyId}`;
+          const url = `${baseUrl}/${apiVersion}/${action}?propertyId=${propertyId}&requestId=${requestId}`;
           const responseHandlingMessage = reallyExpectsResponse
             ? ""
             : " (no response is expected)";
@@ -126,7 +130,7 @@ export default (config, logger, lifecycle, networkStrategy) => {
             throw error;
           };
           return lifecycle
-            .onResponseError({ error })
+            .onResponseError({ error, requestId })
             .then(throwError, throwError);
         });
     }

--- a/test/unit/specs/components/DataCollector/index.spec.js
+++ b/test/unit/specs/components/DataCollector/index.spec.js
@@ -143,9 +143,14 @@ describe("Event Command", () => {
     });
   });
 
-  it("Calls onBeforeDataCollection", () => {
+  it("Calls onBeforeDataCollection with the requestId", () => {
     return eventCommand({}).then(() => {
+      expect(sendRequestSpy).toHaveBeenCalled();
       expect(onBeforeDataCollectionSpy).toHaveBeenCalled();
+      expect(onBeforeDataCollectionSpy).toHaveBeenCalledWith({
+        payload: jasmine.anything(),
+        requestId: sendRequestSpy.calls.argsFor(0)[1]
+      });
     });
   });
 
@@ -181,6 +186,7 @@ describe("Event Command", () => {
     return eventCommand({}).then(() => {
       expect(sendRequestSpy).toHaveBeenCalledWith(
         jasmine.anything(),
+        jasmine.anything(),
         true,
         false
       );
@@ -190,6 +196,7 @@ describe("Event Command", () => {
   it("sends expectsResponse == false", () => {
     return eventCommand({}).then(() => {
       expect(sendRequestSpy).toHaveBeenCalledWith(
+        jasmine.anything(),
         jasmine.anything(),
         false,
         false
@@ -201,8 +208,17 @@ describe("Event Command", () => {
     return eventCommand({ documentUnloading: true }).then(() => {
       expect(sendRequestSpy).toHaveBeenCalledWith(
         jasmine.anything(),
+        jasmine.anything(),
         false,
         true
+      );
+    });
+  });
+
+  it("creates a uuid for the requestId", () => {
+    return eventCommand({}).then(() => {
+      expect(sendRequestSpy.calls.argsFor(0)[1]).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
       );
     });
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add the requestId to the queryString of the request.  Also, I added requestId to the onBeforeDataCollection, onResponse, and onResponseError lifecycle calls.

## Related Issue

https://jira.corp.adobe.com/browse/CORE-31911

## Motivation and Context

The requestId can be used by Konductor and other downstream systems so we can trace the processing of the data.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
