### PR TITLE
fixed - duplicates of metas in notification call

### DIFF
--- a/src/components/Personalization/event.js
+++ b/src/components/Personalization/event.js
@@ -25,7 +25,7 @@ export const mergeQuery = (event, details) => {
 
 export const createQueryDetails = decisionScopes => {
   return {
-    accepts: ALL_SCHEMAS,
+    schemas: ALL_SCHEMAS,
     decisionScopes
   };
 };

--- a/test/unit/specs/components/Personalization/createExecuteDecisions.spec.js
+++ b/test/unit/specs/components/Personalization/createExecuteDecisions.spec.js
@@ -13,11 +13,7 @@ governing permissions and limitations under the License.
 import createExecuteDecisions from "../../../../../src/components/Personalization/createExecuteDecisions";
 
 describe("Personalization::createExecuteDecisions", () => {
-  const logger = {
-    log() {},
-    warn() {},
-    error: jasmine.createSpy()
-  };
+  const logger = jasmine.createSpyObj("logger", ["log", "warn", "error"]);
   let executeActions;
   let collect;
 
@@ -81,7 +77,7 @@ describe("Personalization::createExecuteDecisions", () => {
       .createSpy()
       .and.returnValues(
         [{ meta: metas[0] }, { meta: metas[0] }],
-        [{ meta: metas[1] }]
+        [{ meta: metas[1], error: "could not render this item" }]
       );
 
     const spy = jasmine.createSpy();
@@ -100,7 +96,11 @@ describe("Personalization::createExecuteDecisions", () => {
         modules,
         logger
       );
-      expect(collect).toHaveBeenCalledWith({ decisions: metas });
+      expect(logger.warn).toHaveBeenCalledWith({
+        meta: metas[1],
+        error: "could not render this item"
+      });
+      expect(collect).toHaveBeenCalledWith({ decisions: [metas[0]] });
     });
   });
 

--- a/test/unit/specs/components/Personalization/createExecuteDecisions.spec.js
+++ b/test/unit/specs/components/Personalization/createExecuteDecisions.spec.js
@@ -79,7 +79,10 @@ describe("Personalization::createExecuteDecisions", () => {
   it("should trigger executeActions and collect when provided with an array of actions", () => {
     executeActions = jasmine
       .createSpy()
-      .and.returnValues([{ meta: metas[0] }], [{ meta: metas[1] }]);
+      .and.returnValues(
+        [{ meta: metas[0] }, { meta: metas[0] }],
+        [{ meta: metas[1] }]
+      );
 
     const spy = jasmine.createSpy();
     const modules = {

--- a/test/unit/specs/components/Personalization/event.spec.js
+++ b/test/unit/specs/components/Personalization/event.spec.js
@@ -14,13 +14,13 @@ import { createQueryDetails } from "../../../../../src/components/Personalizatio
 import * as SCHEMAS from "../../../../../src/constants/schemas";
 import { values } from "../../../../../src/utils";
 
-const accepts = values(SCHEMAS);
+const schemas = values(SCHEMAS);
 
 describe("Personalization::event", () => {
   it("create query details", () => {
     const decisionScopes = ["__view__", "foo"];
     const result = createQueryDetails(decisionScopes);
 
-    expect(result).toEqual({ accepts, decisionScopes });
+    expect(result).toEqual({ schemas, decisionScopes });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
If we have a decision with multiple items we should have only one insert in the `personalization.decisions` array
```
{
  "decisions": [
    {
      "id": "TNT:113866:1"
    },
    {
      "id": "TNT:115166:0"
    },
    {
      "id": "TNT:113712:1"
    }
  ]
}
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
