### PR TITLE
Support dataset, schema ids and debug.

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -60,7 +60,11 @@
           if (urlSearchParams.has("campaign")) {
             data.campaign = urlSearchParams.get("campaign");
           }
-        }
+        },
+        debug: true,
+        datasetId: "5db865ad86c04218a91f2185",
+        schemaId:
+          "https://ns.adobe.com/atag/schemas/ec93478f46500c25dc13dc1141091fdb"
       });
 
       alloy("event", {

--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -74,25 +74,19 @@
           device: {
             screenHeight: 1
           }
-        },
-        data: {
-          nonXdmKey: "nonXdmValue",
-          // The following prop is a trait set in Audience Manager to
-          // return destinations.
-          name: "home"
         }
       }).then(function(data) {
         console.log("Sandbox: View start event has completed.", data);
       });
 
       alloy("setCustomerIds", {
-        emailHash: {
+        Email_LC_SHA256: {
           id: "me@gmail.com",
           authenticatedState: "ambiguous",
           hash: true, //TODO: document customer ID hashing syntax
           primary: true
         },
-        crm: {
+        HYP: {
           id: "1234",
           authenticatedState: "ambiguous"
         }

--- a/sandbox/src/Home.js
+++ b/sandbox/src/Home.js
@@ -20,29 +20,6 @@ function HomeWithHistory({ history }) {
     previousPath = loc.pathname;
   });
 
-  const visitDoc = ev => {
-    window.alloy("event", {
-      xdm: {
-        eventType: "visit-doc",
-        "activitystreams:href": ev.target.href,
-        "activitystreams:name": ev.target.name,
-        "activitystreams:mediaType": "text/html"
-      }
-    });
-  };
-
-  const copyBaseCode = ev => {
-    window.alloy("event", {
-      xdm: {
-        eventType: "copy-base-code",
-        "activitystreams:href":
-          "https://launch.gitbook.io/adobe-experience-platform-web-sdk/",
-        "activitystreams:name": "copyBaseCode",
-        "activitystreams:mediaType": "text/html"
-      }
-    });
-  };
-
   const makeOptInCommand = purposes => () => {
     window
       .alloy("optIn", {
@@ -71,88 +48,27 @@ function HomeWithHistory({ history }) {
           <span role="img" aria-label="">
             👆
           </span>{" "}
-          if you collect:
-          <pre>{JSON.stringify({ data: { nonXdmKey: "nonXdmValue" } })}</pre>
+          <br></br>
+          if you qualify for the <strong>`Shopping Cart Visitor`</strong>{" "}
+          Segment. (ID: 16754409):
         </div>
       </section>
 
       <section>
         <div>
-          <h1>Getting Started with Alloy</h1>
-          <h3>Installation</h3>
-          <p>
-            The first step in implemented the Adobe Experience Platform SDK is
-            to copy and paste the following "base code" as high as possible in
-            the head tag of your HTML:
-          </p>
-          <pre>
-            <code>
-              {`
-                <script>
-                  !function(n,o){o.forEach(function(o){n[o]||((n.__alloyNS=n.__alloyNS||
-                  []).push(o),n[o]=function(){var u=arguments;return new Promise(
-                  function(i,l){n[o].q.push([i,l,u])})},n[o].q=[])})}
-                  (window,["alloy"]);
-                </script>
-                <script src="alloy.js" async></script>
-              `}
-            </code>
-          </pre>
-          <button onClick={copyBaseCode}>Copy Base Code</button>
-
-          <p>
-            The base code, by default, creates a global function named alloy.
-            You will use this function to interact with the SDK. If you would
-            like to name the global function something else, you may change the
-            alloy name as follows:
-          </p>
-          <pre>
-            <code>
-              {`
-                <script>
-                  !function(n,o){o.forEach(function(o){n[o]||((n.__alloyNS=n.__alloyNS||
-                  []).push(o),n[o]=function(){var u=arguments;return new Promise(
-                  function(i,l){n[o].q.push([i,l,u])})},n[o].q=[])})}
-                  (window,["mycustomname"]);
-                </script>
-                <script src="alloy.js" async></script>
-              `}
-            </code>
-          </pre>
-          <p>
-            With this change made, the global function would be named
-            mycustomname instead of alloy. This base code, in addition to
-            creating a global function, also loads additional code contained{" "}
-            <br />
-            within an external file (alloy.js) hosted on a server. By default,
-            this code is loaded asynchronously to allow your webpage to be as
-            performant as possible. This is the recommended implementation.
-          </p>
-          <a
-            href="https://launch.gitbook.io/adobe-experience-platform-web-sdk/"
-            onClick={visitDoc}
-            name="Alloy Public Documentation"
-          >
-            Read full documentation
-          </a>
-
+          <h2>Opt-In</h2>
+          <p>To test Opt-In on load, set the `optInEnabled` config to true.</p>
           <div>
-            <h2>Opt-In</h2>
-            <p>
-              To test Opt-In on load, set the `optInEnabled` config to true.
-            </p>
-            <div>
-              <button onClick={makeOptInCommand("all")}>
-                OptIn to all purposes
-              </button>
-              <span>should trigger queued up commands.</span>
-            </div>
-            <div>
-              <button onClick={makeOptInCommand("none")}>
-                OptIn to no purposes
-              </button>
-              <span>should stop most commands and throw an error.</span>
-            </div>
+            <button onClick={makeOptInCommand("all")}>
+              OptIn to all purposes
+            </button>
+            <span>should trigger queued up commands.</span>
+          </div>
+          <div>
+            <button onClick={makeOptInCommand("none")}>
+              OptIn to no purposes
+            </button>
+            <span>should stop most commands and throw an error.</span>
           </div>
         </div>
       </section>

--- a/src/core/createConfigValidators.js
+++ b/src/core/createConfigValidators.js
@@ -38,5 +38,17 @@ export default () => ({
   onBeforeEventSend: {
     defaultValue: () => undefined,
     validate: callback()
+  },
+  datasetId: {
+    defaultValue: undefined,
+    validate: string().nonEmpty()
+  },
+  schemaId: {
+    defaultValue: undefined,
+    validate: string().nonEmpty()
+  },
+  debug: {
+    defaultValue: false,
+    validate: boolean()
   }
 });

--- a/src/utils/assignIf.js
+++ b/src/utils/assignIf.js
@@ -1,0 +1,21 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import assign from "./assign";
+
+export default (target, source, predicate) => {
+  if (predicate()) {
+    assign(target, source);
+  }
+
+  return target;
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -14,6 +14,7 @@ governing permissions and limitations under the License.
 
 // Please keep in alphabetical order.
 export { default as assign } from "./assign";
+export { default as assignIf } from "./assignIf";
 export { default as clone } from "./clone";
 export { default as convertBufferToHex } from "./convertBufferToHex";
 export {

--- a/test/unit/specs/core/createEventManager.spec.js
+++ b/test/unit/specs/core/createEventManager.spec.js
@@ -24,7 +24,6 @@ describe("createEventManager", () => {
   let eventManager;
   let logger;
   let lastChanceCallback;
-  let createEvent;
   beforeEach(() => {
     event = {
       mergeXdm() {},
@@ -34,7 +33,7 @@ describe("createEventManager", () => {
       isDocumentUnloading: () => false,
       applyCallback: jasmine.createSpy()
     };
-    createEvent = jasmine.createSpy().and.returnValue(event);
+    const createEvent = jasmine.createSpy().and.returnValue(event);
     lifecycle = {
       onBeforeEvent: jasmine.createSpy().and.returnValue(Promise.resolve()),
       onBeforeDataCollection: jasmine
@@ -59,7 +58,9 @@ describe("createEventManager", () => {
     config = {
       imsOrgId: "ABC123",
       onBeforeEventSend: jasmine.createSpy(),
-      debug: true
+      debug: true,
+      datasetId: "DATASETID",
+      schemaId: "SCHEMAID"
     };
     logger = {
       error: jasmine.createSpy()
@@ -83,36 +84,6 @@ describe("createEventManager", () => {
   describe("sendEvent", () => {
     it("creates the payload and adds event and meta", () => {
       return eventManager.sendEvent(event).then(() => {
-        expect(payload.addEvent).toHaveBeenCalledWith(event);
-        expect(payload.mergeMeta).toHaveBeenCalledWith({
-          gateway: {
-            imsOrgId: "ABC123"
-          },
-          collect: {
-            synchronousValidation: true
-          }
-        });
-      });
-    });
-
-    it("adds datasetId and schemaId to meta if set in config", () => {
-      const configWithDatasetAndSchema = {
-        imsOrgId: "ABC123",
-        onBeforeEventSend: jasmine.createSpy(),
-        debug: true,
-        datasetId: "DATASETID",
-        schemaId: "SCHEMAID"
-      };
-
-      const eventManagerWithCollectInMeta = createEventManager({
-        createEvent,
-        optIn,
-        lifecycle,
-        network,
-        configWithDatasetAndSchema,
-        logger
-      });
-      return eventManagerWithCollectInMeta.sendEvent(event).then(() => {
         expect(payload.addEvent).toHaveBeenCalledWith(event);
         expect(payload.mergeMeta).toHaveBeenCalledWith({
           gateway: {

--- a/test/unit/specs/core/createEventManager.spec.js
+++ b/test/unit/specs/core/createEventManager.spec.js
@@ -24,6 +24,7 @@ describe("createEventManager", () => {
   let eventManager;
   let logger;
   let lastChanceCallback;
+  let createEvent;
   beforeEach(() => {
     event = {
       mergeXdm() {},
@@ -33,7 +34,7 @@ describe("createEventManager", () => {
       isDocumentUnloading: () => false,
       applyCallback: jasmine.createSpy()
     };
-    const createEvent = jasmine.createSpy().and.returnValue(event);
+    createEvent = jasmine.createSpy().and.returnValue(event);
     lifecycle = {
       onBeforeEvent: jasmine.createSpy().and.returnValue(Promise.resolve()),
       onBeforeDataCollection: jasmine
@@ -57,7 +58,8 @@ describe("createEventManager", () => {
     };
     config = {
       imsOrgId: "ABC123",
-      onBeforeEventSend: jasmine.createSpy()
+      onBeforeEventSend: jasmine.createSpy(),
+      debug: true
     };
     logger = {
       error: jasmine.createSpy()
@@ -88,6 +90,38 @@ describe("createEventManager", () => {
           },
           collect: {
             synchronousValidation: true
+          }
+        });
+      });
+    });
+
+    it("adds datasetId and schemaId to meta if set in config", () => {
+      const configWithDatasetAndSchema = {
+        imsOrgId: "ABC123",
+        onBeforeEventSend: jasmine.createSpy(),
+        debug: true,
+        datasetId: "DATASETID",
+        schemaId: "SCHEMAID"
+      };
+
+      const eventManagerWithCollectInMeta = createEventManager({
+        createEvent,
+        optIn,
+        lifecycle,
+        network,
+        configWithDatasetAndSchema,
+        logger
+      });
+      return eventManagerWithCollectInMeta.sendEvent(event).then(() => {
+        expect(payload.addEvent).toHaveBeenCalledWith(event);
+        expect(payload.mergeMeta).toHaveBeenCalledWith({
+          gateway: {
+            imsOrgId: "ABC123"
+          },
+          collect: {
+            synchronousValidation: true,
+            datasetId: "DATASETID",
+            schemaId: "SCHEMAID"
           }
         });
       });


### PR DESCRIPTION
## Description

- Support overriding `datasetId` and `schemaId` that are usually provided in the Config Service.
- Support setting a `debug: boolean` config. This config might enable other features in the future, but we start by enabling `synchronous validation` of the `xdm` payload. Once set to true, and there's an error in your `xdm` data, you will see a `collect:error` handle in the response, with an error message explaining which part of your schema was invalid.

Documentation + Launch extension changes are coming soon.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ X ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [ X ] I have made any necessary test changes and all tests pass.
- [ X ] I have run the Sandbox successfully.
