### PR TITLE
Now showing available commands in missing command error

### DIFF
--- a/src/core/createComponentRegistry.js
+++ b/src/core/createComponentRegistry.js
@@ -92,6 +92,9 @@ export default () => {
     getCommand(commandName) {
       return commandsByName[commandName];
     },
+    getCommandNames() {
+      return Object.keys(commandsByName);
+    },
     getLifecycleCallbacks(hookName) {
       return lifecycleCallbacksByName[hookName] || [];
     }

--- a/src/core/executeCommandFactory.js
+++ b/src/core/executeCommandFactory.js
@@ -43,7 +43,9 @@ export default ({ logger, configureCommand, debugCommand, handleError }) => {
             componentRegistry => {
               const command = componentRegistry.getCommand(commandName);
               if (!isFunction(command)) {
-                throw new Error(`The ${commandName} command does not exist.`);
+                throw new Error(
+                  `The ${commandName} command does not exist. List of available commands: ${componentRegistry.getCommandNames()}.`
+                );
               }
               return command(options);
             },

--- a/src/core/executeCommandFactory.js
+++ b/src/core/executeCommandFactory.js
@@ -44,7 +44,9 @@ export default ({ logger, configureCommand, debugCommand, handleError }) => {
               const command = componentRegistry.getCommand(commandName);
               if (!isFunction(command)) {
                 throw new Error(
-                  `The ${commandName} command does not exist. List of available commands: ${componentRegistry.getCommandNames()}.`
+                  `The ${commandName} command does not exist. List of available commands: ${componentRegistry
+                    .getCommandNames()
+                    .join(", ")}.`
                 );
               }
               return command(options);

--- a/test/unit/specs/core/executeCommandFactory.spec.js
+++ b/test/unit/specs/core/executeCommandFactory.spec.js
@@ -57,7 +57,10 @@ describe("executeCommandFactory", () => {
 
   it("rejects promise if command doesn't exist", () => {
     const componentRegistry = {
-      getCommand() {}
+      getCommand() {},
+      getCommandNames() {
+        return ["genuine"];
+      }
     };
     const configureCommand = () => Promise.resolve(componentRegistry);
     const executeCommand = executeCommandFactory({
@@ -69,7 +72,9 @@ describe("executeCommandFactory", () => {
     return executeCommand("bogus")
       .then(fail)
       .catch(error => {
-        expect(error.message).toBe("The bogus command does not exist.");
+        expect(error.message).toBe(
+          "The bogus command does not exist. List of available commands: genuine."
+        );
       });
   });
 


### PR DESCRIPTION

## Motivation and Context

Makes it easier for developers starting out with alloy to see what commands are available.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/2584844/73003241-23ad6900-3dba-11ea-9ccb-11544532ab9d.png)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
