### PR TITLE
Expect response during ECID migration

### DIFF
--- a/sandbox/public/legacy.html
+++ b/sandbox/public/legacy.html
@@ -8,7 +8,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <meta name="theme-color" content="#000000" />
-    <script src="https://github.com/Adobe-Marketing-Cloud/id-service/releases/download/4.4.1/visitorapi.min.js"></script>
+    <script src="https://github.com/Adobe-Marketing-Cloud/id-service/releases/download/4.5.1/visitorapi.min.js"></script>
     <meta
       http-equiv="Content-Security-Policy"
       content="default-src 'self' *.demdex.net;

--- a/src/components/Identity/createComponent.js
+++ b/src/components/Identity/createComponent.js
@@ -23,7 +23,7 @@ export default (processIdSyncs, config, logger, consent, eventManager) => {
     orgId,
     IDENTITY_COOKIE_KEY
   );
-  let deferredForEcid;
+  let deferredForIdentityCookie;
   const migration = createMigration({ orgId, consent });
   const hasIdentityCookie = () => Boolean(cookieJar.get(identityCookieName));
   const customerIds = createCustomerIds({ eventManager, consent, logger });
@@ -33,45 +33,60 @@ export default (processIdSyncs, config, logger, consent, eventManager) => {
     let promise;
 
     if (!hasIdentityCookie()) {
-      if (deferredForEcid) {
+      if (deferredForIdentityCookie) {
         // We don't have an identity cookie, but the first request has
         // been sent to get it. We must wait for the response to the first
         // request to come back and a cookie set before we can let this
         // request go out.
         logger.log("Delaying request while retrieving ECID from server.");
-        promise = deferredForEcid.promise.then(() => {
+        promise = deferredForIdentityCookie.promise.then(() => {
           logger.log("Resuming previously delayed request.");
         });
       } else {
         const ecidToMigrate =
           idMigrationEnabled && migration.getEcidFromLegacyCookies();
 
-        // We don't have an identity cookie and no request has gone out
-        // to get it. We'll let this request go out to fetch the cookie,
-        // but we'll set up a promise so that future requests can
-        // know when the cookie has been set. We don't let additional
-        // requests to go out in the meantime because a new ECID would
-        // be minted for each request (each request would be seen as a
-        // new visitor).
-        deferredForEcid = defer();
+        // For Alloy+Konductor communication to be as robust as possible and
+        // to ensure we don't mint new ECIDs for requests that would otherwise
+        // be sent in parallel, we'll let this request go out to fetch the
+        // cookie, but we'll set up a promise so that future requests can
+        // know when the cookie has been set.
+        deferredForIdentityCookie = defer();
+
+        // payload.expectsResponse() forces the request to go to the
+        // /interact endpoint. Why can't we go to the /collect endpoint
+        // to get the identity cookie?
+        // There are a couple cases where first-party cookies can't be
+        // set when hitting /collect:
+        //
+        // 1. If Alloy calls /collect when Konductor is on a different
+        // domain (e.g., edge.adobedc.net), Konductor can't set cookies
+        // on its own through HTTP headers and won't send a response body
+        // so it can't tell Alloy to write a cookie on its behalf.
+        // 2. Alloy may use sendBeacon() to send requests to /collect,
+        // in which case the HTTP response will usually be ignored by
+        // the browser.
         payload.expectResponse();
 
         if (ecidToMigrate) {
-          // We don't have an identity cookie, but we do have an ECID
-          // from a legacy cookie that we can explicitly provide
-          // to the server. Since we have an ECID, it might be reasonable to
-          // allow other requests to go out in parallel, but to make sure
-          // there aren't unforeseen problems, we will hold back other
-          // requests until the identity cookie gets set.
+          // We have an ECID, but we still want to establish an
+          // identity cookie before allowing other requests to be sent.
           addEcidToPayload(payload, ecidToMigrate);
-        } else if (
+        }
+
+        if (
           config.thirdPartyCookiesEnabled &&
           areThirdPartyCookiesSupportedByDefault(getBrowser(window))
         ) {
           // If third-party cookies are enabled by the customer and
           // supported by the browser, we will send the request to a
-          // a third-party domain that allows for more accurate
+          // a third-party identification domain that allows for more accurate
           // identification of the user through use of a third-party cookie.
+          // If we have an ECID to migrate, we still want to hit the
+          // third-party domain because the third-party identification domain
+          // will use our ECID to set the third-party cookie if the third-party
+          // cookie isn't already set, which provides for better cross-domain
+          // identification for future requests.
           payload.useIdThirdPartyDomain();
         }
       }
@@ -132,8 +147,8 @@ export default (processIdSyncs, config, logger, consent, eventManager) => {
         // and now we have the identity cookie, we can let the queued
         // requests go out. Technically, we should always have an identity
         // cookie at this point, but we check just to be sure.
-        if (deferredForEcid && hasIdentityCookie()) {
-          deferredForEcid.resolve();
+        if (deferredForIdentityCookie && hasIdentityCookie()) {
+          deferredForIdentityCookie.resolve();
         }
 
         promises.push(

--- a/src/components/Identity/createComponent.js
+++ b/src/components/Identity/createComponent.js
@@ -42,6 +42,11 @@ export default (processIdSyncs, config, logger, consent, eventManager) => {
         // to the server, which is sufficient until the identity cookie
         // gets set.
         addEcidToPayload(payload, ecidToMigrate);
+
+        // Even though we have an ECID from a legacy cookie, we still want
+        // the server to set the newer identity cookie, so we'll expect
+        // a response from the server.
+        payload.expectResponse();
       } else if (deferredForEcid) {
         // We don't have an identity cookie, but the first request has
         // been sent to get it. We must wait for the response to the first


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When we have an ECID that we can migrate, we previously were not calling `payload.expectResponse()`. That means if no other components expected a response, the request would go to the `collect` endpoint instead of the `interact` endpoint and the identity cookie wouldn't be set.

I talked with @jfkhoury about this and we decided it would be best to expect a response in this case so that the identity cookie gets set on the first request+response. We also decided that it would be best to hold up other requests in this case as well, since ensuring an identity cookie exists before letting other requests go is probably the most consistent/robust way of managing identity. However, if we have an ECID to migrate, I opted to not make the request go to demdex, since I don't think it provides any particular value (please correct me if this might be wrong!).

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-39325
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Trying to make Alloy + Konductor communication as robust as possible.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [ ] **I was going to add unit tests for identity, but noticed that JIRA shows that @jileeshs is starting on identity tests and I didn't want to cause a big conflict** I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
