### PR TITLE
C2599 - Adds only device context data when only device is specified in configuration

### DIFF
--- a/test/functional/helpers/constants/deviceContextConfig.js
+++ b/test/functional/helpers/constants/deviceContextConfig.js
@@ -1,0 +1,7 @@
+import baseConfig from "./baseConfig";
+
+export default {
+  debugEnabled: true,
+  context: ["device"],
+  ...baseConfig
+};

--- a/test/functional/specs/C2599.js
+++ b/test/functional/specs/C2599.js
@@ -1,0 +1,49 @@
+import { t, ClientFunction } from "testcafe";
+import createNetworkLogger from "../helpers/networkLogger";
+import { responseStatus } from "../helpers/assertions/index";
+import fixtureFactory from "../helpers/fixtureFactory";
+import deviceContextConfig from "../helpers/constants/deviceContextConfig";
+import configureAlloyInstance from "../helpers/configureAlloyInstance";
+
+const networkLogger = createNetworkLogger();
+
+fixtureFactory({
+  title:
+    "C2599 - Adds only device context data when only device is specified in configuration.",
+  requestHooks: [networkLogger.edgeEndpointLogs]
+});
+
+test.meta({
+  ID: "C2599",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+
+const triggerAlloyEvent = ClientFunction(() => {
+  return window.alloy("event", {
+    xdm: {
+      web: {
+        webPageDetails: {
+          URL: "https://alloyio.com/functional-test/alloyTestPage.html"
+        }
+      }
+    }
+  });
+});
+
+test("C2599 - Adds only device context data when only device is specified in configuration.", async () => {
+  await configureAlloyInstance("alloy", deviceContextConfig);
+  await triggerAlloyEvent();
+
+  await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
+  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
+
+  const request = networkLogger.edgeEndpointLogs.requests[0].request.body;
+  const stringifyRequest = JSON.parse(request);
+
+  await t.expect(stringifyRequest.events[0].xdm.device).ok();
+  await t.expect(stringifyRequest.events[0].xdm.web.webPageDetails).ok();
+
+  await t.expect(stringifyRequest.events[0].xdm.placeContext).notOk();
+  await t.expect(stringifyRequest.events[0].xdm.environment).notOk();
+});


### PR DESCRIPTION
Adds only device context data when only device is specified in configuration

## Description


1 ) Configure the SDK with context: ["device"]. Execute an event command.

Expected: Only device context data should be added to the request and not other context data.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
