### PR TITLE
CORE-33754 CORE-35634 Improved persistence of log enablement.

### DIFF
--- a/src/core/buildAndValidateConfig.js
+++ b/src/core/buildAndValidateConfig.js
@@ -27,7 +27,7 @@ export default ({
   });
   config.validate();
   setErrorsEnabled(config.errorsEnabled);
-  setLogEnabled(config.logEnabled, { persist: false, highPriority: false });
+  setLogEnabled(config.logEnabled, { fromConfig: true });
   // toJson is expensive so we short circuit if logging is disabled
   if (logger.enabled) {
     logger.log("Computed configuration:", config.toJSON());

--- a/src/core/buildAndValidateConfig.js
+++ b/src/core/buildAndValidateConfig.js
@@ -10,18 +10,14 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { queryString, stringToBoolean } from "../utils";
-import logQueryParam from "../constants/logQueryParam";
-
 export default ({
   options,
   componentCreators,
   createConfig,
   coreConfigValidators,
-  logCommand,
   logger,
-  setErrorsEnabled,
-  window
+  setLogEnabled,
+  setErrorsEnabled
 }) => {
   const config = createConfig(options);
   config.addValidators(coreConfigValidators);
@@ -31,14 +27,10 @@ export default ({
   });
   config.validate();
   setErrorsEnabled(config.errorsEnabled);
-  const parsedQueryString = queryString.parse(window.location.search);
-  logCommand({
-    enabled:
-      parsedQueryString[logQueryParam] !== undefined
-        ? stringToBoolean(parsedQueryString[logQueryParam])
-        : config.logEnabled
-  });
+  setLogEnabled(config.logEnabled, { persist: false, highPriority: false });
   // toJson is expensive so we short circuit if logging is disabled
-  if (logger.enabled) logger.log("Computed configuration:", config.toJSON());
+  if (logger.enabled) {
+    logger.log("Computed configuration:", config.toJSON());
+  }
   return config;
 };

--- a/src/core/createLogController.js
+++ b/src/core/createLogController.js
@@ -25,27 +25,24 @@ export default ({
   const storage = createNamespacedStorage(`instance.${instanceNamespace}.`);
 
   let logEnabled = storage.session.getItem("log") === "true";
-  let logEnabledSetWithHighPriority = false;
+  let logEnabledWritableFromConfig = true;
 
   const getLogEnabled = () => logEnabled;
-  const setLogEnabled = (value, { persist, highPriority }) => {
-    if (highPriority) {
-      logEnabledSetWithHighPriority = true;
+  const setLogEnabled = (value, { fromConfig }) => {
+    if (!fromConfig || logEnabledWritableFromConfig) {
+      logEnabled = value;
     }
 
-    if (highPriority || !logEnabledSetWithHighPriority) {
+    if (!fromConfig) {
       // Web storage only allows strings, so we explicitly convert to string.
-      if (persist) {
-        storage.session.setItem("log", value.toString());
-      }
-      logEnabled = value;
+      storage.session.setItem("log", value.toString());
+      logEnabledWritableFromConfig = false;
     }
   };
 
   if (parsedQueryString[logQueryParam] !== undefined) {
     setLogEnabled(stringToBoolean(parsedQueryString[logQueryParam]), {
-      persist: true,
-      highPriority: true
+      fromConfig: false
     });
   }
 

--- a/src/core/createLogger.js
+++ b/src/core/createLogger.js
@@ -10,16 +10,16 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const createLogger = (console, logController, prefix) => {
+export default (console, getLogEnabled, prefix) => {
   const process = (level, ...rest) => {
-    if (logController.logEnabled) {
+    if (getLogEnabled()) {
       console[level](prefix, ...rest);
     }
   };
 
   return {
     get enabled() {
-      return logController.logEnabled;
+      return getLogEnabled();
     },
     /**
      * Outputs a message to the web console.
@@ -42,19 +42,10 @@ const createLogger = (console, logController, prefix) => {
      * Outputs an error message to the web console.
      * @param {...*} arg Any argument to be logged.
      */
-    error: process.bind(null, "error"),
+    error: process.bind(null, "error")
     /**
      * Creates a new logger with an additional prefix.
      * @param {String} additionalPrefix
      */
-    spawn(additionalPrefix) {
-      return createLogger(
-        console,
-        logController,
-        `${prefix} ${additionalPrefix}`
-      );
-    }
   };
 };
-
-export default createLogger;

--- a/src/core/handleErrorFactory.js
+++ b/src/core/handleErrorFactory.js
@@ -12,9 +12,9 @@ governing permissions and limitations under the License.
 
 import { toError } from "../utils";
 
-export default ({ namespace, getErrorsEnabled, logger }) => error => {
+export default ({ instanceNamespace, getErrorsEnabled, logger }) => error => {
   const err = toError(error);
-  err.message = `[${namespace}] ${err.message}`;
+  err.message = `[${instanceNamespace}] ${err.message}`;
   if (getErrorsEnabled()) {
     throw err;
   } else {

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -82,10 +82,7 @@ if (instanceNamespaces) {
     };
 
     const logCommand = options => {
-      setLogEnabled(options.enabled, {
-        persist: true,
-        highPriority: true
-      });
+      setLogEnabled(options.enabled, { fromConfig: false });
     };
 
     const configureCommand = options => {

--- a/src/core/tools/loggerToolFactory.js
+++ b/src/core/tools/loggerToolFactory.js
@@ -13,6 +13,6 @@ governing permissions and limitations under the License.
 /**
  * Tool-specific dependencies => config => componentCreator => result
  */
-export default logger => () => componentCreator => {
-  return logger.spawn(`[${componentCreator.namespace}]`);
+export default createComponentLogger => () => componentCreator => {
+  return createComponentLogger(componentCreator.namespace);
 };

--- a/test/unit/specs/core/buildAndValidateConfig.spec.js
+++ b/test/unit/specs/core/buildAndValidateConfig.spec.js
@@ -87,7 +87,7 @@ describe("buildAndValidateConfig", () => {
     expect(setErrorsEnabled).toHaveBeenCalledWith(true);
   });
 
-  it("calls log command based on config", () => {
+  it("sets log enabled based on config", () => {
     config.logEnabled = true;
     buildAndValidateConfig({
       options,
@@ -98,10 +98,7 @@ describe("buildAndValidateConfig", () => {
       setLogEnabled,
       setErrorsEnabled
     });
-    expect(setLogEnabled).toHaveBeenCalledWith(true, {
-      persist: false,
-      highPriority: false
-    });
+    expect(setLogEnabled).toHaveBeenCalledWith(true, { fromConfig: true });
   });
 
   it("logs and returns computed configuration", () => {

--- a/test/unit/specs/core/buildAndValidateConfig.spec.js
+++ b/test/unit/specs/core/buildAndValidateConfig.spec.js
@@ -18,10 +18,9 @@ describe("buildAndValidateConfig", () => {
   let config;
   let createConfig;
   let coreConfigValidators;
-  let logCommand;
   let logger;
+  let setLogEnabled;
   let setErrorsEnabled;
-  let window;
 
   beforeEach(() => {
     options = {};
@@ -48,17 +47,12 @@ describe("buildAndValidateConfig", () => {
         defaultValue: true
       }
     };
-    logCommand = jasmine.createSpy();
     logger = {
       enabled: false,
       log: jasmine.createSpy()
     };
+    setLogEnabled = jasmine.createSpy();
     setErrorsEnabled = jasmine.createSpy();
-    window = {
-      location: {
-        search: ""
-      }
-    };
   });
 
   it("adds validators and validates options", () => {
@@ -67,10 +61,9 @@ describe("buildAndValidateConfig", () => {
       componentCreators,
       createConfig,
       coreConfigValidators,
-      logCommand,
       logger,
-      setErrorsEnabled,
-      window
+      setLogEnabled,
+      setErrorsEnabled
     });
     expect(createConfig).toHaveBeenCalledWith(options);
     expect(config.addValidators).toHaveBeenCalledWith(coreConfigValidators);
@@ -87,10 +80,9 @@ describe("buildAndValidateConfig", () => {
       componentCreators,
       createConfig,
       configValidators: coreConfigValidators,
-      logCommand,
       logger,
-      setErrorsEnabled,
-      window
+      setLogEnabled,
+      setErrorsEnabled
     });
     expect(setErrorsEnabled).toHaveBeenCalledWith(true);
   });
@@ -102,31 +94,13 @@ describe("buildAndValidateConfig", () => {
       componentCreators,
       createConfig,
       configValidators: coreConfigValidators,
-      logCommand,
       logger,
-      setErrorsEnabled,
-      window
+      setLogEnabled,
+      setErrorsEnabled
     });
-    expect(logCommand).toHaveBeenCalledWith({
-      enabled: true
-    });
-  });
-
-  it("calls log command based on querystring (and takes priority over config)", () => {
-    config.logEnabled = false;
-    window.location.search = "?alloy_log=true";
-    buildAndValidateConfig({
-      options,
-      componentCreators,
-      createConfig,
-      configValidators: coreConfigValidators,
-      logCommand,
-      logger,
-      setErrorsEnabled,
-      window
-    });
-    expect(logCommand).toHaveBeenCalledWith({
-      enabled: true
+    expect(setLogEnabled).toHaveBeenCalledWith(true, {
+      persist: false,
+      highPriority: false
     });
   });
 
@@ -138,10 +112,9 @@ describe("buildAndValidateConfig", () => {
       componentCreators,
       createConfig,
       configValidators: coreConfigValidators,
-      logCommand,
       logger,
-      setErrorsEnabled,
-      window
+      setLogEnabled,
+      setErrorsEnabled
     });
     expect(logger.log).toHaveBeenCalledWith("Computed configuration:", {
       foo: "bar"
@@ -154,10 +127,9 @@ describe("buildAndValidateConfig", () => {
       componentCreators,
       createConfig,
       configValidators: coreConfigValidators,
-      logCommand,
       logger,
-      setErrorsEnabled,
-      window
+      setLogEnabled,
+      setErrorsEnabled
     });
     expect(result).toBe(config);
   });

--- a/test/unit/specs/core/createLogger.spec.js
+++ b/test/unit/specs/core/createLogger.spec.js
@@ -14,50 +14,32 @@ import createLogger from "../../../../src/core/createLogger";
 
 const logMethods = ["log", "info", "warn", "error"];
 const prefix = "testprefix";
-const spawnPrefix = "testspawnprefix";
 const message = "test message";
 
 describe("createLogger", () => {
   let console;
-  let logController;
+  let logEnabled = false;
   let logger;
 
   beforeEach(() => {
     console = jasmine.createSpyObj("console", logMethods);
-    logController = {};
-    logger = createLogger(console, logController, prefix);
+    const getLogEnabled = () => logEnabled;
+    logger = createLogger(console, getLogEnabled, prefix);
   });
 
-  const testLogMethods = expectedPrefix => {
-    logMethods.forEach(logMethod => {
-      it(`logs message if debugging is enabled and ${logMethod} is called`, () => {
-        logController.logEnabled = true;
-        logger[logMethod](message);
+  logMethods.forEach(logMethod => {
+    it(`logs message if debugging is enabled and ${logMethod} is called`, () => {
+      logEnabled = true;
+      logger[logMethod](message);
 
-        expect(console[logMethod]).toHaveBeenCalledWith(
-          expectedPrefix,
-          message
-        );
-      });
-
-      it(`does not log a message if debugging is disabled and ${logMethod} is called`, () => {
-        logController.logEnabled = false;
-        logger[logMethod](message);
-
-        expect(console[logMethod]).not.toHaveBeenCalled();
-      });
-    });
-  };
-
-  describe("with top-level logger", () => {
-    testLogMethods(prefix);
-  });
-
-  describe("with spawned logger", () => {
-    beforeEach(() => {
-      logger = logger.spawn(spawnPrefix);
+      expect(console[logMethod]).toHaveBeenCalledWith(prefix, message);
     });
 
-    testLogMethods(`${prefix} ${spawnPrefix}`);
+    it(`does not log a message if debugging is disabled and ${logMethod} is called`, () => {
+      logEnabled = false;
+      logger[logMethod](message);
+
+      expect(console[logMethod]).not.toHaveBeenCalled();
+    });
   });
 });

--- a/test/unit/specs/core/handleErrorFactory.spec.js
+++ b/test/unit/specs/core/handleErrorFactory.spec.js
@@ -15,7 +15,7 @@ import handleErrorFactory from "../../../../src/core/handleErrorFactory";
 describe("handleErrorFactory", () => {
   it("converts non-error to error and throws", () => {
     const handleError = handleErrorFactory({
-      namespace: "testnamespace",
+      instanceNamespace: "testinstanceNamespace",
       getErrorsEnabled() {
         return true;
       }
@@ -23,12 +23,12 @@ describe("handleErrorFactory", () => {
 
     expect(() => {
       handleError("Bad thing happened.");
-    }).toThrowError("[testnamespace] Bad thing happened.");
+    }).toThrowError("[testinstanceNamespace] Bad thing happened.");
   });
 
-  it("rethrows error with namespace prepended", () => {
+  it("rethrows error with instanceNamespace prepended", () => {
     const handleError = handleErrorFactory({
-      namespace: "testnamespace",
+      instanceNamespace: "testinstanceNamespace",
       getErrorsEnabled() {
         return true;
       }
@@ -36,13 +36,13 @@ describe("handleErrorFactory", () => {
 
     expect(() => {
       handleError(new Error("Bad thing happened."));
-    }).toThrowError("[testnamespace] Bad thing happened.");
+    }).toThrowError("[testinstanceNamespace] Bad thing happened.");
   });
 
   it("logs error instead of throwing if errors are not enabled", () => {
     const logger = jasmine.createSpyObj("logger", ["error"]);
     const handleError = handleErrorFactory({
-      namespace: "testnamespace",
+      instanceNamespace: "testinstanceNamespace",
       getErrorsEnabled() {
         return false;
       },

--- a/test/unit/specs/core/tools/loggerToolFactory.spec.js
+++ b/test/unit/specs/core/tools/loggerToolFactory.spec.js
@@ -14,15 +14,15 @@ import loggerToolFactory from "../../../../../src/core/tools/loggerToolFactory";
 
 describe("loggerToolFactory", () => {
   it("returns logger tool", () => {
-    const spawnedLogger = {};
-    const logger = {
-      spawn: jasmine.createSpy().and.returnValue(spawnedLogger)
-    };
+    const componentLogger = {};
+    const createComponentLogger = jasmine
+      .createSpy()
+      .and.returnValue(componentLogger);
     const componentCreator = {
       namespace: "testnamespace"
     };
-    const tool = loggerToolFactory(logger)()(componentCreator);
-    expect(logger.spawn).toHaveBeenCalledWith("[testnamespace]");
-    expect(tool).toBe(spawnedLogger);
+    const tool = loggerToolFactory(createComponentLogger)()(componentCreator);
+    expect(createComponentLogger).toHaveBeenCalledWith("testnamespace");
+    expect(tool).toBe(componentLogger);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Right now, there are three ways of turning on logging:

(1) Through the logEnabled option during configuration.
(2) Using the log command.
(3) Setting the alloy_log querystring parameter.

For all scenarios, if logging is enabled, it stays enabled until you explicitly set it to false. I've found behavior to be awkward in scenario #1. If I set logEnabled to true in configuration, and then I remove the logEnabled option, I expect logging to turn off, but right now it stays on until I set logEnabled: false.

I brought this up with the alpha testers and I agree with the feedback we received, that is, if logEnabled: true in configuration, logging should be enabled. If logEnabled is set to false or removed entirely from configuration, logging should be turned off.

If logging is enabled by using the log command or the alloy_log querystring parameter, logging should stay on for the session (right now we're using local storage, so we should switch to session storage) or until the user explicitly runs the log command with enabled: false or sets the alloy_log querystring parameter value to false.

The log command and the alloy_log querystring parameter should always trump the logEnabled configuration option.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-33754
https://jira.corp.adobe.com/browse/CORE-35634
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
More predictable behavior when toggling logging.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I'll queue up a PR right now -> I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
