### PR TITLE
`setCustomerIds` command: Updating warning message on failed hashing 

### DIFF
--- a/src/components/Identity/customerIds/createCustomerIds.js
+++ b/src/components/Identity/customerIds/createCustomerIds.js
@@ -1,13 +1,12 @@
 import { normalizeCustomerIds, validateCustomerIds } from "./util";
-import {
-  convertBufferToHex,
-  convertStringToSha256Buffer,
-  clone,
-  noop,
-  isEmptyObject
-} from "../../../utils";
+import { convertBufferToHex, clone, noop, isEmptyObject } from "../../../utils";
 
-export default ({ eventManager, consent, logger }) => {
+export default ({
+  eventManager,
+  consent,
+  logger,
+  convertStringToSha256Buffer
+}) => {
   const hash = (originalIds, normalizedIds) => {
     const idNames = Object.keys(normalizedIds);
     const idsToHash = idNames.filter(idName => originalIds[idName].hashEnabled);
@@ -19,7 +18,7 @@ export default ({ eventManager, consent, logger }) => {
         if (!hashedId) {
           delete finalIds[idsToHash[index]];
           logger.warn(
-            `Unable to hash identity ${idsToHash[index]} due to lack of browser support. Provided ${idsToHash[index]} will not be sent to Adobe Experience Cloud`
+            `Unable to hash identity ${idsToHash[index]} due to lack of browser support. Provided ${idsToHash[index]} will not be sent to Adobe Experience Cloud.`
           );
         } else {
           finalIds[idsToHash[index]].id = convertBufferToHex(hashedId);

--- a/src/components/Identity/customerIds/createCustomerIds.js
+++ b/src/components/Identity/customerIds/createCustomerIds.js
@@ -19,7 +19,7 @@ export default ({ eventManager, consent, logger }) => {
         if (!hashedId) {
           delete finalIds[idsToHash[index]];
           logger.warn(
-            `Unable to hash identity ${idsToHash[index]} due to lack of browser support.`
+            `Unable to hash identity ${idsToHash[index]} due to lack of browser support. Provided ${idsToHash[index]} will not be sent to Adobe Experience Cloud`
           );
         } else {
           finalIds[idsToHash[index]].id = convertBufferToHex(hashedId);

--- a/src/components/Identity/index.js
+++ b/src/components/Identity/index.js
@@ -12,7 +12,8 @@ governing permissions and limitations under the License.
 
 import {
   fireReferrerHideableImage,
-  areThirdPartyCookiesSupportedByDefault
+  areThirdPartyCookiesSupportedByDefault,
+  convertStringToSha256Buffer
 } from "../../utils";
 import processIdSyncsFactory from "./processIdSyncsFactory";
 import configValidators from "./configValidators";
@@ -39,7 +40,12 @@ const createIdentity = ({
   sendEdgeNetworkRequest
 }) => {
   const { orgId, idMigrationEnabled, thirdPartyCookiesEnabled } = config;
-  const customerIds = createCustomerIds({ eventManager, consent, logger });
+  const customerIds = createCustomerIds({
+    eventManager,
+    consent,
+    logger,
+    convertStringToSha256Buffer
+  });
   const migration = createMigration({ idMigrationEnabled, orgId, logger });
   const doesIdentityCookieExist = doesIdentityCookieExistFactory({ orgId });
   const getEcid = createGetEcid({ sendEdgeNetworkRequest, consent });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updating warning message when browser fails to hash a customer id to inform the customer that the id will not be sent to Exp Cloud.

## Description
Updating warning message from
`Unable to hash identity **NAMESPACE** due to lack of browser support` to
`Unable to hash identity **NAMESPACE** due to lack of browser support. Provided **NAMESPACE** will not be sent to Adobe Experience Cloud`

## Related Issue

https://jira.corp.adobe.com/browse/CORE-39142

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have submitted a [documentation](https://github.com/AdobeDocs/alloy-docs) pull request or no changes are needed.
- [ ] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
