### PR TITLE
Remove environment from implementationDetails

### DIFF
--- a/src/components/Context/implementationDetailsFactory.js
+++ b/src/components/Context/implementationDetailsFactory.js
@@ -15,8 +15,7 @@ export default version => {
   return xdm => {
     const implementationDetails = {
       name: "https://ns.adobe.com/experience/alloy",
-      version,
-      environment: "web"
+      version
     };
     deepAssign(xdm, { implementationDetails });
   };

--- a/test/unit/specs/components/Context/implementationDetailsFactory.spec.js
+++ b/test/unit/specs/components/Context/implementationDetailsFactory.spec.js
@@ -21,8 +21,7 @@ describe("Context::implementationDetails", () => {
     expect(xdm).toEqual({
       implementationDetails: {
         name: "https://ns.adobe.com/experience/alloy",
-        version: "1.2.3",
-        environment: "web"
+        version: "1.2.3"
       }
     });
   });


### PR DESCRIPTION
## Description

I was mistaken when creating the PR for xdm.  I thought that implementationDetails allowed extra fields, but after the PR was merged we still got errors from Platform that the xdm didn't match the schema.  I'm removing the environment key here until I can get a PR merged in XDM to add the field.

## Related Issue

https://jira.corp.adobe.com/browse/CORE-31964

## Motivation and Context

The environment field will have things like [mobile|web|server|iot]

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
