### PR TITLE
C2598 - Adds only web context data when only web is specified in configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:watch:chrome": "karma start --browsers Chrome",
     "functional:ci": "EDGE_ENV=\"'ee'\" testcafe 'saucelabs:Chrome@latest:OS X 10.11'",
     "functional:local": "EDGE_ENV=\"'ee'\" testcafe chrome",
+    "functional:local:allure": "EDGE_ENV=\"'ee'\" testcafe chrome -r allure",
     "functional:local:headless": "EDGE_ENV=\"'ee'\" testcafe chrome:headless",
     "functional:local:build": "EDGE_ENV=\"'ee'\" npm run build:prod && testcafe chrome",
     "functional:local:watch": "EDGE_ENV=\"'ee'\" testcafe chrome --live",

--- a/sandbox/public/functional-test/alloyTestPage.html
+++ b/sandbox/public/functional-test/alloyTestPage.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Alloy Test Page</title>
+    <!-- prettier-ignore -->
+  </head>
+  <body>
+    <h1>
+      Testcafe injects the Alloy SDK and configurations during runtime. This is
+      a standalone test page that is hosted on Alloyio.com/functional-test/
+    </h1>
+  </body>
+</html>

--- a/test/functional/helpers/constants/webContextConfig.js
+++ b/test/functional/helpers/constants/webContextConfig.js
@@ -1,0 +1,7 @@
+import baseConfig from "./baseConfig";
+
+export default {
+  debugEnabled: true,
+  context: ["web"],
+  ...baseConfig
+};

--- a/test/functional/specs/C2598.js
+++ b/test/functional/specs/C2598.js
@@ -1,0 +1,50 @@
+import { t, ClientFunction } from "testcafe";
+import createNetworkLogger from "../helpers/networkLogger";
+import { responseStatus } from "../helpers/assertions/index";
+import fixtureFactory from "../helpers/fixtureFactory";
+import webContextConfig from "../helpers/constants/webContextConfig";
+import configureAlloyInstance from "../helpers/configureAlloyInstance";
+
+const networkLogger = createNetworkLogger();
+
+fixtureFactory({
+  title:
+    "C2598 - Adds only web context data when only web is specified in configuration.",
+  requestHooks: [networkLogger.edgeEndpointLogs]
+});
+
+test.meta({
+  ID: "C2598",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+
+const triggerAlloyEvent = ClientFunction(() => {
+  return window.alloy("event", {
+    xdm: {
+      web: {
+        webPageDetails: {
+          URL: "https://alloyio.com/functional-test/alloyTestPage.html"
+        }
+      }
+    }
+  });
+});
+
+test("Test C2598 - Adds only web context data when only web is specified in configuration.", async () => {
+  await configureAlloyInstance("alloy", webContextConfig);
+  await triggerAlloyEvent();
+
+  await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
+  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
+
+  const request = networkLogger.edgeEndpointLogs.requests[0].request.body;
+  const stringifyRequest = JSON.parse(request);
+
+  await t.expect(stringifyRequest.events[0].xdm.web).ok();
+  await t.expect(stringifyRequest.events[0].xdm.web.webPageDetails).ok();
+
+  await t.expect(stringifyRequest.events[0].xdm.device).notOk();
+  await t.expect(stringifyRequest.events[0].xdm.placeContext).notOk();
+  await t.expect(stringifyRequest.events[0].xdm.environment).notOk();
+});


### PR DESCRIPTION
## Description


1 ) Configure the SDK with context: ["web"]. Execute an event command. 

Expected: Only web context data should be added to the request and not other context data.



## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
