### PR TITLE
Update e2e test HTML page with setCustomerIds support

### DIFF
--- a/sandbox/public/e2e/index.html
+++ b/sandbox/public/e2e/index.html
@@ -29,11 +29,53 @@
           : decodeURIComponent(results[1].replace(/\+/g, " "));
       }
 
+      function generateEmail(length, domain) {
+        const chars = [..."abcdefghijklmnopqrstuvwxyz0123456789"];
+        return [...Array(length)].map(i=>chars[Math.random()*chars.length|0]).join`` + '@' + domain;
+      }
+
+      var email = generateEmail(15,"alloye2etest.com");
+
+      // function to get email sha-256 cryptographic value
+      async function get_email_sha256(str) {
+        const buf = await crypto.subtle.digest("SHA-256", new TextEncoder("utf-8").encode(str));
+        return Array.prototype.map.call(new Uint8Array(buf), x=>(('00'+x.toString(16)).slice(-2))).join('');
+      }
+
+      function isSetCustomerIds() {
+        return (getUrlParameter("setCustomerIds") == "true");
+      }
+
       alloy("configure", {
+        // TO-DO: remove temporary workaround for collect call with identityMap until thirdPartyCookiesEnabled default behavior is fixed
+        thirdPartyCookiesEnabled: isSetCustomerIds() ? true : false,
         edgeDomain: "firstparty.alloyio.com",
         configId: getUrlParameter("configId"),
         orgId: "555B08345D76A68D0A495E79@AdobeOrg"
       });
+
+      if (isSetCustomerIds()) {
+        var emailPromise = Promise.resolve(get_email_sha256(email));
+        emailPromise.then(function(result) {
+            window.e2e_email_lc_sha256 = result;
+        });
+        console.log("setCustomerIds option is enabled");
+        alloy("setCustomerIds", {
+          Email_LC_SHA256: {
+            id: email,
+            authenticatedState: "ambiguous",
+            hashEnabled: true,
+            primary: true
+          },
+          HYP: {
+            id: "9997",
+            authenticatedState: "ambiguous"
+          }
+        }).then(function() {
+          console.log("Email SHA-256 value: ", e2e_email_lc_sha256);
+          console.log("Sandbox: Set customer IDs event has completed.");
+        });
+      }
 
       alloy("event", {
         viewStart: true

--- a/sandbox/public/e2e/index.html
+++ b/sandbox/public/e2e/index.html
@@ -31,33 +31,44 @@
 
       function generateEmail(length, domain) {
         const chars = [..."abcdefghijklmnopqrstuvwxyz0123456789"];
-        return [...Array(length)].map(i=>chars[Math.random()*chars.length|0]).join`` + '@' + domain;
+        return (
+          [...Array(length)].map(i => chars[(Math.random() * chars.length) | 0])
+            .join`` +
+          "@" +
+          domain
+        );
       }
 
-      var email = generateEmail(15,"alloye2etest.com");
+      const email = generateEmail(15, "alloye2etest.com");
+      const namespaceUserId = new Date().getTime();
+      const isSetCustomerIds = getUrlParameter("setCustomerIds") === "true";
 
       // function to get email sha-256 cryptographic value
-      async function get_email_sha256(str) {
-        const buf = await crypto.subtle.digest("SHA-256", new TextEncoder("utf-8").encode(str));
-        return Array.prototype.map.call(new Uint8Array(buf), x=>(('00'+x.toString(16)).slice(-2))).join('');
-      }
-
-      function isSetCustomerIds() {
-        return (getUrlParameter("setCustomerIds") == "true");
+      async function getEmailSha256(str) {
+        const buf = await crypto.subtle.digest(
+          "SHA-256",
+          new TextEncoder("utf-8").encode(str)
+        );
+        return Array.prototype.map
+          .call(new Uint8Array(buf), x => ("00" + x.toString(16)).slice(-2))
+          .join("");
       }
 
       alloy("configure", {
         // TO-DO: remove temporary workaround for collect call with identityMap until thirdPartyCookiesEnabled default behavior is fixed
-        thirdPartyCookiesEnabled: isSetCustomerIds() ? true : false,
+        thirdPartyCookiesEnabled: isSetCustomerIds,
         edgeDomain: "firstparty.alloyio.com",
         configId: getUrlParameter("configId"),
         orgId: "555B08345D76A68D0A495E79@AdobeOrg"
       });
 
-      if (isSetCustomerIds()) {
-        var emailPromise = Promise.resolve(get_email_sha256(email));
+      if (isSetCustomerIds) {
+        var emailPromise = Promise.resolve(getEmailSha256(email));
         emailPromise.then(function(result) {
-            window.e2e_email_lc_sha256 = result;
+          window.e2eParamsObj = {
+            email_lc_sha256: result,
+            namespaceUserId: namespaceUserId
+          };
         });
         console.log("setCustomerIds option is enabled");
         alloy("setCustomerIds", {
@@ -68,11 +79,16 @@
             primary: true
           },
           HYP: {
-            id: "9997",
+            id: namespaceUserId,
             authenticatedState: "ambiguous"
           }
         }).then(function() {
-          console.log("Email SHA-256 value: ", e2e_email_lc_sha256);
+          console.log(
+            "Email SHA-256 value: ",
+            e2eParamsObj["email_lc_sha256"],
+            " and namespace user ID: ",
+            e2eParamsObj["namespaceUserId"]
+          );
           console.log("Sandbox: Set customer IDs event has completed.");
         });
       }


### PR DESCRIPTION
## Description

Adding setCustomerIds support in the E2E HTML test page via query string param flag.
More details on:  https://wiki.corp.adobe.com/display/DMSArchitecture/E2E+Experience+Edge+Alloy.js

## Related Issue
Not that I'm aware of.
## Motivation and Context
See the above links.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
