### PR TITLE
remove viewStart from getDecisions

### DIFF
--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -19,9 +19,11 @@ import * as SCHEMAS from "../../constants/schemas";
 
 const DECISIONS_HANDLE = "personalization:decisions";
 const PAGE_WIDE_SCOPE = "page_wide_scope";
-const GET_DECISIONS_OPTIONS_SCHEMA = {
-  scopes: arrayOf(string()).default([])
-};
+const GET_DECISIONS_VALIDATOR = objectOf({
+  scopes: arrayOf(string().required())
+    .nonEmpty()
+    .required()
+}).required();
 const allSchemas = values(SCHEMAS);
 // This is used for Target VEC integration
 const isAuthoringMode = () => document.location.href.indexOf("mboxEdit") !== -1;
@@ -89,21 +91,6 @@ const createCollect = eventManager => {
   };
 };
 
-const validateOptions = options => {
-  const validate = objectOf(GET_DECISIONS_OPTIONS_SCHEMA);
-  const result = validate(options);
-  const { scopes } = result;
-
-  if (scopes.length === 0) {
-    throw new Error(
-      "Invalid getDecisions command options parameter: " +
-        "Scopes must be defined."
-    );
-  }
-
-  return result;
-};
-
 const createPersonalization = ({ config, logger, eventManager }) => {
   const { prehidingStyle } = config;
   const authoringModeEnabled = isAuthoringMode();
@@ -166,8 +153,8 @@ const createPersonalization = ({ config, logger, eventManager }) => {
     },
 
     commands: {
-      getDecisions(options = {}) {
-        const { scopes } = validateOptions(options);
+      getDecisions(options) {
+        const { scopes } = GET_DECISIONS_VALIDATOR(options);
         // Cloning scopes to avoid changing input options
         const localScopes = [...scopes];
 

--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import { isNonEmptyArray, groupBy, values, assign } from "../../utils";
-import { string, boolean, arrayOf, objectOf } from "../../utils/validation";
+import { string, arrayOf, objectOf } from "../../utils/validation";
 import { initDomActionsModules, executeActions } from "./turbine";
 import { hideContainers, showContainers } from "./flicker";
 import collectClicks from "./helper/clicks/collectClicks";
@@ -20,7 +20,6 @@ import * as SCHEMAS from "../../constants/schemas";
 const DECISIONS_HANDLE = "personalization:decisions";
 const PAGE_WIDE_SCOPE = "page_wide_scope";
 const GET_DECISIONS_OPTIONS_SCHEMA = {
-  viewStart: boolean().default(false),
   scopes: arrayOf(string()).default([])
 };
 const allSchemas = values(SCHEMAS);
@@ -93,12 +92,12 @@ const createCollect = eventManager => {
 const validateOptions = options => {
   const validate = objectOf(GET_DECISIONS_OPTIONS_SCHEMA);
   const result = validate(options);
-  const { viewStart, scopes } = result;
+  const { scopes } = result;
 
-  if (!viewStart && scopes.length === 0) {
+  if (scopes.length === 0) {
     throw new Error(
       "Invalid getDecisions command options parameter: " +
-        "'viewStart' must be set to true or scopes must be defined."
+        "Scopes must be defined."
     );
   }
 
@@ -168,13 +167,9 @@ const createPersonalization = ({ config, logger, eventManager }) => {
 
     commands: {
       getDecisions(options = {}) {
-        const { viewStart, scopes } = validateOptions(options);
+        const { scopes } = validateOptions(options);
         // Cloning scopes to avoid changing input options
         const localScopes = [...scopes];
-
-        if (viewStart) {
-          localScopes.push(PAGE_WIDE_SCOPE);
-        }
 
         return filterDecisions(decisionsStorage, localScopes);
       }

--- a/test/unit/specs/components/Personalization/index.spec.js
+++ b/test/unit/specs/components/Personalization/index.spec.js
@@ -68,28 +68,6 @@ describe("Personalization", () => {
     expect(event.expectResponse).not.toHaveBeenCalled();
   });
 
-  it("expects getDecisions to return empty array when there are no decisions in storage for page wide scope", () => {
-    const isViewStart = true;
-    const response = {
-      getPayloadsByType() {
-        return SCOPES_FOO1_FOO2_DECISIONS;
-      }
-    };
-    const personalization = createPersonalization({
-      config,
-      logger,
-      eventManager
-    });
-
-    personalization.lifecycle.onResponse({ response });
-
-    const result = personalization.commands.getDecisions({
-      viewStart: isViewStart
-    });
-
-    expect(result).toEqual([]);
-  });
-
   it("expects getDecisions to return an array of decisions for the scopes provided", () => {
     const scopes = ["Foo1", "Foo3"];
     const response = {
@@ -184,65 +162,6 @@ describe("Personalization", () => {
 
     expect(Array.isArray(result)).toBeTrue();
     expect(result.length).toEqual(0);
-  });
-
-  it("expects getDecisions to return only the page wide scope decisions when only parameter viewStart is passed", () => {
-    const isViewStart = true;
-    const first = {
-      getPayloadsByType() {
-        return NO_SCOPES_DECISIONS;
-      }
-    };
-    const second = {
-      getPayloadsByType() {
-        return SCOPES_FOO1_FOO3_DECISIONS;
-      }
-    };
-    const personalization = createPersonalization({
-      config,
-      logger,
-      eventManager
-    });
-    personalization.lifecycle.onResponse({ response: first });
-    personalization.lifecycle.onResponse({ response: second });
-
-    const result = personalization.commands.getDecisions({
-      viewStart: isViewStart
-    });
-
-    expect(Array.isArray(result)).toBeTrue();
-    expect(result.length).toEqual(1);
-    expect(result[0].id).toEqual("TNT:activity1:experience1");
-  });
-
-  it("expects getDecisions to return page wide scope and specific scopes decisions when parameter viewStart and scopes is passed", () => {
-    const isViewStart = true;
-    const scopes = ["Foo1", "Foo3"];
-    const first = {
-      getPayloadsByType() {
-        return NO_SCOPES_DECISIONS;
-      }
-    };
-    const second = {
-      getPayloadsByType() {
-        return SCOPES_FOO1_FOO3_DECISIONS;
-      }
-    };
-    const personalization = createPersonalization({
-      config,
-      logger,
-      eventManager
-    });
-    personalization.lifecycle.onResponse({ response: first });
-    personalization.lifecycle.onResponse({ response: second });
-
-    const result = personalization.commands.getDecisions({
-      viewStart: isViewStart,
-      scopes
-    });
-
-    expect(Array.isArray(result)).toBeTrue();
-    expect(result.length).toEqual(3);
   });
 
   it("expects getDecisions to return empty array if the storage is empty", () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Removing `viewStart` flag. We will retrieve decisions by scope only. We will not retrieve page-wide scope decisions for now.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
