### PR TITLE
CORE-37168 Added support for identification via 3rd-party domain

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -15,7 +15,7 @@
             script-src 'self' 'unsafe-inline' assets.adobedtm.com cdn.tt.omtrdc.net;
             style-src 'self' 'unsafe-inline' cdn.tt.omtrdc.net;
             img-src * data:;
-            connect-src 'self' unifiedjslab.tt.omtrdc.net *.demdex.net http://localhost:8080 https://alpha.konductor.adobedc.net https://beta.adobedc.net https://edgegateway.azurewebsites.net konductor-qe.apps-exp-edge-npe-va6.experience-edge.adobeinternal.net"
+            connect-src 'self' ws://localhost:3000 http://localhost:8080 unifiedjslab.tt.omtrdc.net *.demdex.net https://alpha.konductor.adobedc.net https://beta.adobedc.net https://edgegateway.azurewebsites.net konductor-qe.apps-exp-edge-npe-va6.experience-edge.adobeinternal.net"
     />
 
     <title>Mock website hosting Alloy</title>
@@ -40,6 +40,15 @@
     <script src="alloy.js" async></script>
 
     <script>
+      function getUrlParameter(name) {
+        name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+        var regex = new RegExp("[\\?&]" + name + "=([^&#]*)");
+        var results = regex.exec(location.search);
+        return results === null
+          ? ""
+          : decodeURIComponent(results[1].replace(/\+/g, " "));
+      }
+
       alloy("configure", {
         // edgeDomain: "ENTER YOUR COLLECTION CNAME IF AVAILABLE",
         // optInEnabled: true,
@@ -52,13 +61,16 @@
         prehidingStyle: ".personalization-container { opacity: 0 !important }",
         idSyncContainerId: 81,
         migrateIds: true,
-        onBeforeEventSend({ xdm, data }) {
-          const urlSearchParams = new URLSearchParams(window.location.search);
-          if (urlSearchParams.has("title")) {
-            xdm.web.webPageDetails.name = urlSearchParams.get("title");
+        onBeforeEventSend: function(options) {
+          const xdm = options.xdm;
+          const data = options.data;
+          const titleParam = getUrlParameter("title");
+          if (titleParam) {
+            xdm.web.webPageDetails.name = titleParam;
           }
-          if (urlSearchParams.has("campaign")) {
-            data.campaign = urlSearchParams.get("campaign");
+          const campaignParam = getUrlParameter("title");
+          if (campaignParam) {
+            data.campaign = campaignParam;
           }
         },
         debug: true,

--- a/src/components/Identity/createComponent.js
+++ b/src/components/Identity/createComponent.js
@@ -2,6 +2,7 @@ import createCustomerIds from "./customerIds/createCustomerIds";
 import { defer } from "../../utils";
 import { EXPERIENCE_CLOUD_ID } from "./constants/cookieNames";
 import createMigration from "./createMigration";
+import isThirdPartyCookieSupported from "../../utils/isThirdPartyCookieSupported";
 
 const addIdsContext = (payload, ecid) => {
   payload.addIdentity(EXPERIENCE_CLOUD_ID, {
@@ -101,6 +102,12 @@ export default (
             // promise so that future requests can know when the ECID has returned.
             deferredForEcid = defer();
             payload.expectResponse();
+            if (
+              config.thirdPartyCookiesEnabled &&
+              isThirdPartyCookieSupported(window)
+            ) {
+              payload.useIdThirdPartyDomain();
+            }
           }
           customerIds.addToPayload(payload);
           return promise;

--- a/src/components/Identity/createMigration.js
+++ b/src/components/Identity/createMigration.js
@@ -14,8 +14,11 @@ export default (imsOrgId, migrateIds) => {
       if (migrateIds) {
         const amcvCookieValue = cookieJar.get(`AMCV_${imsOrgId}`);
         if (amcvCookieValue) {
-          const reg = /MCMID\|(\d+)\|/;
-          [, ecid] = amcvCookieValue.match(reg);
+          const reg = /(^|\|)MCMID\|(\d+)($|\|)/;
+          const matches = amcvCookieValue.match(reg);
+          // Destructuring arrays breaks in IE
+          // eslint-disable-next-line prefer-destructuring
+          ecid = matches[2];
           identityCookieJar.set(EXPERIENCE_CLOUD_ID, ecid);
         }
       }

--- a/src/constants/domains.js
+++ b/src/constants/domains.js
@@ -10,27 +10,5 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import flatMap from "../../../../src/utils/flatMap";
-
-const identity = item => item;
-
-describe("flatMap", () => {
-  it("handles empty array with identity function", () => {
-    expect(flatMap([], identity)).toEqual([]);
-  });
-
-  it("flattens arrays with identity function", () => {
-    expect(flatMap([[1], [2, 3], [], [4]], identity)).toEqual([1, 2, 3, 4]);
-  });
-
-  it("maps and flattens together", () => {
-    expect(flatMap([1, 2, 3], item => [item, item])).toEqual([
-      1,
-      1,
-      2,
-      2,
-      3,
-      3
-    ]);
-  });
-});
+export const EDGE_DOMAIN = "beta.adobedc.net";
+export const ID_THIRD_PARTY_DOMAIN = "adobedc.demdex.net";

--- a/src/core/createConfigValidators.js
+++ b/src/core/createConfigValidators.js
@@ -11,6 +11,8 @@ governing permissions and limitations under the License.
 */
 
 import { boolean, string, callback } from "../utils/configValidators";
+import { EDGE_DOMAIN } from "../constants/domains";
+import EDGE_BASE_PATH from "../constants/edgeBasePath";
 
 export default () => ({
   errorsEnabled: {
@@ -25,11 +27,11 @@ export default () => ({
     validate: string().unique()
   },
   edgeDomain: {
-    defaultValue: "beta.adobedc.net",
+    defaultValue: EDGE_DOMAIN,
     validate: string().domain()
   },
   edgeBasePath: {
-    defaultValue: "ee",
+    defaultValue: EDGE_BASE_PATH,
     validate: string().nonEmpty()
   },
   imsOrgId: {

--- a/src/core/createEvent.js
+++ b/src/core/createEvent.js
@@ -33,7 +33,7 @@ export default () => {
     documentUnloading() {
       documentUnloading = true;
     },
-    isDocumentUnloading() {
+    get isDocumentUnloading() {
       return documentUnloading;
     },
     expectResponse() {

--- a/src/core/createEventManager.js
+++ b/src/core/createEventManager.js
@@ -79,7 +79,8 @@ export default ({ createEvent, optIn, lifecycle, network, config, logger }) => {
         .then(() => {
           return network.sendRequest(payload, {
             expectsResponse: payload.expectsResponse,
-            documentUnloading: event.isDocumentUnloading()
+            documentUnloading: event.isDocumentUnloading,
+            useIdThirdPartyDomain: payload.shouldUseIdThirdPartyDomain
           });
         })
         .then(response => {

--- a/src/core/network/createNetwork.js
+++ b/src/core/network/createNetwork.js
@@ -14,6 +14,7 @@ import createPayload from "./createPayload";
 import createResponse from "./createResponse";
 import { executeWithRetry, stackError, uuid } from "../../utils";
 import apiVersion from "../../constants/apiVersion";
+import { ID_THIRD_PARTY_DOMAIN } from "../../constants/domains";
 
 export default ({ config, logger, lifecycle, networkStrategy }) => {
   const handleResponse = (requestId, responseBody) => {
@@ -58,7 +59,11 @@ export default ({ config, logger, lifecycle, networkStrategy }) => {
      * with undefined.
      */
     sendRequest(payload, options = {}) {
-      const { expectsResponse = true, documentUnloading = false } = options;
+      const {
+        expectsResponse = true,
+        documentUnloading = false,
+        useIdThirdPartyDomain = false
+      } = options;
       const requestId = uuid();
       if (documentUnloading) {
         logger.log(`No response requested due to document unloading.`);
@@ -67,8 +72,11 @@ export default ({ config, logger, lifecycle, networkStrategy }) => {
       return Promise.resolve()
         .then(() => {
           const action = reallyExpectsResponse ? "interact" : "collect";
+          const domain = useIdThirdPartyDomain
+            ? ID_THIRD_PARTY_DOMAIN
+            : edgeDomain;
 
-          let baseUrl = `https://${edgeDomain}`;
+          let baseUrl = `https://${domain}`;
 
           // #if _DEV
           if (config.get("localEdge")) {

--- a/src/core/network/createPayload.js
+++ b/src/core/network/createPayload.js
@@ -15,6 +15,7 @@ import { createMerger } from "../../utils";
 export default () => {
   const content = {};
   let expectsResponse = false;
+  let shouldUseIdThirdPartyDomain = false;
 
   return {
     addIdentity: (namespaceCode, identity) => {
@@ -30,6 +31,12 @@ export default () => {
       content.events.push(event.toJSON());
     },
     mergeMeta: createMerger(content, "meta"),
+    useIdThirdPartyDomain() {
+      shouldUseIdThirdPartyDomain = true;
+    },
+    get shouldUseIdThirdPartyDomain() {
+      return shouldUseIdThirdPartyDomain;
+    },
     expectResponse() {
       expectsResponse = true;
     },

--- a/src/utils/getBrowser.js
+++ b/src/utils/getBrowser.js
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import memoize from "./memoize";
+
+export const EDGE = "Edge";
+export const CHROME = "Chrome";
+export const FIREFOX = "Firefox";
+export const IE = "IE";
+export const SAFARI = "Safari";
+export const UNKNOWN = "Unknown";
+
+const matchUserAgent = regexs => {
+  return userAgent => {
+    const keys = Object.keys(regexs);
+    for (let i = 0; i < keys.length; i += 1) {
+      const key = keys[i];
+      const regex = regexs[key];
+      if (regex.test(userAgent)) {
+        return key;
+      }
+    }
+    return UNKNOWN;
+  };
+};
+
+export default memoize(window => {
+  return matchUserAgent({
+    // The order here is important, since user agent strings of some browsers
+    // contain names of other browsers (for example, Edge's contains
+    // both "Chrome" and "Safari")
+    [EDGE]: /Edge/,
+    [CHROME]: /Chrome/,
+    [FIREFOX]: /Firefox/,
+    [IE]: /Trident/, // This only covers version 11, but that's all we support.
+    [SAFARI]: /Safari/
+  })(window.navigator.userAgent);
+});

--- a/src/utils/isThirdPartyCookieSupported.js
+++ b/src/utils/isThirdPartyCookieSupported.js
@@ -10,27 +10,13 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import flatMap from "../../../../src/utils/flatMap";
+import getBrowser, { CHROME, IE, UNKNOWN } from "./getBrowser";
+import includes from "./includes";
 
-const identity = item => item;
+// Users could have also disabled third-party cookies in Chrome or IE, but we
+// don't know. We also assume "unknown" browsers support third-party cookies,
+// though we don't really know that either. We're making best guesses.
+const browsersSupportingThirdPartyCookie = [CHROME, IE, UNKNOWN];
 
-describe("flatMap", () => {
-  it("handles empty array with identity function", () => {
-    expect(flatMap([], identity)).toEqual([]);
-  });
-
-  it("flattens arrays with identity function", () => {
-    expect(flatMap([[1], [2, 3], [], [4]], identity)).toEqual([1, 2, 3, 4]);
-  });
-
-  it("maps and flattens together", () => {
-    expect(flatMap([1, 2, 3], item => [item, item])).toEqual([
-      1,
-      1,
-      2,
-      2,
-      3,
-      3
-    ]);
-  });
-});
+export default window =>
+  includes(browsersSupportingThirdPartyCookie, getBrowser(window));

--- a/test/unit/specs/core/createEvent.spec.js
+++ b/test/unit/specs/core/createEvent.spec.js
@@ -137,9 +137,9 @@ describe("createEvent", () => {
   });
 
   it("sets documentUnloading", () => {
-    expect(event.isDocumentUnloading()).toBeFalse();
+    expect(event.isDocumentUnloading).toBeFalse();
     event.documentUnloading();
-    expect(event.isDocumentUnloading()).toBeTrue();
+    expect(event.isDocumentUnloading).toBeTrue();
   });
 
   it("sets expectsResponse", () => {

--- a/test/unit/specs/core/createEventManager.spec.js
+++ b/test/unit/specs/core/createEventManager.spec.js
@@ -30,7 +30,7 @@ describe("createEventManager", () => {
       set lastChanceCallback(value) {
         lastChanceCallback = value;
       },
-      isDocumentUnloading: () => false,
+      isDocumentUnloading: false,
       applyCallback: jasmine.createSpy()
     };
     const createEvent = jasmine.createSpy().and.returnValue(event);
@@ -44,6 +44,7 @@ describe("createEventManager", () => {
       addEvent: jasmine.createSpy(),
       mergeMeta: jasmine.createSpy(),
       expectsResponse: false,
+      shouldUseIdThirdPartyDomain: false,
       toJSON() {
         return { meta: {} };
       }
@@ -181,7 +182,8 @@ describe("createEventManager", () => {
       return eventManager.sendEvent(event).then(() => {
         expect(network.sendRequest).toHaveBeenCalledWith(payload, {
           expectsResponse: false,
-          documentUnloading: false
+          documentUnloading: false,
+          useIdThirdPartyDomain: false
         });
       });
     });
@@ -191,17 +193,30 @@ describe("createEventManager", () => {
       return eventManager.sendEvent(event).then(() => {
         expect(network.sendRequest).toHaveBeenCalledWith(payload, {
           expectsResponse: true,
-          documentUnloading: false
+          documentUnloading: false,
+          useIdThirdPartyDomain: false
         });
       });
     });
 
     it("sends payload through network with documentUnloading true", () => {
-      event.isDocumentUnloading = () => true;
+      event.isDocumentUnloading = true;
       return eventManager.sendEvent(event).then(() => {
         expect(network.sendRequest).toHaveBeenCalledWith(payload, {
           expectsResponse: false,
-          documentUnloading: true
+          documentUnloading: true,
+          useIdThirdPartyDomain: false
+        });
+      });
+    });
+
+    it("sends payload through network with useIdThirdPartyDomain true", () => {
+      payload.shouldUseIdThirdPartyDomain = true;
+      return eventManager.sendEvent(event).then(() => {
+        expect(network.sendRequest).toHaveBeenCalledWith(payload, {
+          expectsResponse: false,
+          documentUnloading: false,
+          useIdThirdPartyDomain: true
         });
       });
     });

--- a/test/unit/specs/core/network/createNetwork.spec.js
+++ b/test/unit/specs/core/network/createNetwork.spec.js
@@ -93,6 +93,18 @@ describe("createNetwork", () => {
       });
   });
 
+  it("uses ID third-party domain when expected", () => {
+    return network.sendRequest({}, { useIdThirdPartyDomain: true }).then(() => {
+      expect(networkStrategy).toHaveBeenCalledWith(
+        jasmine.stringMatching(
+          /^https:\/\/adobedc\.demdex\.net\/ee\/v1\/interact\?configId=myconfigId&requestId=[0-9a-f-]+$/
+        ),
+        "{}",
+        false
+      );
+    });
+  });
+
   it("supports custom edgeBasePath settings", () => {
     const { edgeDomain, configId } = config;
     network = createNetwork({

--- a/test/unit/specs/core/network/createPayload.spec.js
+++ b/test/unit/specs/core/network/createPayload.spec.js
@@ -19,19 +19,25 @@ describe("Payload", () => {
   const collectEvent = createEvent();
 
   it("doesn't expect a response when empty", () => {
-    expect(createPayload().expectsResponse).toBe(false);
+    expect(createPayload().expectsResponse).toBeFalse();
   });
 
   it("doesn't expect a response with one collect event", () => {
     const payload = createPayload();
     payload.addEvent(collectEvent);
-    expect(payload.expectsResponse).toBe(false);
+    expect(payload.expectsResponse).toBeFalse();
+  });
+
+  it("expects a response when expectResponse is called", () => {
+    const payload = createPayload();
+    payload.expectResponse();
+    expect(payload.expectsResponse).toBeTrue();
   });
 
   it("expects a response with one interact event", () => {
     const payload = createPayload();
     payload.addEvent(interactEvent);
-    expect(payload.expectsResponse).toBe(true);
+    expect(payload.expectsResponse).toBeTrue();
   });
 
   it("expects a response with lots of events", () => {
@@ -40,7 +46,7 @@ describe("Payload", () => {
     payload.addEvent(collectEvent);
     payload.addEvent(interactEvent);
     payload.addEvent(collectEvent);
-    expect(payload.expectsResponse).toBe(true);
+    expect(payload.expectsResponse).toBeTrue();
   });
 
   it("doesn't expect a response with a bunch of collect Events", () => {
@@ -49,7 +55,18 @@ describe("Payload", () => {
     payload.addEvent(collectEvent);
     payload.addEvent(collectEvent);
     payload.addEvent(collectEvent);
-    expect(payload.expectsResponse).toBe(false);
+    expect(payload.expectsResponse).toBeFalse();
+  });
+
+  it("should not use ID third-party domain when useIdThirdPartyDomain is not called", () => {
+    const payload = createPayload();
+    expect(payload.shouldUseIdThirdPartyDomain).toBeFalse();
+  });
+
+  it("should use ID third-party domain when useIdThirdPartyDomain is called", () => {
+    const payload = createPayload();
+    payload.useIdThirdPartyDomain();
+    expect(payload.shouldUseIdThirdPartyDomain).toBeTrue();
   });
 
   it("calls toJSON on the event when it is added to the payload", () => {

--- a/test/unit/specs/utils/assignIf.spec.js
+++ b/test/unit/specs/utils/assignIf.spec.js
@@ -10,27 +10,5 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import flatMap from "../../../../src/utils/flatMap";
-
-const identity = item => item;
-
-describe("flatMap", () => {
-  it("handles empty array with identity function", () => {
-    expect(flatMap([], identity)).toEqual([]);
-  });
-
-  it("flattens arrays with identity function", () => {
-    expect(flatMap([[1], [2, 3], [], [4]], identity)).toEqual([1, 2, 3, 4]);
-  });
-
-  it("maps and flattens together", () => {
-    expect(flatMap([1, 2, 3], item => [item, item])).toEqual([
-      1,
-      1,
-      2,
-      2,
-      3,
-      3
-    ]);
-  });
-});
+// eslint-disable-next-line no-unused-vars
+import assignIf from "../../../../src/utils/assignIf";

--- a/test/unit/specs/utils/getBrowser.spec.js
+++ b/test/unit/specs/utils/getBrowser.spec.js
@@ -1,0 +1,68 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import getBrowser, {
+  EDGE,
+  CHROME,
+  FIREFOX,
+  IE,
+  SAFARI,
+  UNKNOWN
+} from "../../../../src/utils/getBrowser";
+
+const userAgentsByBrowser = {
+  [EDGE]: [
+    "Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10136",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/17.17134"
+  ],
+  // Chrome on iOS will not be detected as Chrome. That is because Chrome on
+  // iOS is just Safari wrapped in Chrome.
+  [CHROME]: [
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.87 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.117 Safari/537.36"
+  ],
+  [FIREFOX]: [
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:69.0) Gecko/20100101 Firefox/69.0",
+    "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:54.0) Gecko/20100101 Firefox/54.0"
+  ],
+  [IE]: [
+    "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; Tablet PC 2.0; rv:11.0) like Gecko",
+    "Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko"
+  ],
+  [SAFARI]: [
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Safari/605.1.15",
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13 Mobile/15E148 Safari/604.1"
+  ],
+  // Note that browsers like Opera will usually be reported as something like
+  // Chrome instead of Unknown because they contain other browser names in their
+  // user agent strings. For example, this one from Opera:
+  // Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.97 Safari/537.36 OPR/64.0.3417.92
+  [UNKNOWN]: [
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBAV/238.0.0.50.115;FBBV/171859800;FBDV/iPhone9,3;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/2;FBID/phone;FBLC/en_US;FBOP/5;FBRV/172564136;FBCR/AT&T]"
+  ]
+};
+
+describe("getBrowser", () => {
+  Object.keys(userAgentsByBrowser).forEach(browser => {
+    const userAgents = userAgentsByBrowser[browser];
+    userAgents.forEach(userAgent => {
+      it(`reports ${browser} for ${userAgent}`, () => {
+        const window = {
+          navigator: {
+            userAgent
+          }
+        };
+        expect(getBrowser(window)).toBe(browser);
+      });
+    });
+  });
+});

--- a/test/unit/specs/utils/isThirdPartyCookieSupported.spec.js
+++ b/test/unit/specs/utils/isThirdPartyCookieSupported.spec.js
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import isThirdPartyCookieSupported from "../../../../src/utils/isThirdPartyCookieSupported";
+
+const userAgentsWithSupport = [
+  // Chrome
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.87 Safari/537.36",
+  "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.117 Safari/537.36",
+  // IE
+  "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; Tablet PC 2.0; rv:11.0) like Gecko",
+  "Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko",
+  // Unknown
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBAV/238.0.0.50.115;FBBV/171859800;FBDV/iPhone9,3;FBMD/iPhone;FBSN/iOS;FBSV/12.4.1;FBSS/2;FBID/phone;FBLC/en_US;FBOP/5;FBRV/172564136;FBCR/AT&T]"
+];
+
+const userAgentsWithoutSupport = [
+  // Firefox
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:69.0) Gecko/20100101 Firefox/69.0",
+  "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:54.0) Gecko/20100101 Firefox/54.0",
+  // Safari
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Safari/605.1.15",
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13 Mobile/15E148 Safari/604.1"
+];
+
+describe("isThirdPartyCookieSupported", () => {
+  userAgentsWithSupport.forEach(userAgent => {
+    it(`reports true for ${userAgent}`, () => {
+      const window = {
+        navigator: {
+          userAgent
+        }
+      };
+      expect(isThirdPartyCookieSupported(window)).toBeTrue();
+    });
+  });
+
+  userAgentsWithoutSupport.forEach(userAgent => {
+    it(`reports false for ${userAgent}`, () => {
+      const window = {
+        navigator: {
+          userAgent
+        }
+      };
+      expect(isThirdPartyCookieSupported(window)).toBeFalse();
+    });
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If the ECID isn't on the client, and it's the first request where we retrieve the ECID, and `thirdPartyCookiesEnabled` is `true`, and the browser actually supports third party cookies (more specifically, if we detect that the browser Chrome or IE), then we send the request to `adobedc.demdex.net` instead of the regular edge domain.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-37168
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Enhanced identification.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I think this needs documentation? Anyway, I haven't done it yet. -> I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
