### PR TITLE
Core 42887 - send bulk notifications

### DIFF
--- a/src/components/Personalization/createCollect.js
+++ b/src/components/Personalization/createCollect.js
@@ -16,6 +16,6 @@ export default ({ eventManager, mergeMeta }) => {
 
     mergeMeta(event, meta);
 
-    eventManager.sendEvent(event);
+    return eventManager.sendEvent(event);
   };
 };

--- a/src/components/Personalization/createExecuteDecisions.js
+++ b/src/components/Personalization/createExecuteDecisions.js
@@ -22,18 +22,23 @@ const buildActions = decision => {
 
 export default ({ modules, logger, executeActions, collect }) => {
   return decisions => {
-    const decisionPromise = decisions.map(decision => {
+    const decisionMetasPromise = decisions.map(decision => {
       const actions = buildActions(decision);
 
       return executeActions(actions, modules, logger);
     });
-    return Promise.all(decisionPromise).then(result => {
-      if (isNonEmptyArray(result)) {
+    return Promise.all(decisionMetasPromise)
+      .then(result => {
         const metas = flatMap(result, identity);
-        const decisionMetas = metas.map(item => item.meta);
-
-        collect({ decisions: decisionMetas });
-      }
-    });
+        return metas.map(item => item.meta);
+      })
+      .then(metas => {
+        if (isNonEmptyArray(metas)) {
+          collect({ decisions: metas });
+        }
+      })
+      .catch(error => {
+        logger.error(error);
+      });
   };
 };

--- a/src/components/Personalization/createExecuteDecisions.js
+++ b/src/components/Personalization/createExecuteDecisions.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { assign, flatMap } from "../../utils";
+import { assign, flatMap, isNonEmptyArray } from "../../utils";
 
 const identity = item => item;
 
@@ -27,11 +27,13 @@ export default ({ modules, logger, executeActions, collect }) => {
 
       return executeActions(actions, modules, logger);
     });
-    return Promise.all(decisionPromise).then(meta => {
-      const metas = flatMap(meta, identity);
-      const decisionMetas = metas.map(item => item.meta);
+    return Promise.all(decisionPromise).then(result => {
+      if (isNonEmptyArray(result)) {
+        const metas = flatMap(result, identity);
+        const decisionMetas = metas.map(item => item.meta);
 
-      collect({ decisions: decisionMetas });
+        collect({ decisions: decisionMetas });
+      }
     });
   };
 };

--- a/src/components/Personalization/createExecuteDecisions.js
+++ b/src/components/Personalization/createExecuteDecisions.js
@@ -32,9 +32,9 @@ export default ({ modules, logger, executeActions, collect }) => {
         const metas = flatMap(result, identity);
         return metas.map(item => item.meta);
       })
-      .then(metas => {
-        if (isNonEmptyArray(metas)) {
-          collect({ decisions: metas });
+      .then(decisionMetas => {
+        if (isNonEmptyArray(decisionMetas)) {
+          collect({ decisions: decisionMetas });
         }
       })
       .catch(error => {

--- a/src/components/Personalization/dom-actions/action.js
+++ b/src/components/Personalization/dom-actions/action.js
@@ -33,7 +33,7 @@ const renderContent = (elements, content, renderFunc) => {
   return Promise.all(executions);
 };
 
-export const createAction = (collect, renderFunc) => {
+export const createAction = renderFunc => {
   return settings => {
     const { selector, prehidingSelector, content, meta } = settings;
 
@@ -43,15 +43,15 @@ export const createAction = (collect, renderFunc) => {
       .then(elements => renderContent(elements, content, renderFunc))
       .then(
         () => {
-          // if everything is OK, notify and show elements
-          collect(meta);
+          // if everything is OK, show elements
           showElements(prehidingSelector);
+          return { meta };
         },
-        () => {
+        error => {
           // in case of awaiting timing or error, we need to remove the style tag
-          // hence showing the pre-hidden elements and notify
-          collect(meta);
+          // hence showing the pre-hidden elements
           showElements(prehidingSelector);
+          return { meta, error };
         }
       );
   };

--- a/src/components/Personalization/dom-actions/executeActions.js
+++ b/src/components/Personalization/dom-actions/executeActions.js
@@ -30,13 +30,14 @@ const logActionCompleted = (logger, action) => {
   }
 };
 
-const executeAction = (modules, type, args) => {
+const executeAction = (logger, modules, type, args) => {
   const execute = modules[type];
 
   if (!execute) {
-    throw new Error(`DOM action "${type}" not found`);
+    const error = new Error(`DOM action "${type}" not found`);
+    logActionError(logger, args[0], error);
+    throw error;
   }
-
   return execute(...args);
 };
 
@@ -44,7 +45,7 @@ export default (actions, modules, logger) => {
   const actionPromises = actions.map(action => {
     const { type } = action;
 
-    return executeAction(modules, type, [action])
+    return executeAction(logger, modules, type, [action])
       .then(result => {
         logActionCompleted(logger, action);
         return result;

--- a/src/components/Personalization/dom-actions/executeActions.js
+++ b/src/components/Personalization/dom-actions/executeActions.js
@@ -41,16 +41,18 @@ const executeAction = (modules, type, args) => {
 };
 
 export default (actions, modules, logger) => {
-  actions.forEach(action => {
+  const actionPromises = actions.map(action => {
     const { type } = action;
 
-    try {
-      executeAction(modules, type, [action]);
-    } catch (e) {
-      logActionError(logger, action, e);
-      return;
-    }
-
-    logActionCompleted(logger, action);
+    return executeAction(modules, type, [action])
+      .then(result => {
+        logActionCompleted(logger, action);
+        return result;
+      })
+      .catch(error => {
+        logActionError(logger, action, error);
+        throw error;
+      });
   });
+  return Promise.all(actionPromises);
 };

--- a/src/components/Personalization/dom-actions/initDomActionsModules.js
+++ b/src/components/Personalization/dom-actions/initDomActionsModules.js
@@ -27,23 +27,23 @@ import {
   click
 } from "./action";
 
-export default (collect, store) => {
+export default store => {
   return {
-    setHtml: createAction(collect, setHtml),
-    customCode: createAction(collect, prependHtml),
-    setText: createAction(collect, setText),
-    setAttribute: createAction(collect, setAttributes),
-    setImageSource: createAction(collect, swapImage),
-    setStyle: createAction(collect, setStyles),
-    move: createAction(collect, setStyles),
-    resize: createAction(collect, setStyles),
-    rearrange: createAction(collect, rearrangeChildren),
-    remove: createAction(collect, removeNode),
-    insertAfter: createAction(collect, insertHtmlAfter),
-    insertBefore: createAction(collect, insertHtmlBefore),
-    replaceHtml: createAction(collect, replaceHtml),
-    prependHtml: createAction(collect, prependHtml),
-    appendHtml: createAction(collect, appendHtml),
+    setHtml: createAction(setHtml),
+    customCode: createAction(prependHtml),
+    setText: createAction(setText),
+    setAttribute: createAction(setAttributes),
+    setImageSource: createAction(swapImage),
+    setStyle: createAction(setStyles),
+    move: createAction(setStyles),
+    resize: createAction(setStyles),
+    rearrange: createAction(rearrangeChildren),
+    remove: createAction(removeNode),
+    insertAfter: createAction(insertHtmlAfter),
+    insertBefore: createAction(insertHtmlBefore),
+    replaceHtml: createAction(replaceHtml),
+    prependHtml: createAction(prependHtml),
+    appendHtml: createAction(appendHtml),
     click: settings => click(settings, store)
   };
 };

--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -26,11 +26,12 @@ import createOnClickHandler from "./createOnClickHandler";
 const createPersonalization = ({ config, logger, eventManager }) => {
   const collect = createCollect({ eventManager, mergeMeta });
   const clickStorage = [];
-  const modules = initDomActionsModules(collect, clickStorage.push);
+  const modules = initDomActionsModules(clickStorage.push);
   const executeDecisions = createExecuteDecisions({
     modules,
     logger,
-    executeActions
+    executeActions,
+    collect
   });
   const onResponseHandler = createOnResponseHandler({
     extractDecisions,

--- a/test/unit/specs/components/Personalization/createExecuteDecisions.spec.js
+++ b/test/unit/specs/components/Personalization/createExecuteDecisions.spec.js
@@ -15,7 +15,8 @@ import createExecuteDecisions from "../../../../../src/components/Personalizatio
 describe("Personalization::createExecuteDecisions", () => {
   const logger = {
     log() {},
-    warn() {}
+    warn() {},
+    error: jasmine.createSpy()
   };
   let executeActions;
   let collect;
@@ -115,6 +116,28 @@ describe("Personalization::createExecuteDecisions", () => {
     return executeDecisions([]).then(() => {
       expect(executeActions).not.toHaveBeenCalled();
       expect(collect).not.toHaveBeenCalled();
+    });
+  });
+  it("should log an error when collect call fails", () => {
+    const error = new Error("test error");
+    collect = jasmine.createSpy().and.throwError("test error");
+    const actionSpy = jasmine.createSpy();
+    const modules = {
+      foo: actionSpy
+    };
+    executeActions = jasmine
+      .createSpy()
+      .and.returnValues([{ meta: metas[0] }], [{ meta: metas[1] }]);
+    const executeDecisions = createExecuteDecisions({
+      modules,
+      logger,
+      executeActions,
+      collect
+    });
+    return executeDecisions(decisions).then(() => {
+      expect(executeActions).toHaveBeenCalled();
+      expect(collect).toThrowError();
+      expect(logger.error).toHaveBeenCalledWith(error);
     });
   });
 });

--- a/test/unit/specs/components/Personalization/createExecuteDecisions.spec.js
+++ b/test/unit/specs/components/Personalization/createExecuteDecisions.spec.js
@@ -18,6 +18,7 @@ describe("Personalization::createExecuteDecisions", () => {
     warn() {}
   };
   let executeActions;
+  let collect;
 
   const decisions = [
     {
@@ -33,24 +34,52 @@ describe("Personalization::createExecuteDecisions", () => {
           }
         }
       ]
+    },
+    {
+      id: 5,
+      scope: "__view__",
+      items: [
+        {
+          schema: "https://ns.adobe.com/personalization/dom-action",
+          data: {
+            type: "setHtml",
+            selector: "#foo2",
+            content: "<div>offer 2</div>"
+          }
+        }
+      ]
     }
   ];
-
+  const expectedAction = [
+    {
+      type: "setHtml",
+      selector: "#foo",
+      content: "<div>Hola Mundo</div>",
+      meta: {
+        id: decisions[0].id,
+        scope: "foo"
+      }
+    }
+  ];
+  const metas = [
+    {
+      id: decisions[0].id,
+      scope: decisions[0].scope
+    },
+    {
+      id: decisions[1].id,
+      scope: decisions[1].scope
+    }
+  ];
   beforeEach(() => {
-    executeActions = jasmine.createSpy().and.callThrough();
+    collect = jasmine.createSpy();
   });
 
-  it("should trigger executeActions when provided with an array of actions", () => {
-    const expectedAction = [
-      {
-        type: "setHtml",
-        selector: "#foo",
-        content: "<div>Hola Mundo</div>",
-        meta: {
-          decisionId: decisions[0].id
-        }
-      }
-    ];
+  it("should trigger executeActions and collect when provided with an array of actions", () => {
+    executeActions = jasmine
+      .createSpy()
+      .and.returnValues([{ meta: metas[0] }], [{ meta: metas[1] }]);
+
     const spy = jasmine.createSpy();
     const modules = {
       foo: spy
@@ -58,27 +87,34 @@ describe("Personalization::createExecuteDecisions", () => {
     const executeDecisions = createExecuteDecisions({
       modules,
       logger,
-      executeActions
+      executeActions,
+      collect
     });
-    executeDecisions(decisions);
-    expect(executeActions).toHaveBeenCalledWith(
-      expectedAction,
-      modules,
-      logger
-    );
+    return executeDecisions(decisions).then(() => {
+      expect(executeActions).toHaveBeenCalledWith(
+        expectedAction,
+        modules,
+        logger
+      );
+      expect(collect).toHaveBeenCalledWith({ decisions: metas });
+    });
   });
 
-  it("shouldn't trigger executeActions when provided with empty array of actions", () => {
+  it("shouldn't trigger executeActions and collect when provided with empty array of actions", () => {
     const actionSpy = jasmine.createSpy();
     const modules = {
       foo: actionSpy
     };
+    executeActions = jasmine.createSpy().and.callThrough();
     const executeDecisions = createExecuteDecisions({
       modules,
       logger,
-      executeActions
+      executeActions,
+      collect
     });
-    executeDecisions([]);
-    expect(executeActions).not.toHaveBeenCalled();
+    return executeDecisions([]).then(() => {
+      expect(executeActions).not.toHaveBeenCalled();
+      expect(collect).not.toHaveBeenCalled();
+    });
   });
 });

--- a/test/unit/specs/components/Personalization/dom-actions/appendHtml.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/appendHtml.spec.js
@@ -16,8 +16,7 @@ describe("Personalization::actions::appendHtml", () => {
   });
 
   it("should append personalized content", () => {
-    const collect = jasmine.createSpy();
-    const modules = initDomActionsModules(collect);
+    const modules = initDomActionsModules();
     const { appendHtml } = modules;
     const content = `<li>1</li>`;
     const element = createNode(
@@ -43,7 +42,6 @@ describe("Personalization::actions::appendHtml", () => {
       expect(result[0].innerHTML).toEqual("1");
       expect(result[1].innerHTML).toEqual("2");
       expect(result[2].innerHTML).toEqual("3");
-      expect(collect).toHaveBeenCalledWith(meta);
     });
   });
 });

--- a/test/unit/specs/components/Personalization/dom-actions/click.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/click.spec.js
@@ -1,11 +1,9 @@
 import { initDomActionsModules } from "../../../../../../src/components/Personalization/dom-actions";
-import { noop } from "../../../../../../src/utils";
 
 describe("Personalization::actions::click", () => {
   it("should set click tracking attribute", () => {
-    const collect = noop();
     const store = jasmine.createSpy();
-    const modules = initDomActionsModules(collect, store);
+    const modules = initDomActionsModules(store);
     const { click } = modules;
     const selector = "#click";
     const meta = { a: 1 };

--- a/test/unit/specs/components/Personalization/dom-actions/customCode.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/customCode.spec.js
@@ -18,8 +18,7 @@ describe("Personalization::actions::customCode", () => {
   });
 
   it("should set content in container that has children", () => {
-    const collect = jasmine.createSpy();
-    const modules = initDomActionsModules(collect);
+    const modules = initDomActionsModules();
     const { customCode } = modules;
     const element = createNode("div", { class: "customCode" });
     element.innerHTML = `<div id="inner1"></div><div id="inner2"></div>`;
@@ -40,13 +39,11 @@ describe("Personalization::actions::customCode", () => {
       expect(elements[0].innerHTML).toEqual(
         `<p>Hola!</p><div id="inner1"></div><div id="inner2"></div>`
       );
-      expect(collect).toHaveBeenCalledWith(meta);
     });
   });
 
   it("should set content in container that has NO children", () => {
-    const collect = jasmine.createSpy();
-    const modules = initDomActionsModules(collect);
+    const modules = initDomActionsModules();
     const { customCode } = modules;
     const element = createNode("div", { class: "customCode" });
     const elements = [element];
@@ -64,7 +61,6 @@ describe("Personalization::actions::customCode", () => {
 
     return customCode(settings, event).then(() => {
       expect(elements[0].innerHTML).toEqual(`<p>Hola!</p><div>Hello</div>`);
-      expect(collect).toHaveBeenCalledWith(meta);
     });
   });
 });

--- a/test/unit/specs/components/Personalization/dom-actions/executeActions.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/executeActions.spec.js
@@ -12,9 +12,9 @@ governing permissions and limitations under the License.
 
 import executeActions from "../../../../../../src/components/Personalization/dom-actions/executeActions";
 
-describe("Personalization::turbine::executeActions", () => {
+describe("Personalization::executeActions", () => {
   it("should execute actions", () => {
-    const actionSpy = jasmine.createSpy();
+    const actionSpy = jasmine.createSpy().and.returnValue(Promise.resolve(1));
     const logger = jasmine.createSpyObj("logger", ["error", "log"]);
     logger.enabled = true;
     const actions = [{ type: "foo" }];
@@ -22,43 +22,39 @@ describe("Personalization::turbine::executeActions", () => {
       foo: actionSpy
     };
 
-    executeActions(actions, modules, logger);
-
-    expect(actionSpy).toHaveBeenCalled();
-    expect(logger.log.calls.count()).toEqual(1);
-    expect(logger.error).not.toHaveBeenCalled();
+    return executeActions(actions, modules, logger).then(result => {
+      expect(result).toEqual([1]);
+      expect(actionSpy).toHaveBeenCalled();
+      expect(logger.log.calls.count()).toEqual(1);
+      expect(logger.error).not.toHaveBeenCalled();
+    });
   });
 
   it("should not invoke logger.log when logger is not enabled", () => {
-    const actionSpy = jasmine.createSpy();
+    const actionSpy = jasmine.createSpy().and.returnValue(Promise.resolve(1));
     const logger = jasmine.createSpyObj("logger", ["error", "log"]);
     logger.enabled = false;
     const actions = [{ type: "foo" }];
     const modules = {
       foo: actionSpy
     };
-
-    executeActions(actions, modules, logger);
-
-    expect(actionSpy).toHaveBeenCalled();
-    expect(logger.log.calls.count()).toEqual(0);
-    expect(logger.error).not.toHaveBeenCalled();
+    return executeActions(actions, modules, logger).then(result => {
+      expect(result).toEqual([1]);
+      expect(actionSpy).toHaveBeenCalled();
+      expect(logger.log.calls.count()).toEqual(0);
+      expect(logger.error).not.toHaveBeenCalled();
+    });
   });
 
-  it("should log error when execute actions fails", () => {
+  it("should throw error when execute actions fails", () => {
     const logger = jasmine.createSpyObj("logger", ["error", "log"]);
     logger.enabled = true;
     const actions = [{ type: "foo" }];
     const modules = {
-      foo: () => {
-        throw new Error();
-      }
+      foo: jasmine.createSpy().and.throwError("foo's error")
     };
 
-    executeActions(actions, modules, logger);
-
-    expect(logger.log).not.toHaveBeenCalled();
-    expect(logger.error.calls.count()).toEqual(1);
+    expect(() => executeActions(actions, modules, logger)).toThrowError();
   });
 
   it("should log nothing when there are no actions", () => {
@@ -66,35 +62,20 @@ describe("Personalization::turbine::executeActions", () => {
     const actions = [];
     const modules = {};
 
-    executeActions(actions, modules, logger);
-
-    expect(logger.log).not.toHaveBeenCalled();
-    expect(logger.error).not.toHaveBeenCalled();
+    return executeActions(actions, modules, logger).then(result => {
+      expect(result).toEqual([]);
+      expect(logger.log).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
+    });
   });
 
-  it("should log error when there are no actions types", () => {
+  it("should throw error when there are no actions types", () => {
     const logger = jasmine.createSpyObj("logger", ["error", "log"]);
     logger.enabled = true;
     const actions = [{ type: "foo1" }];
     const modules = {
       foo: () => {}
     };
-
-    executeActions(actions, modules, logger);
-
-    expect(logger.error).toHaveBeenCalled();
-  });
-
-  it("should not invoke logger when logger is disabled", () => {
-    const logger = jasmine.createSpyObj("logger", ["error", "log"]);
-    logger.enabled = false;
-    const actions = [{ type: "foo1" }];
-    const modules = {
-      foo: () => {}
-    };
-
-    executeActions(actions, modules, logger);
-
-    expect(logger.error).not.toHaveBeenCalled();
+    expect(() => executeActions(actions, modules, logger)).toThrowError();
   });
 });

--- a/test/unit/specs/components/Personalization/dom-actions/insertHtmlAfter.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/insertHtmlAfter.spec.js
@@ -16,8 +16,7 @@ describe("Personalization::actions::insertAfter", () => {
   });
 
   it("should insert after personalized content", () => {
-    const collect = jasmine.createSpy();
-    const modules = initDomActionsModules(collect);
+    const modules = initDomActionsModules();
     const { insertAfter } = modules;
     const child = createNode(
       "div",
@@ -41,7 +40,6 @@ describe("Personalization::actions::insertAfter", () => {
 
       expect(result[0].innerHTML).toEqual("AAA");
       expect(result[1].innerHTML).toEqual("BBB");
-      expect(collect).toHaveBeenCalledWith(meta);
     });
   });
 });

--- a/test/unit/specs/components/Personalization/dom-actions/insertHtmlBefore.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/insertHtmlBefore.spec.js
@@ -16,8 +16,7 @@ describe("Personalization::actions::insertBefore", () => {
   });
 
   it("should insert before personalized content", () => {
-    const collect = jasmine.createSpy();
-    const modules = initDomActionsModules(collect);
+    const modules = initDomActionsModules();
     const { insertBefore } = modules;
     const child = createNode(
       "div",
@@ -41,7 +40,6 @@ describe("Personalization::actions::insertBefore", () => {
 
       expect(result[0].innerHTML).toEqual("BBB");
       expect(result[1].innerHTML).toEqual("AAA");
-      expect(collect).toHaveBeenCalledWith(meta);
     });
   });
 });

--- a/test/unit/specs/components/Personalization/dom-actions/move.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/move.spec.js
@@ -12,8 +12,7 @@ describe("Personalization::actions::move", () => {
   });
 
   it("should move personalized content", () => {
-    const collect = jasmine.createSpy();
-    const modules = initDomActionsModules(collect);
+    const modules = initDomActionsModules();
     const { move } = modules;
     const element = createNode("div", { id: "move" });
     const elements = [element];
@@ -31,7 +30,6 @@ describe("Personalization::actions::move", () => {
     move(settings).then(() => {
       expect(elements[0].style.left).toEqual("100px");
       expect(elements[0].style.top).toEqual("100px");
-      expect(collect).toHaveBeenCalledWith(meta);
     });
   });
 });

--- a/test/unit/specs/components/Personalization/dom-actions/prependHtml.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/prependHtml.spec.js
@@ -16,8 +16,7 @@ describe("Personalization::actions::prependHtml", () => {
   });
 
   it("should prepend personalized content", () => {
-    const collect = jasmine.createSpy();
-    const modules = initDomActionsModules(collect);
+    const modules = initDomActionsModules();
     const { prependHtml } = modules;
     const content = `<li>3</li>`;
     const element = createNode(
@@ -43,7 +42,6 @@ describe("Personalization::actions::prependHtml", () => {
       expect(result[0].innerHTML).toEqual("1");
       expect(result[1].innerHTML).toEqual("2");
       expect(result[2].innerHTML).toEqual("3");
-      expect(collect).toHaveBeenCalledWith(meta);
     });
   });
 });

--- a/test/unit/specs/components/Personalization/dom-actions/rearrangeChildren.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/rearrangeChildren.spec.js
@@ -16,8 +16,7 @@ describe("Personalization::actions::rearrange", () => {
   });
 
   it("should rearrange elements when from < to", () => {
-    const collect = jasmine.createSpy();
-    const modules = initDomActionsModules(collect);
+    const modules = initDomActionsModules();
     const { rearrange } = modules;
     const content = `
       <li>1</li>
@@ -46,13 +45,11 @@ describe("Personalization::actions::rearrange", () => {
       expect(result[0].textContent).toEqual("2");
       expect(result[1].textContent).toEqual("3");
       expect(result[2].textContent).toEqual("1");
-      expect(collect).toHaveBeenCalledWith(meta);
     });
   });
 
   it("should rearrange elements when from > to", () => {
-    const collect = jasmine.createSpy();
-    const modules = initDomActionsModules(collect);
+    const modules = initDomActionsModules();
     const { rearrange } = modules;
     const content = `
       <li>1</li>
@@ -81,7 +78,6 @@ describe("Personalization::actions::rearrange", () => {
       expect(result[0].textContent).toEqual("3");
       expect(result[1].textContent).toEqual("1");
       expect(result[2].textContent).toEqual("2");
-      expect(collect).toHaveBeenCalledWith(meta);
     });
   });
 });

--- a/test/unit/specs/components/Personalization/dom-actions/remove.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/remove.spec.js
@@ -16,8 +16,7 @@ describe("Personalization::actions::remove", () => {
   });
 
   it("should remove element", () => {
-    const collect = jasmine.createSpy();
-    const modules = initDomActionsModules(collect);
+    const modules = initDomActionsModules();
     const { remove } = modules;
     const content = `<div id="child"></div>`;
     const element = createNode("div", { id: "remove" }, { innerHTML: content });
@@ -35,7 +34,6 @@ describe("Personalization::actions::remove", () => {
       const result = selectNodes("#child");
 
       expect(result.length).toEqual(0);
-      expect(collect).toHaveBeenCalledWith(meta);
     });
   });
 });

--- a/test/unit/specs/components/Personalization/dom-actions/replaceHtml.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/replaceHtml.spec.js
@@ -16,8 +16,7 @@ describe("Personalization::actions::replaceHtml", () => {
   });
 
   it("should replace element with personalized content", () => {
-    const collect = jasmine.createSpy();
-    const modules = initDomActionsModules(collect);
+    const modules = initDomActionsModules();
     const { replaceHtml } = modules;
     const child = createNode(
       "div",
@@ -41,7 +40,6 @@ describe("Personalization::actions::replaceHtml", () => {
 
       expect(result.length).toEqual(1);
       expect(result[0].innerHTML).toEqual("BBB");
-      expect(collect).toHaveBeenCalledWith(meta);
     });
   });
 });

--- a/test/unit/specs/components/Personalization/dom-actions/resize.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/resize.spec.js
@@ -12,8 +12,7 @@ describe("Personalization::actions::resize", () => {
   });
 
   it("should resize personalized content", () => {
-    const collect = jasmine.createSpy();
-    const modules = initDomActionsModules(collect);
+    const modules = initDomActionsModules();
     const { resize } = modules;
     const element = createNode("div", { id: "resize" });
     const elements = [element];
@@ -31,7 +30,6 @@ describe("Personalization::actions::resize", () => {
     return resize(settings).then(() => {
       expect(elements[0].style.width).toEqual("100px");
       expect(elements[0].style.height).toEqual("100px");
-      expect(collect).toHaveBeenCalledWith(meta);
     });
   });
 });

--- a/test/unit/specs/components/Personalization/dom-actions/setAttributes.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/setAttributes.spec.js
@@ -12,8 +12,7 @@ describe("Personalization::actions::setAttribute", () => {
   });
 
   it("should set element attribute", () => {
-    const collect = jasmine.createSpy();
-    const modules = initDomActionsModules(collect);
+    const modules = initDomActionsModules();
     const { setAttribute } = modules;
     const element = createNode("div", { id: "setAttribute" });
     const elements = [element];
@@ -30,7 +29,6 @@ describe("Personalization::actions::setAttribute", () => {
 
     return setAttribute(settings).then(() => {
       expect(elements[0].getAttribute("data-test")).toEqual("bar");
-      expect(collect).toHaveBeenCalledWith(meta);
     });
   });
 });

--- a/test/unit/specs/components/Personalization/dom-actions/setHtml.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/setHtml.spec.js
@@ -14,8 +14,7 @@ describe("Personalization::actions::setHtml", () => {
   });
 
   it("should set personalized content", () => {
-    const collect = jasmine.createSpy();
-    const modules = initDomActionsModules(collect);
+    const modules = initDomActionsModules();
     const { setHtml } = modules;
     const element = createNode("div", { id: "setHtml" });
     element.innerHTML = "foo";
@@ -34,13 +33,11 @@ describe("Personalization::actions::setHtml", () => {
 
     return setHtml(settings, event).then(() => {
       expect(elements[0].innerHTML).toEqual("bar");
-      expect(collect).toHaveBeenCalledWith(meta);
     });
   });
 
   it("should execute inline JavaScript", () => {
-    const collect = jasmine.createSpy();
-    const modules = initDomActionsModules(collect);
+    const modules = initDomActionsModules();
     const { setHtml } = modules;
     const element = createNode("div", { id: "setHtml" });
     element.innerHTML = "foo";
@@ -58,7 +55,6 @@ describe("Personalization::actions::setHtml", () => {
     const event = { elements };
 
     return setHtml(settings, event).then(() => {
-      expect(collect).toHaveBeenCalledWith(meta);
       expect(window.someEvar123).toEqual(1);
     });
   });

--- a/test/unit/specs/components/Personalization/dom-actions/setImageSource.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/setImageSource.spec.js
@@ -13,8 +13,7 @@ describe("Personalization::actions::setImageSource", () => {
 
   it("should swap image", () => {
     const url = "http://foo.com/a.png";
-    const collect = jasmine.createSpy();
-    const modules = initDomActionsModules(collect);
+    const modules = initDomActionsModules();
     const { setImageSource } = modules;
     const element = createNode("img", { id: "setImageSource", src: url });
     const elements = [element];
@@ -31,7 +30,6 @@ describe("Personalization::actions::setImageSource", () => {
 
     return setImageSource(settings).then(() => {
       expect(elements[0].getAttribute("src")).toEqual("http://foo.com/b.png");
-      expect(collect).toHaveBeenCalledWith(meta);
     });
   });
 });

--- a/test/unit/specs/components/Personalization/dom-actions/setStyles.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/setStyles.spec.js
@@ -12,8 +12,7 @@ describe("Personalization::actions::setStyle", () => {
   });
 
   it("should set styles", () => {
-    const collect = jasmine.createSpy();
-    const modules = initDomActionsModules(collect);
+    const modules = initDomActionsModules();
     const { setStyle } = modules;
     const element = createNode("div", { id: "setStyle" });
     const elements = [element];
@@ -30,7 +29,6 @@ describe("Personalization::actions::setStyle", () => {
 
     return setStyle(settings).then(() => {
       expect(elements[0].style.getPropertyValue("font-size")).toEqual("33px");
-      expect(collect).toHaveBeenCalledWith(meta);
     });
   });
 });

--- a/test/unit/specs/components/Personalization/dom-actions/setText.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/setText.spec.js
@@ -12,8 +12,7 @@ describe("Personalization::actions::setText", () => {
   });
 
   it("should set personalized text", () => {
-    const collect = jasmine.createSpy();
-    const modules = initDomActionsModules(collect);
+    const modules = initDomActionsModules();
     const { setText } = modules;
     const element = createNode("div", { id: "setText" });
     element.textContent = "foo";
@@ -31,7 +30,6 @@ describe("Personalization::actions::setText", () => {
 
     return setText(settings).then(() => {
       expect(elements[0].textContent).toEqual("bar");
-      expect(collect).toHaveBeenCalledWith(meta);
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Currently, we are sending a notification-call for each decision that we render. We need to collect metadata from all rendered decisions and send one notification call to Konductor. 
Metadata will look like this:
``` 
personalization: {
   decisions: [{
       id:1,
       scope: "___view__"
   }]
}
```
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
