### PR TITLE
CORE-45102 Removed errorsEnabled. No longer failing commands due to consent.

### DIFF
--- a/src/components/EventMerge/index.js
+++ b/src/components/EventMerge/index.js
@@ -13,18 +13,24 @@ governing permissions and limitations under the License.
 import { uuid } from "../../utils";
 import { callback } from "../../utils/validation";
 
+const generateEventMergeIdResult = () => {
+  return {
+    eventMergeId: uuid()
+  };
+};
+
 const createEventMerge = ({ config }) => {
   // #if _REACTOR
   // This is a way for the Event Merge ID data element in the Reactor extension
   // to get an event merge ID synchronously since data elements are required
   // to be synchronous.
-  config.reactorRegisterCreateEventMergeId(uuid);
+  config.reactorRegisterCreateEventMergeId(generateEventMergeIdResult);
   // #endif
 
   return {
     commands: {
       createEventMergeId: {
-        run: uuid
+        run: generateEventMergeIdResult
       }
     }
   };

--- a/src/components/Identity/createComponent.js
+++ b/src/components/Identity/createComponent.js
@@ -42,20 +42,26 @@ export default ({
       syncIdentity: {
         optionsValidator: validateSyncIdentityOptions,
         run: options => {
-          return identityManager.sync(options.identities);
+          return identityManager.sync(options.identities).then(() => {
+            return {};
+          });
         }
       },
       getIdentity: {
         optionsValidator: getIdentityOptionsValidator,
         run: options => {
-          return consent.awaitConsent().then(() => {
-            if (ecid) {
-              return { ECID: ecid };
-            }
-            return getIdentity(options.namespaces).then(() => {
-              return { ECID: ecid };
+          return consent
+            .awaitConsent()
+            .then(() => {
+              return ecid ? undefined : getIdentity(options.namespaces);
+            })
+            .then(() => {
+              return {
+                identities: {
+                  ECID: ecid
+                }
+              };
             });
-          });
         }
       }
     }

--- a/src/components/Privacy/createComponent.js
+++ b/src/components/Privacy/createComponent.js
@@ -60,7 +60,10 @@ export default ({
               }
               throw error;
             })
-            .then(readCookieIfQueueEmpty);
+            .then(() => {
+              readCookieIfQueueEmpty();
+              return {};
+            });
         }
       }
     },

