### PR TITLE
CORE-37378 add eventType and eventMergeId as event command options

### DIFF
--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -21,8 +21,8 @@ const createDataCollector = ({ eventManager }) => {
           data,
           viewStart = false,
           documentUnloading = false,
-          eventType,
-          eventMergeId
+          type,
+          mergeId
         } = options;
         const event = eventManager.createEvent();
 
@@ -30,16 +30,16 @@ const createDataCollector = ({ eventManager }) => {
           event.documentUnloading();
         }
 
-        if (eventType || eventMergeId) {
+        if (type || mergeId) {
           xdm = Object(xdm);
         }
 
-        if (eventType) {
-          assign(xdm, { eventType });
+        if (type) {
+          assign(xdm, { eventType: type });
         }
 
-        if (eventMergeId) {
-          assign(xdm, { eventMergeId });
+        if (mergeId) {
+          assign(xdm, { eventMergeId: mergeId });
         }
 
         event.userXdm = xdm;

--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -1,3 +1,5 @@
+import { assign } from "../../utils";
+
 /*
 Copyright 2019 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -14,16 +16,30 @@ const createDataCollector = ({ eventManager }) => {
   return {
     commands: {
       event(options) {
+        let { xdm } = options;
         const {
-          xdm,
           data,
           viewStart = false,
-          documentUnloading = false
+          documentUnloading = false,
+          eventType,
+          eventMergeId
         } = options;
         const event = eventManager.createEvent();
 
         if (documentUnloading) {
           event.documentUnloading();
+        }
+
+        if (eventType || eventMergeId) {
+          xdm = Object(xdm);
+        }
+
+        if (eventType) {
+          assign(xdm, { eventType });
+        }
+
+        if (eventMergeId) {
+          assign(xdm, { eventMergeId });
         }
 
         event.userXdm = xdm;

--- a/test/unit/specs/components/DataCollector/index.spec.js
+++ b/test/unit/specs/components/DataCollector/index.spec.js
@@ -80,8 +80,8 @@ describe("Event Command", () => {
 
   it("sets eventType and eventMergeId", () => {
     return eventCommand({
-      eventType: "mytype",
-      eventMergeId: "mymergeid"
+      type: "mytype",
+      mergeId: "mymergeid"
     }).then(() => {
       expect(
         Object.getOwnPropertyDescriptor(event, "userXdm").set
@@ -95,8 +95,8 @@ describe("Event Command", () => {
   it("merges eventType and eventMergeId with the userXdm", () => {
     return eventCommand({
       xdm: { key: "value" },
-      eventType: "mytype",
-      eventMergeId: "mymergeid"
+      type: "mytype",
+      mergeId: "mymergeid"
     }).then(() => {
       expect(
         Object.getOwnPropertyDescriptor(event, "userXdm").set

--- a/test/unit/specs/components/DataCollector/index.spec.js
+++ b/test/unit/specs/components/DataCollector/index.spec.js
@@ -77,4 +77,34 @@ describe("Event Command", () => {
       });
     });
   });
+
+  it("sets eventType and eventMergeId", () => {
+    return eventCommand({
+      eventType: "mytype",
+      eventMergeId: "mymergeid"
+    }).then(() => {
+      expect(
+        Object.getOwnPropertyDescriptor(event, "userXdm").set
+      ).toHaveBeenCalledWith({
+        eventType: "mytype",
+        eventMergeId: "mymergeid"
+      });
+    });
+  });
+
+  it("merges eventType and eventMergeId with the userXdm", () => {
+    return eventCommand({
+      xdm: { key: "value" },
+      eventType: "mytype",
+      eventMergeId: "mymergeid"
+    }).then(() => {
+      expect(
+        Object.getOwnPropertyDescriptor(event, "userXdm").set
+      ).toHaveBeenCalledWith({
+        key: "value",
+        eventType: "mytype",
+        eventMergeId: "mymergeid"
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If present, the eventType and eventMergeId options are added to the userXdm object of the event.

## Related Issue

https://jira.corp.adobe.com/browse/CORE-37378

## Motivation and Context

This will make using the Alloy extension easier as the user can specify their own eventType without modifying the xdm object they are passing in.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [x] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
