### PR TITLE
Adding edgeBasePath as a configurable setting

### DIFF
--- a/src/components/DataCollector/createConfigValidators.js
+++ b/src/components/DataCollector/createConfigValidators.js
@@ -21,6 +21,10 @@ export default () => {
       defaultValue: "beta.adobedc.net",
       validate: string().domain()
     },
+    edgeBasePath: {
+      defaultValue: "ee",
+      validate: string()
+    },
     imsOrgId: {
       validate: string().unique()
     }

--- a/src/core/network/createNetwork.js
+++ b/src/core/network/createNetwork.js
@@ -14,7 +14,6 @@ import createPayload from "./createPayload";
 import createResponse from "./createResponse";
 import { executeWithRetry, stackError, uuid } from "../../utils";
 import apiVersion from "../../constants/apiVersion";
-import edgeBasePath from "../../constants/edgeBasePath";
 
 export default ({ config, logger, lifecycle, networkStrategy }) => {
   const handleResponse = (requestId, responseBody) => {
@@ -35,7 +34,7 @@ export default ({ config, logger, lifecycle, networkStrategy }) => {
     return lifecycle.onResponse({ response, requestId }).then(() => response);
   };
 
-  const { edgeDomain, configId } = config;
+  const { edgeDomain, edgeBasePath, configId } = config;
 
   return {
     /**

--- a/test/unit/specs/components/DataCollector/createConfigValidators.spec.js
+++ b/test/unit/specs/components/DataCollector/createConfigValidators.spec.js
@@ -51,6 +51,10 @@ describe("DataCollector::createConfigValidators", () => {
       configId: "myproperty1",
       edgeDomain: "stats firstparty.com",
       prehidingStyle: ""
+    },
+    {
+      configId: "myproperty1",
+      edgeBasePath: 123
     }
   ].forEach((cfg, i) => {
     it(`invalidates configuration (${i})`, () => {

--- a/test/unit/specs/core/network/createNetwork.spec.js
+++ b/test/unit/specs/core/network/createNetwork.spec.js
@@ -15,6 +15,7 @@ import createNetwork from "../../../../../src/core/network/createNetwork";
 describe("createNetwork", () => {
   const config = {
     edgeDomain: "alloy.mysite.com",
+    edgeBasePath: "ee",
     configId: "myconfigId"
   };
 
@@ -90,6 +91,25 @@ describe("createNetwork", () => {
           true
         );
       });
+  });
+
+  it("supports custom edgeBasePath settings", () => {
+    const { edgeDomain, configId } = config;
+    network = createNetwork({
+      config: { edgeDomain, configId, edgeBasePath: "ee-beta-1" },
+      logger,
+      lifecycle,
+      networkStrategy
+    });
+    return network.sendRequest({}, { documentUnloading: true }).then(() => {
+      expect(networkStrategy).toHaveBeenCalledWith(
+        jasmine.stringMatching(
+          /^https:\/\/alloy\.mysite\.com\/ee-beta-1\/v1\/collect\?configId=myconfigId&requestId=[0-9a-f-]+$/
+        ),
+        "{}",
+        true
+      );
+    });
   });
 
   it("sends the payload", () => {


### PR DESCRIPTION
Adding edgeBasePath as a configurable setting

## Description

Surfacing edgeBasePath as a configurable setting with a default value of 'ee'.

## Related Issue

CORE-37156

## Motivation and Context

Making the setting configurable enables it to be used to control access to future alpha or beta environments.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
