### PR TITLE
CORE-41703 Add validator noUnknownFields

### DIFF
--- a/src/core/buildAndValidateConfig.js
+++ b/src/core/buildAndValidateConfig.js
@@ -26,7 +26,9 @@ const buildSchema = (coreConfigValidators, componentCreators) => {
 
 const transformOptions = (schema, options) => {
   try {
-    const validator = objectOf(schema).required();
+    const validator = objectOf(schema)
+      .noUnknownFields()
+      .required();
     return validator(options);
   } catch (e) {
     throw new Error(

--- a/src/utils/validation/createNoUnknownFieldsValidator.js
+++ b/src/utils/validation/createNoUnknownFieldsValidator.js
@@ -10,37 +10,18 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import isObject from "../isObject";
-import assertValid from "./assertValid";
-
 export default schema => (value, path) => {
-  assertValid(isObject(value), value, path, "an object");
-
   const errors = [];
-  const validatedObject = {};
-  Object.keys(schema).forEach(subKey => {
-    const subValue = value[subKey];
-    const subSchema = schema[subKey];
-    const subPath = path ? `${path}.${subKey}` : subKey;
-    try {
-      const validatedValue = subSchema(subValue, subPath);
-      if (validatedValue !== undefined) {
-        validatedObject[subKey] = validatedValue;
-      }
-    } catch (e) {
-      errors.push(e.message);
-    }
-  });
-
-  // copy over unknown properties
   Object.keys(value).forEach(subKey => {
-    if (!Object.prototype.hasOwnProperty.call(validatedObject, subKey)) {
-      validatedObject[subKey] = value[subKey];
+    if (!schema[subKey]) {
+      const subPath = path ? `${path}.${subKey}` : subKey;
+      errors.push(`'${subPath}': Unknown field.`);
     }
   });
 
   if (errors.length) {
     throw new Error(errors.join("\n"));
   }
-  return validatedObject;
+
+  return value;
 };

--- a/src/utils/validation/index.js
+++ b/src/utils/validation/index.js
@@ -20,6 +20,7 @@ import createArrayOfValidator from "./createArrayOfValidator";
 import createDefaultValidator from "./createDefaultValidator";
 import createLiteralValidator from "./createLiteralValidator";
 import createMinimumValidator from "./createMinimumValidator";
+import createNoUnknownFieldsValidator from "./createNoUnknownFieldsValidator";
 import createNonEmptyValidator from "./createNonEmptyValidator";
 import createObjectOfValidator from "./createObjectOfValidator";
 import createAnyOfValidator from "./createAnyOfValidator";
@@ -97,7 +98,12 @@ const number = function number() {
   });
 };
 const objectOf = function objectOf(schema) {
-  return nullSafeChain(this, createObjectOfValidator(schema));
+  const noUnknownFields = function noUnknownFields() {
+    return nullSafeChain(this, createNoUnknownFieldsValidator(schema));
+  };
+  return nullSafeChain(this, createObjectOfValidator(schema), {
+    noUnknownFields
+  });
 };
 const string = function string() {
   return nullSafeChain(this, stringValidator, {

--- a/test/unit/specs/core/buildAndValidateConfig.spec.js
+++ b/test/unit/specs/core/buildAndValidateConfig.spec.js
@@ -85,7 +85,6 @@ describe("buildAndValidateConfig", () => {
 
   it("logs and returns computed configuration", () => {
     logger.enabled = true;
-    options.foo = "bar";
     buildAndValidateConfig({
       options,
       componentCreators,
@@ -99,6 +98,22 @@ describe("buildAndValidateConfig", () => {
       debugEnabled: false,
       idSyncEnabled: true
     });
+  });
+
+  it("throws an error for unknown fields", () => {
+    logger.enabled = true;
+    options.foo = "bar";
+    expect(() =>
+      buildAndValidateConfig({
+        options,
+        componentCreators,
+        coreConfigValidators,
+        createConfig,
+        logger,
+        setDebugEnabled,
+        setErrorsEnabled
+      })
+    ).toThrowError();
   });
 
   it("returns config", () => {

--- a/test/unit/specs/utils/validation/createNoUnknownFieldsValidator.spec.js
+++ b/test/unit/specs/utils/validation/createNoUnknownFieldsValidator.spec.js
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { objectOf, string } from "../../../../../src/utils/validation";
+import describeValidation from "./describeValidation";
+
+describe("validation::noUnknownFields", () => {
+  describeValidation("optional", objectOf({ a: string() }).noUnknownFields(), [
+    { value: { b: "world" }, error: true },
+    { value: { a: "hello", b: "world" }, error: true },
+    { value: { a: "hello" }, error: false },
+    { value: {}, error: false }
+  ]);
+
+  describeValidation(
+    "required",
+    objectOf({ a: string().required() })
+      .noUnknownFields()
+      .required(),
+    [
+      { value: null, error: true },
+      { value: undefined, error: true },
+      { value: {}, error: true },
+      { value: { a: "Hello" }, error: false }
+    ]
+  );
+
+  describeValidation(
+    "default",
+    objectOf({ a: string().default("hello") })
+      .noUnknownFields()
+      .default({ a: "world" }),
+    [
+      { value: null, expected: { a: "world" } },
+      { value: undefined, expected: { a: "world" } },
+      { value: {}, expected: { a: "hello" } },
+      { value: { b: "goodbye" }, error: true }
+    ]
+  );
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a noUnknownFields validator that can chain with objectOf.  This also changes the objectOf validator to pass through unknown fields.

## Related Issue

https://jira.corp.adobe.com/browse/CORE-41703

## Motivation and Context

If you have a typo in the configuration field name, there was no error reported.  This could be confusing if there is a default value for that field.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
