### PR TITLE
C28756 - Form based offer should return if event command contains its scope

### DIFF
--- a/test/functional/specs/C28756.js
+++ b/test/functional/specs/C28756.js
@@ -1,0 +1,47 @@
+import { t, ClientFunction } from "testcafe";
+import createNetworkLogger from "../helpers/networkLogger";
+import fixtureFactory from "../helpers/fixtureFactory";
+import configureAlloyInstance from "../helpers/configureAlloyInstance";
+import createResponse from "../../../src/core/createResponse";
+import getResponseBody from "../helpers/networkLogger/getResponseBody";
+
+const networkLogger = createNetworkLogger();
+fixtureFactory({
+  title:
+    "C28756 A form based offer should return if event command contains its scope.",
+  requestHooks: [networkLogger.edgeEndpointLogs]
+});
+test.meta({
+  ID: "C28756",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+const triggerAlloyEvent = ClientFunction(() => {
+  return window.alloy("event", {
+    scopes: ["C28756-1"]
+  });
+});
+test("C28756 A form based offer should return if event command contains its scope", async () => {
+  await configureAlloyInstance("alloy", {
+    configId: "60928f59-0406-4353-bfe3-22ed633c4f67",
+    orgId: "334F60F35E1597910A495EC2@AdobeOrg"
+  });
+  // trigger an event
+  await triggerAlloyEvent();
+  const response = JSON.parse(
+    getResponseBody(networkLogger.edgeEndpointLogs.requests[0])
+  );
+  const alloyResponse = createResponse(response);
+  const personalizationPayloads = alloyResponse.getPayloadsByType(
+    "personalization:decisions"
+  );
+  await t.expect(personalizationPayloads).notEql([]);
+
+  const scopedOffer = personalizationPayloads.find(
+    payload => payload.scope === "C28756-1"
+  );
+  await t.expect(scopedOffer).ok();
+  await t
+    .expect(scopedOffer.items[0].schema)
+    .eql("https://ns.adobe.com/personalization/json-content-item");
+});


### PR DESCRIPTION
[WIP]

## Description

Trigger an event command with a scopes prop = ['alloy-test-scope-1`]

Response should contain the offer with this scope

Create a form based offer with scope: alloy-test-scope-1
Use alloyio.com/functional-test/alloyTestPage.html as domain

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
