### PR TITLE
Fix for e2e test HTML page namespace id

### DIFF
--- a/sandbox/public/e2e/index.html
+++ b/sandbox/public/e2e/index.html
@@ -40,7 +40,7 @@
       }
 
       const email = generateEmail(15, "alloye2etest.com");
-      const namespaceUserId = new Date().getTime();
+      const namespaceUserId = new Date().getTime().toString();
       const isSetCustomerIds = getUrlParameter("setCustomerIds") === "true";
 
       // function to get email sha-256 cryptographic value


### PR DESCRIPTION
## Description

Adding setCustomerIds support in the E2E HTML test page via query string param flag.
More details on:  https://wiki.corp.adobe.com/display/DMSArchitecture/E2E+Experience+Edge+Alloy.js

## Related Issue
Not that I'm aware of.
## Motivation and Context
See the above links.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