--- a/src/core/buildAndValidateConfig.js
+++ b/src/core/buildAndValidateConfig.js
@@ -47,12 +47,10 @@ export default ({
   coreConfigValidators,
   createConfig,
   logger,
-  setDebugEnabled,
-  setErrorsEnabled
+  setDebugEnabled
 }) => {
   const schema = buildSchema(coreConfigValidators, componentCreators);
   const config = createConfig(transformOptions(schema, options));
-  setErrorsEnabled(config.errorsEnabled);
   setDebugEnabled(config.debugEnabled, { fromConfig: true });
   // toJson is expensive so we short circuit if logging is disabled
   if (logger.enabled) {

--- a/src/core/config/createCoreConfigs.js
+++ b/src/core/config/createCoreConfigs.js
@@ -24,7 +24,6 @@ import { IN, PENDING } from "../../constants/consentStatus";
 import { GENERAL } from "../../constants/consentPurpose";
 
 export default () => ({
-  errorsEnabled: boolean().default(true),
   debugEnabled: boolean().default(false),
   defaultConsent: objectOf({
     [GENERAL]: enumOf(IN, PENDING).default(IN)

--- a/src/core/consent/createConsentStateMachine.js
+++ b/src/core/consent/createConsentStateMachine.js
@@ -13,6 +13,13 @@ governing permissions and limitations under the License.
 import { defer } from "../../utils";
 
 export const DECLINED_CONSENT = "The user declined consent.";
+export const DECLINED_CONSENT_ERROR_CODE = "declinedConsent";
+
+const createDeclinedConsentError = () => {
+  const error = new Error(DECLINED_CONSENT);
+  error.code = DECLINED_CONSENT_ERROR_CODE;
+  return error;
+};
 
 export default () => {
   const deferreds = [];
@@ -24,12 +31,12 @@ export default () => {
   };
   const discardAll = () => {
     while (deferreds.length) {
-      deferreds.shift().reject(new Error(DECLINED_CONSENT));
+      deferreds.shift().reject(createDeclinedConsentError());
     }
   };
 
   const awaitIn = () => Promise.resolve();
-  const awaitOut = () => Promise.reject(new Error(DECLINED_CONSENT));
+  const awaitOut = () => Promise.reject(createDeclinedConsentError());
   const awaitPending = () => {
     const deferred = defer();
     deferreds.push(deferred);

--- a/src/core/executeCommandFactory.js
+++ b/src/core/executeCommandFactory.js
@@ -94,6 +94,8 @@ export default ({
       const executor = getExecutor(commandName, options);
       logger.log(`Executing ${commandName} command.`, "Options:", options);
       resolve(executor());
-    }).catch(handleError);
+    }).catch(error => {
+      return handleError(error, commandName);
+    });
   };
 };

--- a/src/core/handleErrorFactory.js
+++ b/src/core/handleErrorFactory.js
@@ -11,17 +11,20 @@ governing permissions and limitations under the License.
 */
 
 import { toError } from "../utils";
+import { DECLINED_CONSENT_ERROR_CODE } from "./consent/createConsentStateMachine";
 
-const suppressionNote =
-  "Note: Errors can be suppressed by setting the errorsEnabled configuration option to false.";
+export default ({ instanceNamespace, logger }) => (error, commandName) => {
+  // In the case of declined consent, we've opted to not reject the promise
+  // returned to the customer, but instead resolve the promise with an
+  // empty result object.
+  if (error.code === DECLINED_CONSENT_ERROR_CODE) {
+    logger.warn(
+      `The ${commandName} command could not complete because the user declined consent.`
+    );
+    return {};
+  }
 
-export default ({ instanceNamespace, getErrorsEnabled, logger }) => error => {
   const err = toError(error);
   err.message = `[${instanceNamespace}] ${err.message}`;
-  if (getErrorsEnabled()) {
-    err.message += `\n${suppressionNote}`;
-    throw err;
-  } else {
-    logger.error(err);
-  }
+  throw err;
 };

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -61,16 +61,10 @@ if (instanceNamespaces) {
     const componentRegistry = createComponentRegistry();
     const lifecycle = createLifecycle(componentRegistry);
     const networkStrategy = networkStrategyFactory(window, logger);
-    let errorsEnabled = true;
-    const getErrorsEnabled = () => {
-      return errorsEnabled;
-    };
-    const setErrorsEnabled = value => {
-      errorsEnabled = value;
-    };
 
     const setDebugCommand = options => {
       setDebugEnabled(options.enabled, { fromConfig: false });
+      return {};
     };
 
     const configureCommand = options => {
@@ -80,8 +74,7 @@ if (instanceNamespaces) {
         coreConfigValidators,
         createConfig,
         logger,
-        setDebugEnabled,
-        setErrorsEnabled
+        setDebugEnabled
       });
       const cookieTransfer = createCookieTransfer({
         cookieJar,
@@ -134,12 +127,13 @@ if (instanceNamespaces) {
             sendEdgeNetworkRequest
           };
         }
+      }).then(() => {
+        return {};
       });
     };
 
     const handleError = handleErrorFactory({
       instanceNamespace,
-      getErrorsEnabled,
       logger
     });
 

--- a/test/unit/specs/components/EventMerge/index.spec.js
+++ b/test/unit/specs/components/EventMerge/index.spec.js
@@ -32,7 +32,9 @@ describe("EventMerge", () => {
     describe("createEventMergeId", () => {
       it("returns a UUID v4-compliant Id", () => {
         expect(
-          uuidv4Regex.test(eventMerge.commands.createEventMergeId.run())
+          uuidv4Regex.test(
+            eventMerge.commands.createEventMergeId.run().eventMergeId
+          )
         ).toBe(true);
       });
     });
@@ -42,7 +44,7 @@ describe("EventMerge", () => {
     it("registers a function for creating an event merge ID", () => {
       const createEventMergeId = reactorRegisterCreateEventMergeId.calls.first()
         .args[0];
-      expect(uuidv4Regex.test(createEventMergeId())).toBe(true);
+      expect(uuidv4Regex.test(createEventMergeId().eventMergeId)).toBe(true);
     });
   });
 });

--- a/test/unit/specs/components/Identity/createComponent.spec.js
+++ b/test/unit/specs/components/Identity/createComponent.spec.js
@@ -30,10 +30,10 @@ describe("Identity::createComponent", () => {
 
   beforeEach(() => {
     addEcidQueryToEvent = jasmine.createSpy("addEcidQueryToEvent");
-    identityManager = jasmine.createSpyObj("identityManager", [
-      "addToPayload",
-      "sync"
-    ]);
+    identityManager = jasmine.createSpyObj("identityManager", {
+      addToPayload: undefined,
+      sync: Promise.resolve()
+    });
     ensureRequestHasIdentity = jasmine.createSpy("ensureRequestHasIdentity");
     setLegacyEcid = jasmine.createSpy("setLegacyEcid");
     handleResponseForIdSyncs = jasmine.createSpy("handleResponseForIdSyncs");
@@ -122,22 +122,22 @@ describe("Identity::createComponent", () => {
 
   it("syncIdentity syncs identities", () => {
     const identities = { type: "identities" };
-    component.commands.syncIdentity.run({ identities });
-    expect(identityManager.sync).toHaveBeenCalledWith(identities);
+    return component.commands.syncIdentity.run({ identities }).then(result => {
+      expect(identityManager.sync).toHaveBeenCalledWith(identities);
+      expect(result).toEqual({});
+    });
   });
 
   it("getIdentity command should make a request when ecid is not available", () => {
-    let ecid;
+    const onResolved = jasmine.createSpy("onResolved");
     component.commands.getIdentity
       .run({ namespaces: ["ECID"] })
-      .then(identities => {
-        ecid = identities.ECID;
-      });
+      .then(onResolved);
 
     return flushPromiseChains()
       .then(() => {
         expect(getIdentity).not.toHaveBeenCalled();
-        expect(ecid).toBe(undefined);
+        expect(onResolved).not.toHaveBeenCalled();
         consentDeferred.resolve();
         return flushPromiseChains();
       })
@@ -150,7 +150,11 @@ describe("Identity::createComponent", () => {
         return flushPromiseChains();
       })
       .then(() => {
-        expect(ecid).toBe("user@adobe");
+        expect(onResolved).toHaveBeenCalledWith({
+          identities: {
+            ECID: "user@adobe"
+          }
+        });
       });
   });
 
@@ -158,20 +162,22 @@ describe("Identity::createComponent", () => {
     getEcidFromResponse.and.returnValue("user@adobe");
     const response = { type: "response" };
     component.lifecycle.onResponse({ response });
-    let ecid;
-    component.commands.getIdentity.run().then(identities => {
-      ecid = identities.ECID;
-    });
+    const onResolved = jasmine.createSpy("onResolved");
+    component.commands.getIdentity.run().then(onResolved);
     return flushPromiseChains()
       .then(() => {
         expect(getIdentity).not.toHaveBeenCalled();
-        expect(ecid).toBe(undefined);
+        expect(onResolved).not.toHaveBeenCalled();
         consentDeferred.resolve();
         return flushPromiseChains();
       })
       .then(() => {
         expect(getIdentity).not.toHaveBeenCalled();
-        expect(ecid).toBe("user@adobe");
+        expect(onResolved).toHaveBeenCalledWith({
+          identities: {
+            ECID: "user@adobe"
+          }
+        });
       });
   });
 });

--- a/test/unit/specs/components/Privacy/createComponent.spec.js
+++ b/test/unit/specs/components/Privacy/createComponent.spec.js
@@ -62,14 +62,14 @@ describe("privacy:createComponent", () => {
     defaultConsent = { general: "pending" };
     readStoredConsent.and.returnValues({}, { general: "in" });
     build();
-    validateSetConsentOptions.and.returnValue({ general: "in" });
     sendSetConsentRequest.and.returnValue(Promise.resolve());
-    component.commands.setConsent.run(validateSetConsentOptions("unvalidated"));
-    expect(validateSetConsentOptions).toHaveBeenCalledWith("unvalidated");
+    const onResolved = jasmine.createSpy("onResolved");
+    component.commands.setConsent.run({ general: "in" }).then(onResolved);
     expect(consent.suspend).toHaveBeenCalled();
     return flushPromiseChains().then(() => {
       expect(sendSetConsentRequest).toHaveBeenCalledWith({ general: "in" });
       expect(consent.setConsent).toHaveBeenCalledWith({ general: "in" });
+      expect(onResolved).toHaveBeenCalledWith({});
     });
   });
 

--- a/test/unit/specs/core/buildAndValidateConfig.spec.js
+++ b/test/unit/specs/core/buildAndValidateConfig.spec.js
@@ -20,7 +20,6 @@ describe("buildAndValidateConfig", () => {
   let coreConfigValidators;
   let logger;
   let setDebugEnabled;
-  let setErrorsEnabled;
 
   beforeEach(() => {
     options = {};
@@ -38,7 +37,6 @@ describe("buildAndValidateConfig", () => {
       log: jasmine.createSpy()
     };
     setDebugEnabled = jasmine.createSpy();
-    setErrorsEnabled = jasmine.createSpy();
   });
 
   it("adds validators and validates options", () => {
@@ -49,24 +47,9 @@ describe("buildAndValidateConfig", () => {
         coreConfigValidators,
         createConfig,
         logger,
-        setDebugEnabled,
-        setErrorsEnabled
+        setDebugEnabled
       });
     }).toThrowError();
-  });
-
-  it("sets errors enabled based on config", () => {
-    options.errorsEnabled = true;
-    buildAndValidateConfig({
-      options,
-      componentCreators,
-      coreConfigValidators,
-      createConfig,
-      logger,
-      setDebugEnabled,
-      setErrorsEnabled
-    });
-    expect(setErrorsEnabled).toHaveBeenCalledWith(true);
   });
 
   it("sets debug enabled based on config", () => {
@@ -77,8 +60,7 @@ describe("buildAndValidateConfig", () => {
       coreConfigValidators,
       createConfig,
       logger,
-      setDebugEnabled,
-      setErrorsEnabled
+      setDebugEnabled
     });
     expect(setDebugEnabled).toHaveBeenCalledWith(true, { fromConfig: true });
   });
@@ -91,8 +73,7 @@ describe("buildAndValidateConfig", () => {
       coreConfigValidators,
       createConfig,
       logger,
-      setDebugEnabled,
-      setErrorsEnabled
+      setDebugEnabled
     });
     expect(logger.log).toHaveBeenCalledWith("Computed configuration:", {
       debugEnabled: false,
@@ -110,8 +91,7 @@ describe("buildAndValidateConfig", () => {
         coreConfigValidators,
         createConfig,
         logger,
-        setDebugEnabled,
-        setErrorsEnabled
+        setDebugEnabled
       })
     ).toThrowError();
   });
@@ -123,8 +103,7 @@ describe("buildAndValidateConfig", () => {
       coreConfigValidators,
       createConfig,
       logger,
-      setDebugEnabled,
-      setErrorsEnabled
+      setDebugEnabled
     });
     expect(result).toEqual({ idSyncEnabled: true, debugEnabled: false });
   });

--- a/test/unit/specs/core/config/createCoreConfigs.spec.js
+++ b/test/unit/specs/core/config/createCoreConfigs.spec.js
@@ -18,38 +18,6 @@ import { GENERAL } from "../../../../../src/constants/consentPurpose";
 describe("createCoreConfigs", () => {
   const baseConfig = { edgeConfigId: "1234", orgId: "org1" };
 
-  describe("errorsEnabled", () => {
-    it("validates errorsEnabled=undefined", () => {
-      const config = objectOf(createCoreConfigs())(baseConfig);
-      expect(config.errorsEnabled).toBe(true);
-    });
-
-    it("validates errorsEnabled=true", () => {
-      const config = objectOf(createCoreConfigs())({
-        errorsEnabled: true,
-        ...baseConfig
-      });
-      expect(config.errorsEnabled).toBe(true);
-    });
-
-    it("validates errorsEnabled=false", () => {
-      const config = objectOf(createCoreConfigs())({
-        errorsEnabled: false,
-        ...baseConfig
-      });
-      expect(config.errorsEnabled).toBe(false);
-    });
-
-    it("validates errorsEnabled=123", () => {
-      expect(() => {
-        objectOf(createCoreConfigs())({
-          errorsEnabled: 123,
-          ...baseConfig
-        });
-      }).toThrowError();
-    });
-  });
-
   describe("debugEnabled", () => {
     it("validates debugEnabled=undefined", () => {
       const config = objectOf(createCoreConfigs())(baseConfig);

--- a/test/unit/specs/core/consent/createConsentStateMachine.spec.js
+++ b/test/unit/specs/core/consent/createConsentStateMachine.spec.js
@@ -13,6 +13,8 @@ governing permissions and limitations under the License.
 import createConsentStateMachine from "../../../../../src/core/consent/createConsentStateMachine";
 import flushPromiseChains from "../../../helpers/flushPromiseChains";
 
+const DECLINED_CONSENT_ERROR_CODE = "declinedConsent";
+
 describe("createConsentStateMachine", () => {
   let subject;
 
@@ -46,7 +48,8 @@ describe("createConsentStateMachine", () => {
     subject.awaitConsent().catch(onRejected);
 
     return flushPromiseChains().then(() => {
-      expect(onRejected).toHaveBeenCalled();
+      const error = onRejected.calls.argsFor(0)[0];
+      expect(error.code).toBe(DECLINED_CONSENT_ERROR_CODE);
     });
   });
 
@@ -68,17 +71,18 @@ describe("createConsentStateMachine", () => {
 
   it("rejects queued promises when consent set to out", () => {
     subject.pending();
-    const onFulfilled = jasmine.createSpy("onFulfilled");
-    subject.awaitConsent().catch(onFulfilled);
+    const onRejected = jasmine.createSpy("onFulfilled");
+    subject.awaitConsent().catch(onRejected);
 
     return flushPromiseChains()
       .then(() => {
-        expect(onFulfilled).not.toHaveBeenCalled();
+        expect(onRejected).not.toHaveBeenCalled();
         subject.out();
         return flushPromiseChains();
       })
       .then(() => {
-        expect(onFulfilled).toHaveBeenCalled();
+        const error = onRejected.calls.argsFor(0)[0];
+        expect(error.code).toBe(DECLINED_CONSENT_ERROR_CODE);
       });
   });
 });


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
No longer reject command promises if the user has declined consent. Remove `errorsEnabled` configuration option. We may add it back later if we still find it is necessary, but now that promises aren't rejected due to consent, there will be much fewer failures and any failures that do occur probably deserve attention.

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-45102
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
I discussed this with the team, then with internal beta customers, then with Joe Khoury and Justin Grover. When a command is executed and the user is opted out, the promise returned from the command will now be resolved rather than rejected. The promise will be resolved with an object, but the object may not contain all the properties it would have had the user opted in. We also decided to remove the errorsEnabled configuration option. We may add it back later, but the primary reason for it, in my opinion and if I recall correctly, was because of the sheer quantity of errors we would be throwing when the customer attempts to execute commands and the user has opted out. Now that executing a command when the user is opted out is not considered an error, the number of errors thrown will be greatly reduced and really will deserve the customer's attention.

For all commands (even commands that have nothing to do with consent, like setDebug), we will always resolve the promise with an object as long as no error is thrown. When we have data to add to the object, we will do so and the data will be segregated into their own properties on the object (for example, decisions will go under result.decisions, identities will go under result.identities). This is somewhat akin to how we have an options parameter for every command for extensibility so that we can add options/properties later if needed.

We discussed always adding another property to the result object like optedOut or even including the consent status for each purpose, so that customers could programmatically know why the result object may not contain the full data they were expecting. This has its own shortcomings, however. We suspect that in the future, when granular consent purposes are introduced, that after the user opted into some purposes and opted out of other purposes, when a command like sendEvent is executed, Alloy may still send the request to Konductor, and Konductor would have logic based on the consent status of each purpose which results in a partial response. As an arbitrary example, maybe it returns identities but not decisions) for a particular request/response due to the users being opted into one purpose but not another. In such a case, Alloy would resolve the command's promise with a result object containing only identities and not decisions.

At that point, having a property on the result object like optedOut is too broad, since the user only opted out of some purposes and not others. Including the consent status for all purposes on the result object doesn't seem to be particularly useful. For example, would the customer use it to determine whether they can access result.decisions? Why wouldn't the customer check to see if result.decisions is defined directly? If customers are wanting to programmatically react to consent-based logic that is occurring within Konductor, then the best way to do that would be to have Konductor provide additional details in its response regarding why certain data was or was not included, which Alloy could then surface on the result object. Until we have granular purposes and this becomes more of a reality, any command that requires consent in order to complete will log a warning if the user is opted out and will resolve the command promise with an empty object.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
