### PR TITLE
CORE-44791 Prevent modification of passed in xdm and data objects.

### DIFF
--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -1,4 +1,3 @@
-import { assign } from "../../utils";
 import validateUserEventOptions from "./validateUserEventOptions";
 
 /*
@@ -22,8 +21,8 @@ const createDataCollector = ({ eventManager, logger }) => {
           return validateUserEventOptions({ options, logger });
         },
         run: options => {
-          let { xdm } = options;
           const {
+            xdm,
             data,
             documentUnloading = false,
             type,
@@ -37,20 +36,20 @@ const createDataCollector = ({ eventManager, logger }) => {
             event.documentMayUnload();
           }
 
-          if (type || mergeId) {
-            xdm = Object(xdm);
-          }
+          event.setUserXdm(xdm);
+          event.setUserData(data);
 
           if (type) {
-            assign(xdm, { eventType: type });
+            event.mergeXdm({
+              eventType: type
+            });
           }
 
           if (mergeId) {
-            assign(xdm, { eventMergeId: mergeId });
+            event.mergeXdm({
+              eventMergeId: mergeId
+            });
           }
-
-          event.setUserXdm(xdm);
-          event.setUserData(data);
 
           return eventManager.sendEvent(event, {
             renderDecisions,

--- a/test/functional/specs/C75372.js
+++ b/test/functional/specs/C75372.js
@@ -1,0 +1,45 @@
+import { t, ClientFunction } from "testcafe";
+import createNetworkLogger from "../helpers/networkLogger";
+import fixtureFactory from "../helpers/fixtureFactory";
+import configureAlloyInstance from "../helpers/configureAlloyInstance";
+import { orgMainConfigMain } from "../helpers/constants/configParts";
+
+const networkLogger = createNetworkLogger();
+
+fixtureFactory({
+  title:
+    "C75372 - XDM and data objects passed into event command should not be modified",
+  requestHooks: [networkLogger.setConsentEndpointLogs]
+});
+
+test.meta({
+  ID: "C75372",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+
+const sendEvent = ClientFunction(() => {
+  const xdmDataLayer = { foo: "bar" };
+  const nonXdmDataLayer = { baz: "quux" };
+  // Using a merge ID is a decent test because it's one thing we know
+  // gets merged with the XDM object.
+  return window
+    .alloy("event", {
+      xdm: xdmDataLayer,
+      data: nonXdmDataLayer,
+      mergeId: "abc"
+    })
+    .then(() => {
+      return {
+        xdmDataLayer,
+        nonXdmDataLayer
+      };
+    });
+});
+
+test("C75372 - XDM and data objects passed into event command should not be modified", async () => {
+  await configureAlloyInstance("alloy", orgMainConfigMain);
+  const { xdmDataLayer, nonXdmDataLayer } = await sendEvent();
+  await t.expect(xdmDataLayer).eql({ foo: "bar" });
+  await t.expect(nonXdmDataLayer).eql({ baz: "quux" });
+});

--- a/test/unit/specs/components/DataCollector/index.spec.js
+++ b/test/unit/specs/components/DataCollector/index.spec.js
@@ -11,7 +11,6 @@ governing permissions and limitations under the License.
 
 import createDataCollector from "../../../../../src/components/DataCollector/index";
 import { noop } from "../../../../../src/utils";
-import createEvent from "../../../../../src/core/createEvent";
 
 describe("Event Command", () => {
   let event;
@@ -19,10 +18,12 @@ describe("Event Command", () => {
   let eventManager;
   let eventCommand;
   beforeEach(() => {
-    event = createEvent();
-    spyOn(event, "documentMayUnload").and.callThrough();
-    spyOn(event, "setUserData").and.callThrough();
-    spyOn(event, "setUserXdm").and.callThrough();
+    event = jasmine.createSpyObj("event", [
+      "documentMayUnload",
+      "setUserData",
+      "setUserXdm",
+      "mergeXdm"
+    ]);
     logger = jasmine.createSpyObj("logger", {
       warn: undefined
     });
@@ -99,31 +100,25 @@ describe("Event Command", () => {
     });
   });
 
-  it("sets eventType and eventMergeId", () => {
+  it("merges eventType", () => {
     return eventCommand
       .run({
-        type: "mytype",
-        mergeId: "mymergeid"
+        type: "mytype"
       })
       .then(() => {
-        expect(event.setUserXdm).toHaveBeenCalledWith({
-          eventType: "mytype",
-          eventMergeId: "mymergeid"
+        expect(event.mergeXdm).toHaveBeenCalledWith({
+          eventType: "mytype"
         });
       });
   });
 
-  it("merges eventType and eventMergeId with the userXdm", () => {
+  it("merges eventMergeID", () => {
     return eventCommand
       .run({
-        xdm: { key: "value" },
-        type: "mytype",
         mergeId: "mymergeid"
       })
       .then(() => {
-        expect(event.setUserXdm).toHaveBeenCalledWith({
-          key: "value",
-          eventType: "mytype",
+        expect(event.mergeXdm).toHaveBeenCalledWith({
           eventMergeId: "mymergeid"
         });
       });

--- a/test/unit/specs/core/createEvent.spec.js
+++ b/test/unit/specs/core/createEvent.spec.js
@@ -62,6 +62,46 @@ describe("createEvent", () => {
     });
   });
 
+  it("does not modify the original user XDM object", () => {
+    const dataLayer = {
+      fruit: {
+        type: "apple"
+      },
+      veggie: {
+        type: "carrot"
+      }
+    };
+    event.setUserXdm(dataLayer);
+    event.mergeXdm({
+      fruit: {
+        type: "strawberry"
+      },
+      sport: {
+        type: "basketball"
+      }
+    });
+    expect(dataLayer).toEqual({
+      fruit: {
+        type: "apple"
+      },
+      veggie: {
+        type: "carrot"
+      }
+    });
+  });
+
+  it("handles undefined user XDM", () => {
+    event.setUserXdm(undefined);
+    event.mergeXdm({
+      fruit: "apple"
+    });
+    expect(event.toJSON()).toEqual({
+      xdm: {
+        fruit: "apple"
+      }
+    });
+  });
+
   it("sets user data", () => {
     event.setUserData({ fruit: "apple" });
     event.setUserData({ veggie: "carrot" });
@@ -70,6 +110,11 @@ describe("createEvent", () => {
         veggie: "carrot"
       }
     });
+  });
+
+  it("handles undefined user data", () => {
+    event.setUserData(undefined);
+    expect(event.toJSON()).toEqual({});
   });
 
   it("deeply merges meta", () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When xdm is passed as an option to the event command AND either type or mergeId are passed as options, DataCollector ends up modifying the xdm object passed by the customer. This is bad for a couple reasons:

1. The xdm object the customer passes is possibly used by other customer code. For example, it may be the customer's data layer and they may be sending the data layer to other endpoints as well. In this case, they probably don't want Alloy-event-specific information being added to the data layer.
2. It can cause incorrect event types and event merge IDs to be sent. For example, if I do this:

```
const dataLayer = { foo: "bar" };
alloy("event", { xdm: dataLayer, mergeId: "abc" });
alloy("event", { xdm: dataLayer, mergeId: "def" });
```

Then `def` will be sent for the event merge ID for both requests. This happens because the first command sets `dataLayer.eventMergeId` to `abc`, but before the object is sent to the server, the second command sets `dataLayer.eventMergeId` to "def".

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-44791
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Current behavior is unexpected.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
