### PR TITLE
Replace the @ sign with _ in ORG ID.

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -57,8 +57,6 @@
         viewStart: true,
         xdm: {
           _myorg: {
-            // Using a promise to demonstrate they are supported.
-            type: Promise.resolve("page-view"),
             url: location.href,
             name: location.pathname.substring(1) || "home"
           },

--- a/src/core/tools/cookieJarToolFactory.js
+++ b/src/core/tools/cookieJarToolFactory.js
@@ -22,6 +22,8 @@ export default (
   createComponentNamespacedCookieJar,
   getTopLevelDomain
 ) => config => {
+  // Due to some security software flagging the `@` sign in the ORG ID
+  // as a security vulnerability, we are replacing it with an `_`.
   const cookieName = `${ALLOY_COOKIE_NAME}_${config.imsOrgId.replace(
     "@",
     "_"

--- a/src/core/tools/cookieJarToolFactory.js
+++ b/src/core/tools/cookieJarToolFactory.js
@@ -22,7 +22,10 @@ export default (
   createComponentNamespacedCookieJar,
   getTopLevelDomain
 ) => config => {
-  const cookieName = `${ALLOY_COOKIE_NAME}_${config.imsOrgId}`;
+  const cookieName = `${ALLOY_COOKIE_NAME}_${config.imsOrgId.replace(
+    "@",
+    "_"
+  )}`;
   const cookieProxy = createCookieProxy(
     cookieName,
     ALLOY_COOKIE_TTL_IN_DAYS,


### PR DESCRIPTION
## Description

Some security software has been flagging the `@` sign in the ORG ID that is being used as part of the Alloy cookie name, as a security vulnerability.

We worked with the ORG ID folks and learned that it is very unlikely that they would add a `_` sign the ID, so we are replacing the `@` with `_`.

## Related Issue

https://jira.corp.adobe.com/browse/CORE-35787


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [ x ] I have made any necessary test changes and all tests pass.
- [ x ] I have run the Sandbox successfully.
