### PR TITLE
CORE-39322 Fix ID migration.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/alloy",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/alloy",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Client-Side SDK for Unified Data Collection",
   "main": "src/core/index.js",
   "scripts": {

--- a/src/components/Identity/createComponent.js
+++ b/src/components/Identity/createComponent.js
@@ -121,7 +121,7 @@ export default (processIdSyncs, config, logger, consent, eventManager) => {
           );
 
           if (ecidPayload) {
-            promises.push(migration.createLegacyCookie(ecidPayload.value));
+            promises.push(migration.createLegacyCookie(ecidPayload.id));
           }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When I was preparing my opt-out PR yesterday, I improperly resolved a conflict, resulting in the wrong object property being used to retrieve the ECID from the response payload, which is used to write the AMCV cookie: https://github.com/adobe/alloy/pull/323/files#diff-e3608b4e8d26a7ee90affbadd009744eR124

We need to use the correct property (`id` instead of `value`).

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-39322
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Proper migration.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
