### PR TITLE
Travis chrome build fail fix. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,7 @@ cache:
   - node_modules
 addons:
   firefox: latest
-  apt:
-    sources:
-    - google-chrome
-    packages:
-    - google-chrome-stable fluxbox
+  chrome: stable
   sonarcloud:
     organization: adobeinc
 services:


### PR DESCRIPTION
Switched the Chrome download repo to the internal Travis add-on. 