### PR TITLE
Fix C2579 temporarily.

### DIFF
--- a/test/functional/specs/C2579.js
+++ b/test/functional/specs/C2579.js
@@ -10,7 +10,7 @@ const networkLogger1 = RequestLogger(
   networkLoggerConfig
 );
 const networkLogger2 = RequestLogger(
-  /v1\/(interact|collect)\?configId=8888888/,
+  /v1\/(interact|collect)\?configId=60928f59-0406-4353-bfe3-22ed633c4f67/,
   networkLoggerConfig
 );
 
@@ -41,7 +41,8 @@ const instance1Config = ClientFunction(() =>
     configId: "9999999",
     orgId: "53A16ACB5CC1D3760A495C99@AdobeOrg",
     edgeBasePath: window.edgeBasePath,
-    idMigrationEnabled: false
+    idMigrationEnabled: false,
+    debugEnabled: true
   })
 );
 const instance1Event = ClientFunction(() =>
@@ -49,10 +50,11 @@ const instance1Event = ClientFunction(() =>
 );
 const instance2Config = ClientFunction(() =>
   window.instance2("configure", {
-    configId: "8888888",
-    orgId: "97D1F3F459CE0AD80A495CBE@AdobeOrg",
+    configId: "60928f59-0406-4353-bfe3-22ed633c4f67",
+    orgId: "334F60F35E1597910A495EC2@AdobeOrg",
     edgeBasePath: window.edgeBasePath,
-    idMigrationEnabled: false
+    idMigrationEnabled: false,
+    debugEnabled: true
   })
 );
 const instance2Event = ClientFunction(() =>


### PR DESCRIPTION
It look like konductor is not respecting the ORG ID being passed in meta, and instead its using the config ID to lookup the ORG ID. Since the 888 config ID is coupled to the same ORG ID on the server, konductor is returning the same cookie name for both instances.

Working with the Konductor team to figure out what's going on. Meanwhile, I'm using the newly created ORG + Config ID for the QE team.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
