### PR TITLE
CORE-38396 Properly preserve logging enablement for session

### DIFF
--- a/src/core/createLogController.js
+++ b/src/core/createLogController.js
@@ -24,8 +24,9 @@ export default ({
   const parsedQueryString = queryString.parse(locationSearch);
   const storage = createNamespacedStorage(`instance.${instanceNamespace}.`);
 
-  let debugEnabled = storage.session.getItem("debug") === "true";
-  let debugEnabledWritableFromConfig = true;
+  const debugSessionValue = storage.session.getItem("debug");
+  let debugEnabled = debugSessionValue === "true";
+  let debugEnabledWritableFromConfig = debugSessionValue === null;
 
   const getDebugEnabled = () => debugEnabled;
   const setDebugEnabled = (value, { fromConfig }) => {

--- a/test/unit/specs/core/createLogController.spec.js
+++ b/test/unit/specs/core/createLogController.spec.js
@@ -114,7 +114,7 @@ describe("createLogController", () => {
     expect(getDebugEnabled()).toBe(true);
   });
 
-  it("does not change debugEnabled from config if previously changed from something other than config", () => {
+  it("does not change debugEnabled from config if previously changed from something other than config on same page load", () => {
     const logController = createLogController({
       console,
       locationSearch,
@@ -127,6 +127,21 @@ describe("createLogController", () => {
     logController.setDebugEnabled(false, { fromConfig: true });
     expect(sessionStorage.setItem).toHaveBeenCalledWith("debug", "true");
     expect(sessionStorage.setItem).not.toHaveBeenCalledWith("debug", "false");
+    expect(getDebugEnabled()).toBe(true);
+  });
+
+  it("does not change debugEnabled from config if previously changed from something other than config on previous page load", () => {
+    sessionStorage.getItem = () => "true";
+    const logController = createLogController({
+      console,
+      locationSearch,
+      createLogger,
+      instanceNamespace,
+      createNamespacedStorage
+    });
+
+    logController.setDebugEnabled(false, { fromConfig: true });
+    expect(sessionStorage.setItem).not.toHaveBeenCalled();
     expect(getDebugEnabled()).toBe(true);
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Logging enablement (based on the debugging enablement) wasn't being preserved for the session. Rather, it was being overridden by configure commands. See https://jira.corp.adobe.com/browse/CORE-38396 for more details.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-38396
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Meet customer expectation of logging behavior.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
