### PR TITLE
CORE-34934 Assume errors enabled until configuration says otherwise.

### DIFF
--- a/src/core/createInstance.js
+++ b/src/core/createInstance.js
@@ -29,7 +29,8 @@ export default (
   logger,
   window
 ) => {
-  let errorsEnabled;
+  // Assume errors are enabled until configuration says otherwise.
+  let errorsEnabled = true;
   let configurePromise;
 
   const logCommand = ({ enabled }) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
With a clean local storage and attempting to execute a command before executing the `configure` command, the promise returned to the customer should be rejected. If the promise goes unhandled, the error should show up in the console. 

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-34934
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Customers need to know why the command didn't execute.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
