### PR TITLE
Allow multiple instances with the same orgId

### DIFF
--- a/src/components/Identity/createComponent.js
+++ b/src/components/Identity/createComponent.js
@@ -4,10 +4,9 @@ export default ({
   ensureRequestHasIdentity,
   createLegacyIdentityCookie,
   handleResponseForIdSyncs,
-  getEcidFromResponse
+  getEcidFromResponse,
+  ecidReference
 }) => {
-  let ecid;
-
   return {
     lifecycle: {
       // TODO: It would probably be best to query on the data collection payload level
@@ -21,13 +20,13 @@ export default ({
         return ensureRequestHasIdentity({ payload, onResponse });
       },
       onResponse({ response }) {
-        if (!ecid) {
-          ecid = getEcidFromResponse(response);
+        if (!ecidReference.value) {
+          ecidReference.value = getEcidFromResponse(response);
 
           // Only data collection calls will have an ECID in the response.
           // https://jira.corp.adobe.com/browse/EXEG-1234
-          if (ecid) {
-            createLegacyIdentityCookie(ecid);
+          if (ecidReference.value) {
+            createLegacyIdentityCookie(ecidReference.value);
           }
         }
 
@@ -42,8 +41,8 @@ export default ({
       },
       getEcid: {
         run() {
-          if (ecid) {
-            return ecid;
+          if (ecidReference.value) {
+            return ecidReference.value;
           }
 
           // TODO: Make request for ECID and return the ECID back to the customer.

--- a/src/components/Privacy/createComponent.js
+++ b/src/components/Privacy/createComponent.js
@@ -31,7 +31,9 @@ export default ({
       // Only read cookies when there are no outstanding setConsent
       // requests. This helps with race conditions.
       const storedConsent = readStoredConsent();
-      consentObjects.forEach(() => consent.setConsent(storedConsent));
+      consentObjects.forEach(consentObject =>
+        consentObject.setConsent(storedConsent)
+      );
     }
   };
 
@@ -40,7 +42,7 @@ export default ({
       setConsent: {
         optionsValidator: validateSetConsentOptions,
         run: options => {
-          consentObjects.forEach(() => consent.suspend());
+          consentObjects.forEach(consentObject => consentObject.suspend());
           return taskQueue
             .addTask(() => sendSetConsentRequest(options))
             .catch(error => {

--- a/src/core/config/createCoreConfigs.js
+++ b/src/core/config/createCoreConfigs.js
@@ -40,8 +40,6 @@ export default () => ({
   edgeBasePath: string()
     .nonEmpty()
     .default(EDGE_BASE_PATH),
-  orgId: string()
-    .unique()
-    .required(),
+  orgId: string().required(),
   onBeforeEventSend: callback().default(noop)
 });

--- a/test/unit/specs/components/Identity/createComponent.spec.js
+++ b/test/unit/specs/components/Identity/createComponent.spec.js
@@ -19,6 +19,7 @@ describe("Identity::createComponent", () => {
   let createLegacyIdentityCookie;
   let handleResponseForIdSyncs;
   let getEcidFromResponse;
+  let ecidReference;
   let component;
 
   beforeEach(() => {
@@ -30,13 +31,15 @@ describe("Identity::createComponent", () => {
     );
     handleResponseForIdSyncs = jasmine.createSpy("handleResponseForIdSyncs");
     getEcidFromResponse = jasmine.createSpy("getEcidFromResponse");
+    ecidReference = {};
     component = createComponent({
       addEcidQueryToEvent,
       customerIds,
       ensureRequestHasIdentity,
       createLegacyIdentityCookie,
       handleResponseForIdSyncs,
-      getEcidFromResponse
+      getEcidFromResponse,
+      ecidReference
     });
   });
 

--- a/test/unit/specs/components/Identity/ensureRequestHasIdentityFactory.spec.js
+++ b/test/unit/specs/components/Identity/ensureRequestHasIdentityFactory.spec.js
@@ -23,6 +23,7 @@ describe("Identity::ensureRequestHasIdentityFactory", () => {
   let awaitIdentityCookie;
   let logger;
   let ensureRequestHasIdentity;
+  let identityCookiePromiseReference;
 
   beforeEach(() => {
     doesIdentityCookieExist = jasmine
@@ -40,12 +41,14 @@ describe("Identity::ensureRequestHasIdentityFactory", () => {
       .createSpy("awaitIdentityCookie")
       .and.returnValue(awaitIdentityCookieDeferred.promise);
     logger = jasmine.createSpyObj("logger", ["log"]);
+    identityCookiePromiseReference = {};
     ensureRequestHasIdentity = ensureRequestHasIdentityFactory({
       doesIdentityCookieExist,
       setDomainForInitialIdentityPayload,
       addEcidFromLegacyToPayload,
       awaitIdentityCookie,
-      logger
+      logger,
+      identityCookiePromiseReference
     });
   });
 

--- a/test/unit/specs/components/Privacy/createComponent.spec.js
+++ b/test/unit/specs/components/Privacy/createComponent.spec.js
@@ -21,6 +21,7 @@ describe("privacy:createComponent", () => {
   let consent;
   let sendSetConsentRequest;
   let validateSetConsentOptions;
+  let consentObjects;
   let component;
 
   beforeEach(() => {
@@ -32,6 +33,7 @@ describe("privacy:createComponent", () => {
     validateSetConsentOptions = jasmine
       .createSpy("validateSetConsentOptions")
       .and.callFake(options => options);
+    consentObjects = [consent];
   });
 
   const build = () => {
@@ -41,7 +43,8 @@ describe("privacy:createComponent", () => {
       defaultConsent,
       consent,
       sendSetConsentRequest,
-      validateSetConsentOptions
+      validateSetConsentOptions,
+      consentObjects
     });
   };
 

--- a/test/unit/specs/core/config/createCoreConfigs.spec.js
+++ b/test/unit/specs/core/config/createCoreConfigs.spec.js
@@ -176,7 +176,7 @@ describe("createCoreConfigs", () => {
     expect(() => validator("", config3)).toThrowError();
   });
 
-  it("invalidates duplicate orgIds", () => {
+  it("allows duplicate orgIds", () => {
     const validator = objectOf(createCoreConfigs());
     const config1 = { configId: "a", orgId: "a" };
     const config2 = { configId: "b", orgId: "b" };
@@ -184,6 +184,6 @@ describe("createCoreConfigs", () => {
 
     validator(config1);
     validator(config2);
-    expect(() => validator("", config3)).toThrowError();
+    validator(config3);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR allows multiple instances of Alloy to be created with the same orgId.  This is tricky because all the cookies are keyed off of the orgId, so if multiple instances of Alloy have the same org, they need to share cookies.  When cookies could be written by Konductor, each instance that share the org need to be notified.  This is important for Privacy and Identity because they are the two components that read cookies.

### Identity Configuration
`idMigrationEnabled` and `thirdPartyCookiesEnabled` are the two settings which control how an ECID is obtained.  In a scenario where two instances of Alloy are configured with the same orgId, but these config settings are different, the first instance which attempts to obtain an ECID will use its config.  

**Recommendation:** either each instance that shares an orgId have these settings set the same, or the instance with the desired settings always obtains the ECID first.

### Setting Customer Ids
Setting customer ids on one instance does not affect other instances which share an orgId.  Requests to Konductor will only have the customer ids set on that instance.

### Privacy Configuration
`defaultConsent` can be different across two instances of Alloy which share the same orgId; however, once consent is set, the consent state will be synchronized across the instances.

### Personalization
One thing missing from this that may be important is the ability to send Personalization decisions and rendering information to multiple configIds.  This is not tackled in this PR.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/CORE-41753

## Motivation and Context

Customers want to be able to send data to two configIds within the same IMS org.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
