### PR TITLE
changing hash to hashEnabled

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -94,7 +94,7 @@
         Email_LC_SHA256: {
           id: "me@gmail.com",
           authenticatedState: "ambiguous",
-          hash: true, //TODO: document customer ID hashing syntax
+          hashEnabled: true, //TODO: document customer ID hashing syntax
           primary: true
         },
         HYP: {

--- a/src/components/Identity/customerIds/createCustomerIds.js
+++ b/src/components/Identity/customerIds/createCustomerIds.js
@@ -12,7 +12,7 @@ export default (cookieJar, eventManager) => {
 
   const hash = (originalIds, normalizedIds) => {
     const idNames = Object.keys(normalizedIds);
-    const idsToHash = idNames.filter(idName => originalIds[idName].hash);
+    const idsToHash = idNames.filter(idName => originalIds[idName].hashEnabled);
     const idHashPromises = idsToHash.map(id =>
       convertStringToSha256Buffer(normalizedIds[id].id)
     );

--- a/test/unit/specs/components/Identity/customerIds/createCustomerIds.spec.js
+++ b/test/unit/specs/components/Identity/customerIds/createCustomerIds.spec.js
@@ -12,7 +12,7 @@ describe("Identity::createCustomerIds", () => {
       Email_LC_SHA256: {
         id: "me@gmail.com",
         authState: "ambiguous",
-        hash: true
+        hashEnabled: true
       },
       crm: {
         id: "1234",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Renaming `hash` attributes of `customerIds` to `hashEnabled` to match with other attributes in alloy

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
