### PR TITLE
C31436 - Qualify for URL destinations via Context Data

### DIFF
--- a/test/functional/specs/C31436.js
+++ b/test/functional/specs/C31436.js
@@ -3,8 +3,6 @@ import createNetworkLogger from "../helpers/networkLogger";
 import fixtureFactory from "../helpers/fixtureFactory";
 import { orgMainConfigMain } from "../helpers/constants/configParts";
 import configureAlloyInstance from "../helpers/configureAlloyInstance";
-import createResponse from "../../../src/core/createResponse";
-import getResponseBody from "../helpers/networkLogger/getResponseBody";
 
 const networkLogger = createNetworkLogger();
 
@@ -38,18 +36,6 @@ const triggerAlloyEvent = ClientFunction(() => {
 test("C31436 Qualify for URL destinations via XDM Data.", async () => {
   await configureAlloyInstance("alloy", orgMainConfigMain);
   await triggerAlloyEvent();
-  const response = JSON.parse(
-    getResponseBody(networkLogger.edgeEndpointLogs.requests[0])
-  );
-  const alloyResponse = createResponse(response);
-  const audiencesPayload = alloyResponse.getPayloadsByType("activation:push");
-  // This is a destination set for all visitors.
-  const destinationForAllVisitors = audiencesPayload.find(
-    payload =>
-      payload.type === "url" &&
-      payload.spec.url === "https://cataas.com/cat/cute"
-  );
-  await t.expect(destinationForAllVisitors).ok();
 
   await t.expect(destinationLogger.requests.length > 0).eql(true);
 });

--- a/test/functional/specs/C31436.js
+++ b/test/functional/specs/C31436.js
@@ -37,5 +37,5 @@ test("C31436 Qualify for URL destinations via XDM Data.", async () => {
   await configureAlloyInstance("alloy", orgMainConfigMain);
   await triggerAlloyEvent();
 
-  await t.expect(destinationLogger.requests.length > 0).eql(true);
+  await t.expect(destinationLogger.requests.length).eql(1);
 });

--- a/test/functional/specs/C31436.js
+++ b/test/functional/specs/C31436.js
@@ -1,0 +1,55 @@
+import { RequestLogger, t, ClientFunction } from "testcafe";
+import createNetworkLogger from "../helpers/networkLogger";
+import fixtureFactory from "../helpers/fixtureFactory";
+import { orgMainConfigMain } from "../helpers/constants/configParts";
+import configureAlloyInstance from "../helpers/configureAlloyInstance";
+import createResponse from "../../../src/core/createResponse";
+import getResponseBody from "../helpers/networkLogger/getResponseBody";
+
+const networkLogger = createNetworkLogger();
+
+const networkLoggerConfig = {
+  logRequestBody: true,
+  stringifyRequestBody: true
+};
+
+const destinationLogger = RequestLogger(
+  "https://cataas.com/cat/cute",
+  networkLoggerConfig
+);
+
+fixtureFactory({
+  title: "C31436 Qualify for URL destinations via XDM Data.",
+  requestHooks: [networkLogger.edgeEndpointLogs, destinationLogger]
+});
+
+test.meta({
+  ID: "C31436",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+
+const triggerAlloyEvent = ClientFunction(() => {
+  return window.alloy("event", {
+    xdm: { web: { webPageDetails: { name: "C31436" } } }
+  });
+});
+
+test("C31436 Qualify for URL destinations via XDM Data.", async () => {
+  await configureAlloyInstance("alloy", orgMainConfigMain);
+  await triggerAlloyEvent();
+  const response = JSON.parse(
+    getResponseBody(networkLogger.edgeEndpointLogs.requests[0])
+  );
+  const alloyResponse = createResponse(response);
+  const audiencesPayload = alloyResponse.getPayloadsByType("activation:push");
+  // This is a destination set for all visitors.
+  const destinationForAllVisitors = audiencesPayload.find(
+    payload =>
+      payload.type === "url" &&
+      payload.spec.url === "https://cataas.com/cat/cute"
+  );
+  await t.expect(destinationForAllVisitors).ok();
+
+  await t.expect(destinationLogger.requests.length > 0).eql(true);
+});


### PR DESCRIPTION
## Description

Create a trait based on XDM data from events
Create a Cookie destination based on this trait/segment
Cookie Destination should be in the response of the events containing this XDM data

Expected : This event call should return a URL destination with https://cataas.com/cat/cute

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
