### PR TITLE
Qualifying all link clicks for beacon calls

### DIFF
--- a/src/components/ActivityCollector/createLinkClick.js
+++ b/src/components/ActivityCollector/createLinkClick.js
@@ -50,9 +50,7 @@ export default (window, config) => {
     }
 
     if (isValidLink) {
-      if (linkType === "exit") {
-        event.documentUnloading();
-      }
+      event.documentUnloading();
       event.mergeXdm({
         eventType: "web.webinteraction.linkClicks",
         web: {


### PR DESCRIPTION

## Description

To avoid internal links to get cancelled (and not capture/refire click events) all qualified link clicks will now be sent with beacon calls (if supported).

## Related Issue

CORE-37848

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
