### PR TITLE
Removing element parameter from selectNodesWithEq() method, to avoid …confusion and incorrect usage

### DIFF
--- a/src/components/Personalization/helper/dom/matchesSelectorWithEq.js
+++ b/src/components/Personalization/helper/dom/matchesSelectorWithEq.js
@@ -21,7 +21,7 @@ export default (selector, element) => {
 
   // Using node selection vs matches selector, because of :eq()
   // Find all nodes using document as context
-  const nodes = selectNodesWithEq(selector, document);
+  const nodes = selectNodesWithEq(selector);
   let result = false;
 
   // Iterate through all the identified elements

--- a/src/components/Personalization/helper/dom/selectNodesWithEq.js
+++ b/src/components/Personalization/helper/dom/selectNodesWithEq.js
@@ -57,10 +57,11 @@ export const parseSelector = rawSelector => {
 /**
  * Returns an array of matched DOM nodes.
  * @param {String} selector that contains Sizzle "eq(...)" pseudo selector
- * @param {Node} doc, defaults to document
  * @returns {Array} an array of DOM nodes
  */
-export const selectNodesWithEq = (selector, doc = document) => {
+export const selectNodesWithEq = selector => {
+  const doc = document;
+
   if (isNotEqSelector(selector)) {
     return selectNodes(selector, doc);
   }


### PR DESCRIPTION
Select nodes with EQ bug fix.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Select nodes with EQ bug fix

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

NONE

## Motivation and Context
Select nodes with EQ bug fix

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
