### PR TITLE
Rename the `event` to `sendEvent`

### DIFF
--- a/sandbox/public/e2e/index.html
+++ b/sandbox/public/e2e/index.html
@@ -93,7 +93,7 @@
         });
       }
 
-      alloy("event", {
+      alloy("sendEvent", {
         renderDecisions: true
       }).then(function(data) {
         console.log("Sandbox: View start event has completed.", data);

--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -80,7 +80,7 @@
         console.log("Sandbox: Get Ecid command has completed.,", id);
       });
 
-      alloy("event", {
+      alloy("sendEvent", {
         renderDecisions: true,
         decisionScopes: ["alloy-location-1", "alloy-location-2"],
         xdm: {

--- a/sandbox/public/visitor_consent.html
+++ b/sandbox/public/visitor_consent.html
@@ -50,7 +50,7 @@
         )
       });
 
-      alloy("event", {
+      alloy("sendEvent", {
         renderDecisions: true,
         xdm: {
           // Demonstrates overriding automatically collected data
@@ -73,7 +73,7 @@
       };
 
       const sendEvent = () => {
-        alloy("event", {
+        alloy("sendEvent", {
           renderDecisions: true,
           xdm: {
             // Demonstrates overriding automatically collected data

--- a/sandbox/public/visitor_race.html
+++ b/sandbox/public/visitor_race.html
@@ -47,7 +47,7 @@
         )
       });
 
-      alloy("event", {
+      alloy("sendEvent", {
         renderDecisions: true,
         xdm: {
           // Demonstrates overriding automatically collected data

--- a/sandbox/src/EventMerge.js
+++ b/sandbox/src/EventMerge.js
@@ -6,7 +6,7 @@ export default function EventMerge() {
   useEffect(() => {
     eventMergeIdPromise.current.then(eventMergeId => {
       window
-        .alloy("event", {
+        .alloy("sendEvent", {
           xdm: {
             key1: "value1",
             eventMergeId
@@ -16,7 +16,7 @@ export default function EventMerge() {
 
       setTimeout(() => {
         window
-          .alloy("event", {
+          .alloy("sendEvent", {
             xdm: {
               key2: "value2",
               eventMergeId

--- a/sandbox/src/Home.js
+++ b/sandbox/src/Home.js
@@ -8,7 +8,7 @@ function HomeWithHistory({ history }) {
       const instanceName = loc.pathname.includes("orgTwo")
         ? "organizationTwo"
         : "alloy";
-      window[instanceName]("event", {
+      window[instanceName]("sendEvent", {
         renderDecisions: true,
         xdm: {
           eventType: "page-view"

--- a/sandbox/src/LargePayload.js
+++ b/sandbox/src/LargePayload.js
@@ -5,7 +5,7 @@ export default function LargePayload() {
     var i;
     for (i = 0; i < times; i++) {
       const payload = new Uint8Array(size * 1024);
-      window.alloy("event", {
+      window.alloy("sendEvent", {
         documentUnloading: true,
         data: {
           payload

--- a/sandbox/src/Links.js
+++ b/sandbox/src/Links.js
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function Links() {
   const adobeLink = () => {
-    window.alloy("event", {
+    window.alloy("sendEvent", {
       documentUnloading: true,
       xdm: {
         "activitystreams:href": "http://www.adobe.com"

--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -16,7 +16,7 @@ governing permissions and limitations under the License.
 const createDataCollector = ({ eventManager, logger }) => {
   return {
     commands: {
-      event: {
+      sendEvent: {
         documentationUri: "https://adobe.ly/2r0uUjh",
         optionsValidator: options => {
           return validateUserEventOptions({ options, logger });

--- a/src/components/Privacy/createComponent.js
+++ b/src/components/Privacy/createComponent.js
@@ -25,9 +25,13 @@ export default ({
 
   const readCookieIfQueueEmpty = () => {
     if (taskQueue.length === 0) {
+      const storedConsent = readStoredConsent();
+
       // Only read cookies when there are no outstanding setConsent
       // requests. This helps with race conditions.
-      consent.setConsent(readStoredConsent());
+      if (storedConsent) {
+        consent.setConsent(storedConsent);
+      }
     }
   };
 

--- a/src/components/Privacy/readStoredConsentFactory.js
+++ b/src/components/Privacy/readStoredConsentFactory.js
@@ -18,6 +18,6 @@ export default ({ parseConsentCookie, orgId, cookieJar }) => {
 
   return () => {
     const cookieValue = cookieJar.get(consentCookieName);
-    return cookieValue ? parseConsentCookie(cookieValue) : {};
+    return cookieValue ? parseConsentCookie(cookieValue) : undefined;
   };
 };

--- a/test/functional/specs/C10922.js
+++ b/test/functional/specs/C10922.js
@@ -30,7 +30,7 @@ import setLegacyIdentityCookie from "../helpers/setLegacyIdentityCookie";
 const networkLogger = createNetworkLogger();
 
 const executeEventCommand = ClientFunction(() => {
-  return window.alloy("event");
+  return window.alloy("sendEvent");
 });
 
 const demdexHostRegex = /\.demdex\.net/;

--- a/test/functional/specs/C12411.js
+++ b/test/functional/specs/C12411.js
@@ -29,7 +29,7 @@ test.meta({
 });
 
 const triggerAlloyEvent = ClientFunction(() => {
-  return window.alloy("event", { xdm: { key: "value" } });
+  return window.alloy("sendEvent", { xdm: { key: "value" } });
 });
 
 test("C12411 Response should return URL destinations if turned on in Blackbird", async () => {

--- a/test/functional/specs/C12412.js
+++ b/test/functional/specs/C12412.js
@@ -17,7 +17,7 @@ test.meta({
 });
 
 const triggerAlloyEvent = ClientFunction(() => {
-  return window.alloy("event", { xdm: { key: "value" } });
+  return window.alloy("sendEvent", { xdm: { key: "value" } });
 });
 
 const getDocumentCookie = ClientFunction(() => document.cookie);

--- a/test/functional/specs/C13817.js
+++ b/test/functional/specs/C13817.js
@@ -14,7 +14,7 @@ test("Test C13817: Throws error when running command after bad configure", async
   const eventErrorMessage = await t.eval(() => {
     window.alloy("configure");
     return window
-      .alloy("event", { data: { key: "value" } })
+      .alloy("sendEvent", { data: { key: "value" } })
       .then(() => undefined, e => e.message);
   });
 

--- a/test/functional/specs/C13818.js
+++ b/test/functional/specs/C13818.js
@@ -38,7 +38,7 @@ const apiCalls = ClientFunction((configObject, alternateConfigObject) => {
     Object.keys(alternateConfigObject).forEach(key => {
       configObject[key] = alternateConfigObject[key];
     });
-    return window.alloy("event", { data: { key: "value" } });
+    return window.alloy("sendEvent", { data: { key: "value" } });
   });
 });
 

--- a/test/functional/specs/C14394.js
+++ b/test/functional/specs/C14394.js
@@ -34,7 +34,7 @@ test.meta({
 });
 
 const triggerAlloyEvent = ClientFunction(() => {
-  return window.alloy("event", { renderDecisions: true });
+  return window.alloy("sendEvent", { renderDecisions: true });
 });
 
 test("Test C14394: When ID migration is enabled and no identity cookie is found but legacy identity cookie is found, the ECID will be sent on the request", async () => {

--- a/test/functional/specs/C14399.js
+++ b/test/functional/specs/C14399.js
@@ -38,7 +38,7 @@ const setEcidCookie = ClientFunction(() => {
 });
 
 const triggerAlloyEvent = ClientFunction(() => {
-  return window.alloy("event", { renderDecisions: true });
+  return window.alloy("sendEvent", { renderDecisions: true });
 });
 
 const getDocumentCookie = ClientFunction(() => document.cookie);

--- a/test/functional/specs/C14400.js
+++ b/test/functional/specs/C14400.js
@@ -40,7 +40,7 @@ const setEcidCookie = ClientFunction(() => {
 });
 
 const triggerAlloyEvent = ClientFunction(() => {
-  return window.alloy("event", { renderDecisions: true });
+  return window.alloy("sendEvent", { renderDecisions: true });
 });
 
 const getDocumentCookie = ClientFunction(() => document.cookie);

--- a/test/functional/specs/C14401.js
+++ b/test/functional/specs/C14401.js
@@ -36,7 +36,7 @@ test.meta({
 });
 
 const triggerAlloyEvent = ClientFunction(() => {
-  return window.alloy("event", { renderDecisions: true });
+  return window.alloy("sendEvent", { renderDecisions: true });
 });
 
 test("Test C14401: When ID migration is disabled and no identity cookie is found but legacy identity cookie is found, the ECID will not be sent on the request", async () => {

--- a/test/functional/specs/C14402.js
+++ b/test/functional/specs/C14402.js
@@ -36,7 +36,7 @@ test.meta({
 });
 
 const triggerAlloyEvent = ClientFunction(() => {
-  return window.alloy("event", { renderDecisions: true });
+  return window.alloy("sendEvent", { renderDecisions: true });
 });
 
 const getDocumentCookie = ClientFunction(() => document.cookie);

--- a/test/functional/specs/C14403.js
+++ b/test/functional/specs/C14403.js
@@ -36,7 +36,7 @@ test.meta({
 });
 
 const triggerAlloyEvent = ClientFunction(() => {
-  return window.alloy("event", { renderDecisions: true });
+  return window.alloy("sendEvent", { renderDecisions: true });
 });
 
 const getDocumentCookie = ClientFunction(() => document.cookie);

--- a/test/functional/specs/C14404.js
+++ b/test/functional/specs/C14404.js
@@ -45,7 +45,7 @@ test("Test C14404: User cannot consent to all purposes after consenting to no pu
   // make sure the instance still has no consent
   const eventErrorMessage = await t.eval(() =>
     window
-      .alloy("event", { data: { a: 1 } })
+      .alloy("sendEvent", { data: { a: 1 } })
       .then(() => undefined, e => e.message)
   );
   await t

--- a/test/functional/specs/C14405.js
+++ b/test/functional/specs/C14405.js
@@ -31,7 +31,7 @@ test.meta({
 test("Test C14405: Unidentified user can consent to all purposes", async t => {
   await configureAlloyInstance("alloy", config);
   await t.eval(() => window.alloy("setConsent", { general: "in" }));
-  await t.eval(() => window.alloy("event", { xdm: { key: "value" } }));
+  await t.eval(() => window.alloy("sendEvent", { xdm: { key: "value" } }));
 
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
   const request = networkLogger.edgeEndpointLogs.requests[0].request.body;

--- a/test/functional/specs/C14406.js
+++ b/test/functional/specs/C14406.js
@@ -31,7 +31,7 @@ test("Test C14406: Unidentified user can consent to no purposes", async t => {
   await t.eval(() => window.alloy("setConsent", { general: "out" }));
   const errorMessage = await t.eval(() =>
     window
-      .alloy("event", { data: { a: 1 } })
+      .alloy("sendEvent", { data: { a: 1 } })
       .then(() => undefined, e => e.message)
   );
 

--- a/test/functional/specs/C14407.js
+++ b/test/functional/specs/C14407.js
@@ -20,7 +20,7 @@ const setConsentIn = ClientFunction(() => {
 });
 
 const triggerAlloyEvent = ClientFunction(() => {
-  return window.alloy("event", {});
+  return window.alloy("sendEvent", {});
 });
 
 const configure = ClientFunction(() => {

--- a/test/functional/specs/C14409.js
+++ b/test/functional/specs/C14409.js
@@ -46,7 +46,7 @@ test("C14409 - Consenting to no purposes should be persisted.", async () => {
   // send event
   const errorMessage = await t.eval(() =>
     window
-      .alloy("event", { data: { a: 1 } })
+      .alloy("sendEvent", { data: { a: 1 } })
       .then(() => undefined, e => e.message)
   );
 

--- a/test/functional/specs/C14412.js
+++ b/test/functional/specs/C14412.js
@@ -32,7 +32,7 @@ test("Test C14412: While user is changing consent preferences, other requests sh
   });
   const errorMessage = await t.eval(() =>
     window
-      .alloy("event", { data: { a: 1 } })
+      .alloy("sendEvent", { data: { a: 1 } })
       .then(() => undefined, e => e.message)
   );
 

--- a/test/functional/specs/C14414.js
+++ b/test/functional/specs/C14414.js
@@ -37,7 +37,7 @@ test("Test C14414: Requests are queued while consent changes are pending", async
   });
   const errorMessage = await t.eval(() =>
     window
-      .alloy("event", { data: { a: 1 } })
+      .alloy("sendEvent", { data: { a: 1 } })
       .then(() => undefined, e => e.message)
   );
 

--- a/test/functional/specs/C25148.js
+++ b/test/functional/specs/C25148.js
@@ -18,7 +18,7 @@ test.meta({
 });
 
 const triggerAlloyEvent = ClientFunction(() => {
-  return window.alloy("event", {});
+  return window.alloy("sendEvent", {});
 });
 
 const setConsentOut = ClientFunction(() => {

--- a/test/functional/specs/C2579.js
+++ b/test/functional/specs/C2579.js
@@ -62,14 +62,21 @@ const getIdentityCookieValue = request => {
 
 const instance1Config = () => configureAlloyInstance(altConfig);
 
-const instance1Event = ClientFunction(() =>
-  window.alloy("event", { data: { key: "value" } })
-);
+const instance1Event = ClientFunction(() => {
+  return new Promise(resolve => {
+    return window.alloy("sendEvent", { data: { key: "value" } }).then(resolve);
+  });
+});
+
 const instance2Config = () => configureAlloyInstance("instance2", mainConfig);
 
-const instance2Event = ClientFunction(() =>
-  window.instance2("event", { data: { key: "value" } })
-);
+const instance2Event = ClientFunction(() => {
+  return new Promise(resolve => {
+    return window
+      .instance2("sendEvent", { data: { key: "value" } })
+      .then(resolve);
+  });
+});
 
 test("Test C2579: Separate ECIDs are used for multiple SDK instances.", async () => {
   await instance1Config();

--- a/test/functional/specs/C2581.js
+++ b/test/functional/specs/C2581.js
@@ -30,8 +30,11 @@ test.meta({
 
 const triggerAlloyEvents = ClientFunction(() => {
   return Promise.all([
-    window.alloy("event", { renderDecisions: true, data: { key: "value" } }),
-    window.alloy("event", { data: { key: "value" } })
+    window.alloy("sendEvent", {
+      renderDecisions: true,
+      data: { key: "value" }
+    }),
+    window.alloy("sendEvent", { data: { key: "value" } })
   ]);
 });
 

--- a/test/functional/specs/C2583.js
+++ b/test/functional/specs/C2583.js
@@ -31,29 +31,29 @@ test.meta({
 
 const triggerAlloyEvent = ClientFunction(() => {
   return new Promise(resolve => {
-    window.alloy("event", { xdm: { key: "value" } }).then(() => resolve());
+    window.alloy("sendEvent", { xdm: { key: "value" } }).then(() => resolve());
   });
 });
 
-test("Test C2583: Set the log option to true. Load the page. Execute an event command.", async t => {
+test("Test C2583: Set the log option to true. Load the page. Execute a sendEvent command.", async t => {
   await configureAlloyInstance("alloy", debugEnabledConfig);
 
   await triggerAlloyEvent();
 
   const { log } = await t.getBrowserConsoleMessages();
 
-  await t.expect(log).match(/\[alloy] Executing event command./);
+  await t.expect(log).match(/\[alloy] Executing sendEvent command./);
 });
 
-test("Test C2583: Set the log option in the configuration to false. Refresh the browser. Execute an event command.", async t => {
+test("Test C2583: Set the log option in the configuration to false. Refresh the browser. Execute a sendEvent command.", async t => {
   await configureAlloyInstance("alloy", debugDisabledConfig);
   await triggerAlloyEvent();
 
   const { log } = await t.getBrowserConsoleMessages();
 
-  await t.expect(log).notContains("Executing event command.");
+  await t.expect(log).notContains("Executing sendEvent command.");
 
   await triggerAlloyEvent();
 
-  await t.expect(log).notContains("Executing event command.");
+  await t.expect(log).notContains("Executing sendEvent command.");
 });

--- a/test/functional/specs/C2585.js
+++ b/test/functional/specs/C2585.js
@@ -19,7 +19,7 @@ const triggerAlloyEvent = ClientFunction(() => {
         debugEnabled: true
       })
       .catch(() => {
-        window.alloy("event", { xdm: { key: "value" } }).catch(resolve);
+        window.alloy("sendEvent", { xdm: { key: "value" } }).catch(resolve);
       });
   });
 });

--- a/test/functional/specs/C2592.js
+++ b/test/functional/specs/C2592.js
@@ -28,7 +28,7 @@ test.meta({
 
 const triggerAlloyEvent = ClientFunction(() => {
   return new Promise(resolve => {
-    window.alloy("event", { xdm: { key: "value" } }).then(() => resolve());
+    window.alloy("sendEvent", { xdm: { key: "value" } }).then(() => resolve());
   });
 });
 

--- a/test/functional/specs/C2593.js
+++ b/test/functional/specs/C2593.js
@@ -20,7 +20,7 @@ test.meta({
 
 const triggerEventThenConsent = ClientFunction(() => {
   return new Promise(resolve => {
-    const eventPromise = window.alloy("event", { xdm: { key: "value" } });
+    const eventPromise = window.alloy("sendEvent", { xdm: { key: "value" } });
     window.alloy("setConsent", { general: "in" }).then(() => {
       eventPromise.then(resolve);
     });

--- a/test/functional/specs/C2594.js
+++ b/test/functional/specs/C2594.js
@@ -30,7 +30,7 @@ test("Test C2594: event command rejects promise if user consents to no purposes"
   await configureAlloyInstance("alloy", config);
   const errorMessagePromise = t.eval(() =>
     window
-      .alloy("event", { data: { a: 1 } })
+      .alloy("sendEvent", { data: { a: 1 } })
       .then(() => undefined, e => e.message)
   );
   await t.eval(() => window.alloy("setConsent", { general: "out" }));

--- a/test/functional/specs/C2597.js
+++ b/test/functional/specs/C2597.js
@@ -29,7 +29,7 @@ test.meta({
 });
 
 const triggerAlloyEvent = ClientFunction(() => {
-  return window.alloy("event", { xdm: { key: "value" } });
+  return window.alloy("sendEvent", { xdm: { key: "value" } });
 });
 
 test("Test C2597 - Adds all context data to requests by default.", async () => {

--- a/test/functional/specs/C2598.js
+++ b/test/functional/specs/C2598.js
@@ -20,7 +20,7 @@ test.meta({
 });
 
 const triggerAlloyEvent = ClientFunction(() => {
-  return window.alloy("event", {
+  return window.alloy("sendEvent", {
     xdm: {
       web: {
         webPageDetails: {

--- a/test/functional/specs/C2599.js
+++ b/test/functional/specs/C2599.js
@@ -20,7 +20,7 @@ test.meta({
 });
 
 const triggerAlloyEvent = ClientFunction(() => {
-  return window.alloy("event", {
+  return window.alloy("sendEvent", {
     xdm: {
       web: {
         webPageDetails: {

--- a/test/functional/specs/C2600.js
+++ b/test/functional/specs/C2600.js
@@ -20,7 +20,7 @@ test.meta({
 });
 
 const triggerAlloyEvent = ClientFunction(() => {
-  return window.alloy("event", {
+  return window.alloy("sendEvent", {
     xdm: {
       web: {
         webPageDetails: {

--- a/test/functional/specs/C2601.js
+++ b/test/functional/specs/C2601.js
@@ -20,7 +20,7 @@ test.meta({
 });
 
 const triggerAlloyEvent = ClientFunction(() => {
-  return window.alloy("event", {
+  return window.alloy("sendEvent", {
     xdm: {
       web: {
         webPageDetails: {

--- a/test/functional/specs/C2660.js
+++ b/test/functional/specs/C2660.js
@@ -20,7 +20,7 @@ test.meta({
 });
 
 const sendEvent = ClientFunction(() => {
-  window.alloy("event");
+  window.alloy("sendEvent");
 });
 
 const changeHashAndConsent = ClientFunction(() => {

--- a/test/unit/specs/components/DataCollector/index.spec.js
+++ b/test/unit/specs/components/DataCollector/index.spec.js
@@ -17,7 +17,7 @@ describe("Event Command", () => {
   let event;
   let logger;
   let eventManager;
-  let eventCommand;
+  let sendEventCommand;
   beforeEach(() => {
     event = createEvent();
     spyOn(event, "documentMayUnload").and.callThrough();
@@ -43,7 +43,7 @@ describe("Event Command", () => {
       eventManager,
       logger
     });
-    eventCommand = dataCollector.commands.event;
+    sendEventCommand = dataCollector.commands.sendEvent;
   });
 
   it("sends event", () => {
@@ -57,7 +57,7 @@ describe("Event Command", () => {
       documentUnloading: true
     };
 
-    return eventCommand.run(options).then(result => {
+    return sendEventCommand.run(options).then(result => {
       expect(event.documentMayUnload).toHaveBeenCalled();
       expect(event.setUserXdm).toHaveBeenCalledWith(xdm);
       expect(event.setUserData).toHaveBeenCalledWith(data);
@@ -75,7 +75,7 @@ describe("Event Command", () => {
       decisionScopes: ["Foo1", "Foo2"]
     };
 
-    return eventCommand.run(options).then(result => {
+    return sendEventCommand.run(options).then(result => {
       expect(eventManager.sendEvent).toHaveBeenCalledWith(event, {
         renderDecisions: true,
         decisionScopes: ["Foo1", "Foo2"]
@@ -85,13 +85,13 @@ describe("Event Command", () => {
   });
 
   it("does not call documentMayUnload if documentUnloading is not defined", () => {
-    return eventCommand.run({}).then(() => {
+    return sendEventCommand.run({}).then(() => {
       expect(event.documentMayUnload).not.toHaveBeenCalled();
     });
   });
 
   it("sets renderDecisions to false if renderDecisions is not defined", () => {
-    return eventCommand.run({}).then(() => {
+    return sendEventCommand.run({}).then(() => {
       expect(eventManager.sendEvent).toHaveBeenCalledWith(event, {
         renderDecisions: false,
         decisionScopes: []
@@ -100,7 +100,7 @@ describe("Event Command", () => {
   });
 
   it("sets eventType and eventMergeId", () => {
-    return eventCommand
+    return sendEventCommand
       .run({
         type: "mytype",
         mergeId: "mymergeid"
@@ -114,7 +114,7 @@ describe("Event Command", () => {
   });
 
   it("merges eventType and eventMergeId with the userXdm", () => {
-    return eventCommand
+    return sendEventCommand
       .run({
         xdm: { key: "value" },
         type: "mytype",

--- a/test/unit/specs/components/Privacy/readStoredConsentFactory.spec.js
+++ b/test/unit/specs/components/Privacy/readStoredConsentFactory.spec.js
@@ -23,9 +23,9 @@ describe("Privacy:readStoredConsentFactory", () => {
     expect(parseConsentCookie).toHaveBeenCalledWith("cookieValue");
   });
 
-  it("returns {} if the cookie is not there", () => {
+  it("returns undefined if the cookie is not there", () => {
     cookieJar.get.and.returnValue(undefined);
-    expect(readStoredConsent()).toEqual({});
+    expect(readStoredConsent()).toEqual(undefined);
     expect(parseConsentCookie).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Description

- Rename the `event` command to `sendEvent`, to be a verb, and because @Aaronius 🤣

- Add a fix to Privacy to not call `setConsent` of no consent cookie found.

## Related Issue

https://jira.corp.adobe.com/browse/CORE-44840

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
