### PR TITLE
C2597 - Adds all context data to requests by default

### DIFF
--- a/test/functional/specs/C2597.js
+++ b/test/functional/specs/C2597.js
@@ -1,0 +1,41 @@
+import { t, ClientFunction } from "testcafe";
+import createNetworkLogger from "../helpers/networkLogger";
+import { responseStatus } from "../helpers/assertions/index";
+import fixtureFactory from "../helpers/fixtureFactory";
+import debugEnabledConfig from "../helpers/constants/debugEnabledConfig";
+import configureAlloyInstance from "../helpers/configureAlloyInstance";
+
+const networkLogger = createNetworkLogger();
+
+fixtureFactory({
+  title: "C2597 - Adds all context data to requests by default.",
+  requestHooks: [networkLogger.edgeEndpointLogs]
+});
+
+test.meta({
+  ID: "C2597",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+
+const triggerAlloyEvent = ClientFunction(() => {
+  return new Promise(resolve => {
+    window.alloy("event", { xdm: { key: "value" } }).then(() => resolve());
+  });
+});
+
+test("Test C2597 - Adds all context data to requests by default.", async () => {
+  await configureAlloyInstance("alloy", debugEnabledConfig);
+  await triggerAlloyEvent();
+
+  await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
+  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
+
+  const request = networkLogger.edgeEndpointLogs.requests[0].request.body;
+  const stringifyRequest = JSON.parse(request);
+
+  await t.expect(stringifyRequest.events[0].xdm.device).ok();
+  await t.expect(stringifyRequest.events[0].xdm.placeContext).ok();
+  await t.expect(stringifyRequest.events[0].xdm.environment.type).ok();
+  await t.expect(stringifyRequest.events[0].xdm.web.webPageDetails).ok();
+});

--- a/test/functional/specs/C2597.js
+++ b/test/functional/specs/C2597.js
@@ -19,9 +19,7 @@ test.meta({
 });
 
 const triggerAlloyEvent = ClientFunction(() => {
-  return new Promise(resolve => {
-    window.alloy("event", { xdm: { key: "value" } }).then(() => resolve());
-  });
+  return window.alloy("event", { xdm: { key: "value" } });
 });
 
 test("Test C2597 - Adds all context data to requests by default.", async () => {


### PR DESCRIPTION
## Description
Step: Execute an event command. 
Expected: Request should have web, device, environment, and placeContext data attached.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
