### PR TITLE
Add pages that load Visitor.js

### DIFF
--- a/sandbox/public/functional-test/alloyVisitorTestPageInt.html
+++ b/sandbox/public/functional-test/alloyVisitorTestPageInt.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"></script>
+    <script src="https://github.com/Adobe-Marketing-Cloud/id-service/releases/latest/download/visitorapi.min.js"></script>
+
+    <meta charset="utf-8" />
+    <title>Alloy & Visitor - Int environment</title>
+  </head>
+  <body>
+    <h1>
+      This page loads Visitor.js and gets inject by the Alloy.js library so we
+      can test the Migration use cases.
+    </h1>
+  </body>
+</html>

--- a/sandbox/public/functional-test/alloyVisitorTestPageProd.html
+++ b/sandbox/public/functional-test/alloyVisitorTestPageProd.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"></script>
+    <script src="https://github.com/Adobe-Marketing-Cloud/id-service/releases/latest/download/visitorapi.min.js"></script>
+    <!-- prettier-ignore -->
+    <script>
+      !function(n,o){o.forEach(function(o){n[o]||((n.__alloyNS=n.__alloyNS||
+      []).push(o),n[o]=function(){var u=arguments;return new Promise(
+      function(i,l){n[o].q.push([i,l,u])})},n[o].q=[])})}
+      (window,["alloy", "instance2"]);
+    </script>
+    <script
+      src="https://github.com/adobe/alloy/releases/latest/download/alloy.js"
+      async
+    ></script>
+    <meta charset="utf-8" />
+    <title>Alloy & Visitor - Prod environment</title>
+  </head>
+  <body>
+    <h1>
+      This page loads the latest Alloy.js library as well as the Visitor.js
+      library so we can test the Migration use cases.
+    </h1>
+  </body>
+</html>

--- a/test/functional/helpers/constants/testServerUrl.js
+++ b/test/functional/helpers/constants/testServerUrl.js
@@ -5,4 +5,13 @@ const pageName = {
   prod: "latestAlloyTestPage.html"
 };
 
+const alloyWithVisitorPages = {
+  int: "alloyVisitorTestPageInt.html",
+  prod: "alloyVisitorTestPageProd.html"
+};
+
+const alloyWithVisitorTestPageUrl = `https://alloyio.com/functional-test/${alloyWithVisitorPages[env]}`;
+
+export { alloyWithVisitorTestPageUrl };
+
 export default `https://alloyio.com/functional-test/${pageName[env]}`;


### PR DESCRIPTION
## Description

In the future, we can page this cleaner by injecting Visitor from the spec file, but for now `testcafe` is throwing errors when we try to inject a client script from a secure URL.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
