### PR TITLE
renaming migrateIds to idMigrationEnabled and fixing a failing test case

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -60,7 +60,7 @@
         debugEnabled: true,
         prehidingStyle: ".personalization-container { opacity: 0 !important }",
         idSyncContainerId: 81,
-        migrateIds: true,
+        idMigrationEnabled: true,
         onBeforeEventSend: function(options) {
           const xdm = options.xdm;
           const data = options.data;

--- a/src/components/Identity/createComponent.js
+++ b/src/components/Identity/createComponent.js
@@ -21,8 +21,8 @@ export default (
 ) => {
   let deferredForEcid;
   let alreadyQueriedForIdSyncs = false;
-  const { migrateIds, imsOrgId } = config;
-  const migration = createMigration(imsOrgId, migrateIds);
+  const { idMigrationEnabled, imsOrgId } = config;
+  const migration = createMigration(imsOrgId, idMigrationEnabled);
 
   // TODO: Fetch from server if ECID is not available.
   const getEcid = () => {

--- a/src/components/Identity/createMigration.js
+++ b/src/components/Identity/createMigration.js
@@ -2,12 +2,6 @@ import { cookieJar } from "../../utils";
 import { EXPERIENCE_CLOUD_ID } from "./constants/cookieNames";
 
 export default (imsOrgId, idMigrationEnabled) => {
-  if (!idMigrationEnabled) {
-    return {
-      getEcidFromAmcvCookie() {},
-      createAmcvCookie() {}
-    };
-  }
   return {
     getEcidFromAmcvCookie(identityCookieJar) {
       let ecid = null;

--- a/src/components/Identity/createMigration.js
+++ b/src/components/Identity/createMigration.js
@@ -1,8 +1,8 @@
 import { cookieJar } from "../../utils";
 import { EXPERIENCE_CLOUD_ID } from "./constants/cookieNames";
 
-export default (imsOrgId, migrateIds) => {
-  if (!migrateIds) {
+export default (imsOrgId, idMigrationEnabled) => {
+  if (!idMigrationEnabled) {
     return {
       getEcidFromAmcvCookie() {},
       createAmcvCookie() {}
@@ -11,7 +11,7 @@ export default (imsOrgId, migrateIds) => {
   return {
     getEcidFromAmcvCookie(identityCookieJar) {
       let ecid = null;
-      if (migrateIds) {
+      if (idMigrationEnabled) {
         const amcvCookieValue = cookieJar.get(`AMCV_${imsOrgId}`);
         if (amcvCookieValue) {
           const reg = /(^|\|)MCMID\|(\d+)($|\|)/;
@@ -25,7 +25,7 @@ export default (imsOrgId, migrateIds) => {
       return ecid;
     },
     createAmcvCookie(ecid) {
-      if (migrateIds) {
+      if (idMigrationEnabled) {
         const amcvCookieValue = cookieJar.get(`AMCV_${imsOrgId}`);
         if (!amcvCookieValue) {
           cookieJar.set(`AMCV_${imsOrgId}`, `MCMID|${ecid}`);

--- a/test/unit/specs/components/Identity/createMigration.spec.js
+++ b/test/unit/specs/components/Identity/createMigration.spec.js
@@ -13,7 +13,7 @@ describe("createMigration(", () => {
     cookieJar.remove("AMCV_TEST_ORG");
   });
   describe("getEcidFromAmcvCookie", () => {
-    it("should not read AMCv cookie if migrateIds is false", () => {
+    it("should not read AMCv cookie if idMigrationEnabled is false", () => {
       const migration = createMigration("TEST_ORG");
       expect(migration.getEcidFromAmcvCookie()).toEqual(undefined);
     });
@@ -30,7 +30,7 @@ describe("createMigration(", () => {
     });
   });
   describe("createAmcvCookie", () => {
-    it("should not change AMCV cookie if migrateIds is false", () => {
+    it("should not change AMCV cookie if idMigrationEnabled is false", () => {
       const previousCookieVal = cookieJar.get("AMCV_TEST_ORG");
       const migration = createMigration("TEST_ORG");
       migration.createAmcvCookie("1234");

--- a/test/unit/specs/components/Identity/createMigration.spec.js
+++ b/test/unit/specs/components/Identity/createMigration.spec.js
@@ -15,7 +15,7 @@ describe("createMigration(", () => {
   describe("getEcidFromAmcvCookie", () => {
     it("should not read AMCv cookie if idMigrationEnabled is false", () => {
       const migration = createMigration("TEST_ORG");
-      expect(migration.getEcidFromAmcvCookie()).toEqual(undefined);
+      expect(migration.getEcidFromAmcvCookie()).toEqual(null);
     });
     it("should return an empty string if no AMCV cookie is present", () => {
       const migration = createMigration("TEST_ORG", true);

--- a/test/unit/specs/core/executeCommandFactory.spec.js
+++ b/test/unit/specs/core/executeCommandFactory.spec.js
@@ -100,13 +100,13 @@ describe("executeCommandFactory", () => {
     const configureCommand = jasmine
       .createSpy()
       .and.returnValue(Promise.resolve("configureResult"));
-    const logCommand = jasmine
+    const debugCommand = jasmine
       .createSpy()
       .and.returnValue(Promise.resolve("logResult"));
     const executeCommand = executeCommandFactory({
       logger,
       configureCommand,
-      logCommand,
+      debugCommand,
       handleError
     });
 
@@ -115,7 +115,7 @@ describe("executeCommandFactory", () => {
       executeCommand("log", { baz: "qux" })
     ]).then(([configureResult, logResult]) => {
       expect(configureCommand).toHaveBeenCalledWith({ foo: "bar" });
-      expect(logCommand).toHaveBeenCalledWith({ baz: "qux" });
+      expect(debugCommand).toHaveBeenCalledWith({ baz: "qux" });
       expect(configureResult).toEqual("configureResult");
       expect(logResult).toEqual("logResult");
     });


### PR DESCRIPTION
Renaming the config `migrateIds` to `idMigrationEnabled`

## Description

Renaming the config `migrateIds` to `idMigrationEnabled` to match with rest of teh configs like `optInEnabled`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
