### PR TITLE
C28754 - Consenting to no purposes should result in no data handles in the response.

### DIFF
--- a/test/functional/helpers/networkLogger/index.js
+++ b/test/functional/helpers/networkLogger/index.js
@@ -18,6 +18,7 @@ const createNetworkLogger = () => {
   const edgeEndpoint = /v1\/(interact|collect)\?configId=/;
   const edgeCollectEndpoint = /v1\/collect\?configId=/;
   const edgeInteractEndpoint = /v1\/interact\?configId=/;
+  const setConsentEndpoint = /v1\/privacy\/set-consent\?configId=/;
 
   const gatewayEndpointLogs = createRequestLogger(gatewayEndpoint);
   const adobedcDemdexLogs = createRequestLogger(adobedcDemdex);
@@ -25,6 +26,7 @@ const createNetworkLogger = () => {
   const edgeEndpointLogs = createRequestLogger(edgeEndpoint);
   const edgeCollectEndpointLogs = createRequestLogger(edgeCollectEndpoint);
   const edgeInteractEndpointLogs = createRequestLogger(edgeInteractEndpoint);
+  const setConsentEndpointLogs = createRequestLogger(setConsentEndpoint);
 
   const clearLogs = async () => {
     await gatewayEndpointLogs.clear();
@@ -33,6 +35,7 @@ const createNetworkLogger = () => {
     await edgeEndpointLogs.clear();
     await edgeCollectEndpointLogs.clear();
     await edgeInteractEndpointLogs.clear();
+    await setConsentEndpointLogs.clear();
   };
 
   return {
@@ -42,6 +45,7 @@ const createNetworkLogger = () => {
     edgeEndpointLogs,
     edgeCollectEndpointLogs,
     edgeInteractEndpointLogs,
+    setConsentEndpointLogs,
     clearLogs
   };
 };

--- a/test/functional/specs/C2593.js
+++ b/test/functional/specs/C2593.js
@@ -17,10 +17,6 @@ test.meta({
   SEVERITY: "P0",
   TEST_RUN: "REGRESSION"
 });
-
-const setConsentToIn = ClientFunction(() => {
-  return window.alloy("setConsent", { general: "in" });
-});
 // execute an event command with no request sent
 const triggerAlloyEvent = ClientFunction(() => {
   return { promise: window.alloy("event") };
@@ -36,9 +32,9 @@ test("Test C2593: Event command consents to all purposes", async () => {
   const promise = (await triggerAlloyEvent()).promise;
 
   // set consent to in
-  await setConsentToIn();
-  await promise;
+  await t.eval(() => window.alloy("setConsent", { general: "in" }));
 
-  await responseStatus(networkLogger.edgeEndpointLogs.requests, 204);
+  await promise;
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
+  await responseStatus(networkLogger.edgeEndpointLogs.requests, 204);
 });

--- a/test/functional/specs/C28754.js
+++ b/test/functional/specs/C28754.js
@@ -1,0 +1,41 @@
+import { t } from "testcafe";
+import createNetworkLogger from "../helpers/networkLogger";
+import { responseStatus } from "../helpers/assertions";
+import fixtureFactory from "../helpers/fixtureFactory";
+import baseConfig from "../helpers/constants/baseConfig";
+import configureAlloyInstance from "../helpers/configureAlloyInstance";
+
+const networkLogger = createNetworkLogger();
+
+fixtureFactory({
+  title:
+    "C28754 - Consenting to no purposes should result in no data handles in the response.",
+  requestHooks: [networkLogger.edgeEndpointLogs]
+});
+
+test.meta({
+  ID: "C28754",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+
+test("C28754 - Consenting to no purposes should result in no data handles in the response.", async () => {
+  await configureAlloyInstance("alloy", {
+    defaultConsent: { general: "pending" },
+    ...baseConfig
+  });
+
+  await t.eval(() => window.alloy("setConsent", { general: "out" }));
+
+  await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
+  const errorMessage = await t.eval(() =>
+    window
+      .alloy("event", { data: { a: 1 } })
+      .then(() => undefined, e => e.message)
+  );
+
+  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(0);
+
+  await t.expect(errorMessage).ok("Expected the event command to be rejected");
+  await t.expect(errorMessage).contains("user declined consent");
+});


### PR DESCRIPTION
## Description

If user consents to no purposes: { general: "out" }

We should not see the following in the response:

ID Syncs
Destinations
Personalization offers

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
