### PR TITLE
Fix setCustomerIds promise chain and tests.

### DIFF
--- a/src/components/Identity/customerIds/createCustomerIds.js
+++ b/src/components/Identity/customerIds/createCustomerIds.js
@@ -82,7 +82,7 @@ export default (cookieJar, lifecycle, network, optIn) => {
 
       return hash(originalIds, normalizedIds).then(hashedIds => {
         setState(customerIdChanged, hashedIds);
-        lifecycle
+        return lifecycle
           .onBeforeEvent({
             event,
             options: {},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When working on https://github.com/adobe/alloy/pull/239, I was testing whether the error message would be successfully appended with the message about how to suppress errors. I happened to add `throw new Error("foo")` right before [this line](https://github.com/adobe/alloy/blob/1666324ac0790190f080efe0c948890c06be5b9a/src/components/Identity/index.js#L90) inside `onBeforeDataCollection` in the Identity component. What I discovered is that when using the `setCustomerIds` command, the promise returned from `sync()` inside `createCustomerIds.js` wasn't incorporating the lifecycle promise chain. Because of this, any errors thrown during those asynchronous processes (e.g., `lifecycle.onBeforeEvent`, `lifecycle.onBeforeDataCollection`, `network.sendRequest`) weren't being handled by our global handler. This meant that such errors weren't being properly suppressed by `errorsEnabled: false` or being given additional context like other errors in Alloy are. It also meant the promise being returned from the command was being resolved before the customer IDs were fully synced with the server.

While I was fixing that, I noticed that some of the tests weren't returning promises when they were supposed to, which meant Jasmine was considering the tests as passed before the promises resolved. Tests were succeeding when really they should have been failing. I fixed those as well.


<!--- Describe your changes in detail -->

## Related Issue
None
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Predictable and consistent behavior.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the Sandbox successfully.
