### PR TITLE
Attempt to fix C2593.

### DIFF
--- a/test/functional/specs/C2581.js
+++ b/test/functional/specs/C2581.js
@@ -66,9 +66,12 @@ const triggerAlloyEvents = ClientFunction(() => {
   return new Promise(resolve => {
     window
       .alloy("event", { viewStart: true, data: { key: "value" } })
-      .then(() => resolve());
-    window.alloy("event", { data: { key: "value" } });
-    window.alloy("event", { data: { key: "value" } });
+      .then(() => {
+        window.alloy("event", { data: { key: "value" } });
+        window.alloy("event", { data: { key: "value" } });
+
+        resolve();
+      });
   });
 });
 

--- a/test/functional/specs/C2593.js
+++ b/test/functional/specs/C2593.js
@@ -17,9 +17,14 @@ test.meta({
   SEVERITY: "P0",
   TEST_RUN: "REGRESSION"
 });
-// execute an event command with no request sent
-const triggerAlloyEvent = ClientFunction(() => {
-  return { promise: window.alloy("event") };
+
+const triggerEventThenConsent = ClientFunction(() => {
+  return new Promise(resolve => {
+    const eventPromise = window.alloy("event", { xdm: { key: "value" } });
+    window.alloy("setConsent", { general: "in" }).then(() => {
+      eventPromise.then(resolve);
+    });
+  });
 });
 
 test("Test C2593: Event command consents to all purposes", async () => {
@@ -29,12 +34,8 @@ test("Test C2593: Event command consents to all purposes", async () => {
     ...environmentContextConfig
   });
   // trigger alloy event
-  const promise = (await triggerAlloyEvent()).promise;
+  await triggerEventThenConsent();
 
-  // set consent to in
-  await t.eval(() => window.alloy("setConsent", { general: "in" }));
-
-  await promise;
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
   await responseStatus(networkLogger.edgeEndpointLogs.requests, 204);
 });


### PR DESCRIPTION
## Description

Stop using the `AlloyEvent` helper because it's' assuming that returning a promise from `ClientFunction` would make it safely to testcafe in the Node world, but testcafe is serializing the promise into a regular object; so awaiting that promise is not doing anything, which means race conditions arise.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [x] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
