### PR TITLE
CORE-36762 - Populate specs for Personalization/helper/dom/getFirstChild

### DIFF
--- a/test/unit/specs/components/Personalization/helper/dom/getFirstChild.spec.js
+++ b/test/unit/specs/components/Personalization/helper/dom/getFirstChild.spec.js
@@ -10,7 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-// eslint-disable-next-line no-unused-vars
 import getFirstChild from "../../../../../../../src/components/Personalization/helper/dom/getFirstChild";
 import createFragment from "../../../../../../../src/components/Personalization/helper/dom/createFragment";
 

--- a/test/unit/specs/components/Personalization/helper/dom/getFirstChild.spec.js
+++ b/test/unit/specs/components/Personalization/helper/dom/getFirstChild.spec.js
@@ -12,3 +12,24 @@ governing permissions and limitations under the License.
 
 // eslint-disable-next-line no-unused-vars
 import getFirstChild from "../../../../../../../src/components/Personalization/helper/dom/getFirstChild";
+import createFragment from "../../../../../../../src/components/Personalization/helper/dom/createFragment";
+
+describe("Personalization::helper::dom::getFirstChild", () => {
+  it("the element's getFirstChild should be a div", () => {
+    const element = createFragment(
+      `<h1>hello there</h1><div id="foo">foo</div>`
+    );
+    const result = getFirstChild(element);
+
+    expect(result.tagName).toEqual("H1");
+  });
+});
+
+describe("Personalization::helper::dom::getFirstChild", () => {
+  it("the getFirstChild element should be null", () => {
+    const element = createFragment();
+    const result = getFirstChild(element);
+
+    expect(result).toBeNull();
+  });
+});

--- a/test/unit/specs/components/Personalization/helper/dom/getFirstChild.spec.js
+++ b/test/unit/specs/components/Personalization/helper/dom/getFirstChild.spec.js
@@ -14,7 +14,7 @@ import getFirstChild from "../../../../../../../src/components/Personalization/h
 import createFragment from "../../../../../../../src/components/Personalization/helper/dom/createFragment";
 
 describe("Personalization::helper::dom::getFirstChild", () => {
-  it("the element's getFirstChild should be a div", () => {
+  it("the element's first child node should be a div", () => {
     const element = createFragment(
       `<h1>hello there</h1><div id="foo">foo</div>`
     );
@@ -22,10 +22,8 @@ describe("Personalization::helper::dom::getFirstChild", () => {
 
     expect(result.tagName).toEqual("H1");
   });
-});
 
-describe("Personalization::helper::dom::getFirstChild", () => {
-  it("the getFirstChild element should be null", () => {
+  it("the element's first child should be null", () => {
     const element = createFragment();
     const result = getFirstChild(element);
 

--- a/test/unit/specs/components/Personalization/helper/dom/getFirstChild.spec.js
+++ b/test/unit/specs/components/Personalization/helper/dom/getFirstChild.spec.js
@@ -14,7 +14,7 @@ import getFirstChild from "../../../../../../../src/components/Personalization/h
 import createFragment from "../../../../../../../src/components/Personalization/helper/dom/createFragment";
 
 describe("Personalization::helper::dom::getFirstChild", () => {
-  it("the element's first child node should be a div", () => {
+  it("returns the first child node of the element", () => {
     const element = createFragment(
       `<h1>hello there</h1><div id="foo">foo</div>`
     );
@@ -23,7 +23,7 @@ describe("Personalization::helper::dom::getFirstChild", () => {
     expect(result.tagName).toEqual("H1");
   });
 
-  it("the element's first child should be null", () => {
+  it("returns null if there are no child elements", () => {
     const element = createFragment();
     const result = getFirstChild(element);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
populate spec for getFirstChild
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
populate spec for getFirstChild
## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
