### PR TITLE
Rename authState - Support setting a primary ID

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -83,12 +83,13 @@
       alloy("setCustomerIds", {
         emailHash: {
           id: "me@gmail.com",
-          authState: 0,
-          hash: true //TODO: document customer ID hashing syntax
+          authenticatedState: "ambiguous",
+          hash: true, //TODO: document customer ID hashing syntax
+          primary: true
         },
         crm: {
           id: "1234",
-          authState: 0
+          authenticatedState: "ambiguous"
         }
       }).then(function() {
         console.log("Sandbox: Set customer IDs event has completed.");

--- a/src/components/Identity/constants.js
+++ b/src/components/Identity/constants.js
@@ -1,7 +1,7 @@
 const AUTH_STATES = {
-  UNKNOWN: 0,
-  AUTHENTICATED: 1,
-  LOGGED_OUT: 2
+  AMBIGUOUS: "ambiguous",
+  AUTHENTICATED: "authenticated",
+  LOGGEDOUT: "loggedOut"
 };
 
 const COOKIE_NAMES = {

--- a/src/components/Identity/customerIds/util.js
+++ b/src/components/Identity/customerIds/util.js
@@ -1,20 +1,33 @@
 import { AUTH_STATES } from "../constants";
-import { isObject, includes, keys, values } from "../../../utils";
+import {
+  isObject,
+  includes,
+  keys,
+  values,
+  isBoolean,
+  isNil
+} from "../../../utils";
 
 const ERROR_MESSAGE = "Invalid customer ID format.";
 const NOT_AN_OBJECT_ERROR = "Each namespace should be an object.";
 const NO_ID_ERROR = "Each namespace object should have an ID.";
+const PRIMARY_NOT_BOOLEAN = "The `primary` property should be true or false.";
 
 const validateCustomerIds = customerIds => {
   if (!isObject(customerIds)) {
     throw new Error(`${ERROR_MESSAGE} ${NOT_AN_OBJECT_ERROR}`);
   }
   keys(customerIds).forEach(customerId => {
+    const { primary } = customerIds[customerId];
+
     if (!isObject(customerIds[customerId])) {
       throw new Error(`${ERROR_MESSAGE} ${NOT_AN_OBJECT_ERROR}`);
     }
     if (!customerIds[customerId].id) {
       throw new Error(`${ERROR_MESSAGE} ${NO_ID_ERROR}`);
+    }
+    if (!isNil(primary) && !isBoolean(primary)) {
+      throw new Error(`${ERROR_MESSAGE} ${PRIMARY_NOT_BOOLEAN}`);
     }
   });
 };
@@ -35,13 +48,14 @@ const normalizeCustomerIds = customerIds => {
   const authStates = values(AUTH_STATES);
 
   return keys(sortedCustomerIds).reduce((normalizedIds, customerId) => {
-    const { id, authenticatedState } = sortedCustomerIds[customerId];
+    const { id, authenticatedState, primary } = sortedCustomerIds[customerId];
 
     normalizedIds[customerId] = {
       id,
       authenticatedState: includes(authStates, authenticatedState)
         ? authenticatedState // Set the auth state to the string value like `authenticated`.
-        : AUTH_STATES.AMBIGUOUS
+        : AUTH_STATES.AMBIGUOUS,
+      ...(primary !== undefined && { primary })
     };
 
     return normalizedIds;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -39,6 +39,7 @@ export { default as isFunction } from "./isFunction";
 export { default as isInteger } from "./isInteger";
 export { default as isNonEmptyArray } from "./isNonEmptyArray";
 export { default as isNonEmptyString } from "./isNonEmptyString";
+export { default as isNil } from "./isNil";
 export { default as isNumber } from "./isNumber";
 export { default as isObject } from "./isObject";
 export { default as isString } from "./isString";

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -42,6 +42,7 @@ export { default as isNonEmptyString } from "./isNonEmptyString";
 export { default as isNumber } from "./isNumber";
 export { default as isObject } from "./isObject";
 export { default as isString } from "./isString";
+export { default as keys } from "./keys";
 export { default as memoize } from "./memoize";
 export { default as noop } from "./noop";
 export { default as padStart } from "./padStart";

--- a/test/unit/specs/components/Identity/customerIds/createCustomerIds.spec.js
+++ b/test/unit/specs/components/Identity/customerIds/createCustomerIds.spec.js
@@ -14,12 +14,12 @@ describe("Identity::createCustomerIds", () => {
     idsWithHash = {
       Email_LC_SHA256: {
         id: "me@gmail.com",
-        authState: 0,
+        authState: "ambiguous",
         hash: true
       },
       crm: {
         id: "1234",
-        authState: 0
+        authState: "ambiguous"
       }
     };
     cookieJar = {
@@ -62,16 +62,16 @@ describe("Identity::createCustomerIds", () => {
       );
       customerIds.sync(idsWithHash);
       expect(cookieJar.get).toHaveBeenCalledWith(CUSTOMER_ID_HASH);
-      expect(cookieJar.set).toHaveBeenCalledWith(CUSTOMER_ID_HASH, "807ct1");
+      expect(cookieJar.set).toHaveBeenCalledWith(CUSTOMER_ID_HASH, "donhwg");
     });
-    it("should not update checksum if teh same ID passed twice", () => {
+    it("should not update checksum if the same ID passed twice", () => {
       const customerIds = createCustomerIds(
         cookieJar,
         lifecycle,
         network,
         optIn
       );
-      cookieJar.get = jasmine.createSpy().and.returnValue("807ct1");
+      cookieJar.get = jasmine.createSpy().and.returnValue("donhwg");
       customerIds.sync(idsWithHash);
       expect(cookieJar.get).toHaveBeenCalledWith(CUSTOMER_ID_HASH);
       expect(cookieJar.set).not.toHaveBeenCalled();
@@ -119,11 +119,11 @@ describe("Identity::createCustomerIds", () => {
         expect(payload.addIdentity).toHaveBeenCalledWith("Email_LC_SHA256", {
           id:
             "81d1a7135b9722577fb4f094a2004296d6230512d37b68e64b73f050b919f7c4",
-          authState: 0
+          authState: "ambiguous"
         });
         expect(payload.addIdentity).toHaveBeenCalledWith("crm", {
           id: "1234",
-          authState: 0
+          authState: "ambiguous"
         });
         expect(payload.mergeMeta).toHaveBeenCalledWith({
           identity: { customerIdChanged: true }
@@ -131,7 +131,7 @@ describe("Identity::createCustomerIds", () => {
       });
     });
     it("should set right value for customerIdChanged ", () => {
-      cookieJar.get = jasmine.createSpy().and.returnValue("807ct1");
+      cookieJar.get = jasmine.createSpy().and.returnValue("donhwg");
 
       const customerIds = createCustomerIds(
         cookieJar,

--- a/test/unit/specs/components/Identity/customerIds/util.spec.js
+++ b/test/unit/specs/components/Identity/customerIds/util.spec.js
@@ -61,6 +61,30 @@ describe("Identity::identityUtil", () => {
         validateCustomerIds(objToTest);
       }).not.toThrow();
     });
+
+    it("should throw an error when primary is not a boolean", () => {
+      const objToTest = {
+        email: {
+          id: "tester",
+          primary: "wrong type"
+        }
+      };
+      expect(() => {
+        validateCustomerIds(objToTest);
+      }).toThrow();
+    });
+
+    it("should not throw an error when primary is a boolean", () => {
+      const objToTest = {
+        email: {
+          id: "tester",
+          primary: true
+        }
+      };
+      expect(() => {
+        validateCustomerIds(objToTest);
+      }).not.toThrow();
+    });
   });
 
   describe("normalizeCustomerIds", () => {
@@ -104,6 +128,42 @@ describe("Identity::identityUtil", () => {
         },
         crm: {
           id: "1234",
+          authenticatedState: AUTH_STATES.AMBIGUOUS
+        }
+      };
+      expect(normalizeCustomerIds(objToTest)).toEqual(normalizedObj);
+    });
+
+    it("should pass through the primary prop", () => {
+      const objToTest = {
+        email: {
+          id: "tester",
+          authenticatedState: AUTH_STATES.LOGGEDOUT,
+          primary: true
+        },
+        crm: {
+          id: "1234",
+          authenticatedState: AUTH_STATES.AMBIGUOUS
+        },
+        custom: {
+          id: "abc",
+          primary: false
+        }
+      };
+
+      const normalizedObj = {
+        email: {
+          id: "tester",
+          authenticatedState: AUTH_STATES.LOGGEDOUT,
+          primary: true
+        },
+        crm: {
+          id: "1234",
+          authenticatedState: AUTH_STATES.AMBIGUOUS
+        },
+        custom: {
+          id: "abc",
+          primary: false,
           authenticatedState: AUTH_STATES.AMBIGUOUS
         }
       };

--- a/test/unit/specs/components/Identity/customerIds/util.spec.js
+++ b/test/unit/specs/components/Identity/customerIds/util.spec.js
@@ -64,7 +64,7 @@ describe("Identity::identityUtil", () => {
   });
 
   describe("normalizeCustomerIds", () => {
-    it("should add an authState if missing", () => {
+    it("should add an authenticatedState if missing", () => {
       const objToTest = {
         email: {
           id: "tester"
@@ -76,11 +76,11 @@ describe("Identity::identityUtil", () => {
       const normalizedObj = {
         email: {
           id: "tester",
-          authState: AUTH_STATES.UNKNOWN
+          authenticatedState: AUTH_STATES.AMBIGUOUS
         },
         crm: {
           id: "1234",
-          authState: AUTH_STATES.UNKNOWN
+          authenticatedState: AUTH_STATES.AMBIGUOUS
         }
       };
       expect(normalizeCustomerIds(objToTest)).toEqual(normalizedObj);
@@ -90,21 +90,21 @@ describe("Identity::identityUtil", () => {
       const objToTest = {
         email: {
           id: "tester",
-          authState: "login"
+          authenticatedState: "login"
         },
         crm: {
           id: "1234",
-          authState: "logout"
+          authenticatedState: "logout"
         }
       };
       const normalizedObj = {
         email: {
           id: "tester",
-          authState: AUTH_STATES.UNKNOWN
+          authenticatedState: AUTH_STATES.AMBIGUOUS
         },
         crm: {
           id: "1234",
-          authState: AUTH_STATES.UNKNOWN
+          authenticatedState: AUTH_STATES.AMBIGUOUS
         }
       };
       expect(normalizeCustomerIds(objToTest)).toEqual(normalizedObj);


### PR DESCRIPTION
## Description

### 1st change:

We have a new requirement for the integration with AEP: Set a primary ID in your payload/identityMap.

This will be supported in the Config Service as well.

Identity Item schema in XDM already supports this property: [DOC](https://github.com/adobe/xdm/blob/master/docs/reference/context/identity.schema.md#identity-properties)

### 2nd change:

Rename `authState` to `authenticatedState` since that's how XDM defines it: [DOC](https://github.com/adobe/xdm/blob/master/docs/reference/context/identityitem.schema.md#xdmauthenticatedstate)

Per the XDM doc, we also had to change the values from `0, 1, 2` to `ambiguous, authenticated, loggedOut`. This change might require we expose the enum to make it easier for customers to set those values. Thoughts??


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] All tests pass and I've made any necessary test changes.
- [ x ] I have run the Sandbox successfully.
