### PR TITLE
Set the domain and expiry of the migration cookie.

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -56,6 +56,10 @@
         // cookieDestinationsEnabled: false,
         // errorsEnabled: false,
         // thirdPartyCookiesEnabled: false,
+        edgeDomain:
+          location.host.indexOf("alloyio.com") !== -1
+            ? "firstparty.alloyio.com"
+            : undefined,
         configId: "9999999",
         orgId: "53A16ACB5CC1D3760A495C99@AdobeOrg",
         debugEnabled: true,

--- a/src/components/Identity/createMigration.js
+++ b/src/components/Identity/createMigration.js
@@ -10,7 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { cookieJar } from "../../utils";
+import { getApexDomain, cookieJar } from "../../utils";
+
+const apexDomain = getApexDomain(window, cookieJar);
 
 export default orgId => {
   const amcvCookieName = `AMCV_${orgId}`;
@@ -38,7 +40,9 @@ export default orgId => {
     createLegacyCookie(ecid) {
       const amcvCookieValue = cookieJar.get(amcvCookieName);
       if (!amcvCookieValue) {
-        cookieJar.set(amcvCookieName, `MCMID|${ecid}`);
+        cookieJar.set(amcvCookieName, `MCMID|${ecid}`, {
+          domain: apexDomain
+        });
       }
     }
   };

--- a/src/components/Identity/createMigration.js
+++ b/src/components/Identity/createMigration.js
@@ -11,7 +11,8 @@ governing permissions and limitations under the License.
 */
 
 import { getApexDomain, cookieJar } from "../../utils";
-
+// TODO: We are already retrieving the apex in core; find a way to reuse it.
+// Maybe default the domain in the cookieJar to apex while allowing overrides.
 const apexDomain = getApexDomain(window, cookieJar);
 
 export default orgId => {
@@ -41,7 +42,9 @@ export default orgId => {
       const amcvCookieValue = cookieJar.get(amcvCookieName);
       if (!amcvCookieValue) {
         cookieJar.set(amcvCookieName, `MCMID|${ecid}`, {
-          domain: apexDomain
+          domain: apexDomain,
+          // Without `expires` this will be a session cookie.
+          expires: 390 // days, or 13 months.
         });
       }
     }


### PR DESCRIPTION
## Description

- Without setting a `domain` when creating a cookie, the domain won't start with a `.` which makes it more restricted to sub domains.
- Without setting an `expires` attribute, the cookie will be created as a session cookie.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [ x ] I have made any necessary test changes and all tests pass.
- [ x ] I have run the Sandbox successfully.
