### PR TITLE
Reset the head on the Sandbox prior to pulling

### DIFF
--- a/scripts/deploy_sandbox.sh
+++ b/scripts/deploy_sandbox.sh
@@ -1,1 +1,1 @@
-ssh -t mowla@20.186.4.13 "cd /var/www/alloyio.com && git pull origin master && npm i && npm run build:prod && npm run sandbox:install && npm run sandbox:build && cp /var/www/alloyio.com/dist/standalone/alloy.js /var/www/alloyio.com/sandbox/build"
+ssh -t mowla@20.186.4.13 "cd /var/www/alloyio.com && git reset HEAD --hard && git pull origin master && npm i && npm run build:prod && npm run sandbox:install && npm run sandbox:build && cp /var/www/alloyio.com/dist/standalone/alloy.js /var/www/alloyio.com/sandbox/build"


### PR DESCRIPTION
The generated package-lock file on the VM is preventing the Travis deploy script from pulling the latest from master. Fixing it by resetting the head prior to pulling. 