### PR TITLE
CORE-45621 Renaming syncIdentity option from identities to identity.

### DIFF
--- a/sandbox/public/e2e/index.html
+++ b/sandbox/public/e2e/index.html
@@ -72,7 +72,7 @@
         });
         console.log("syncIdentity option is enabled");
         alloy("syncIdentity", {
-          identities: {
+          identity: {
             Email_LC_SHA256: {
               id: email,
               authenticatedState: "ambiguous",

--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -76,10 +76,10 @@
         }
       });
 
-      alloy("getIdentity", { namespaces: ["ECID"] }).then(function(identities) {
+      alloy("getIdentity", { namespaces: ["ECID"] }).then(function(result) {
         console.log(
-          "Sandbox: Get Identity command has completed.,",
-          identities.ECID
+          "Sandbox: Get Identity command has completed.",
+          result.identity.ECID
         );
       });
 
@@ -97,7 +97,7 @@
       });
 
       alloy("syncIdentity", {
-        identities: {
+        identity: {
           Email_LC_SHA256: {
             id: "me@gmail.com",
             authenticatedState: "ambiguous",

--- a/src/components/Identity/createComponent.js
+++ b/src/components/Identity/createComponent.js
@@ -42,7 +42,7 @@ export default ({
       syncIdentity: {
         optionsValidator: validateSyncIdentityOptions,
         run: options => {
-          return identityManager.sync(options.identities);
+          return identityManager.sync(options.identity);
         }
       },
       getIdentity: {

--- a/src/components/Identity/validateSyncIdentityOptions.js
+++ b/src/components/Identity/validateSyncIdentityOptions.js
@@ -1,7 +1,7 @@
 import { objectOf } from "../../utils/validation";
 
 export default objectOf({
-  identities: objectOf({}).required()
+  identity: objectOf({}).required()
 })
   .noUnknownFields()
   .required();

--- a/test/unit/specs/components/Identity/createComponent.spec.js
+++ b/test/unit/specs/components/Identity/createComponent.spec.js
@@ -121,9 +121,9 @@ describe("Identity::createComponent", () => {
   });
 
   it("syncIdentity syncs identities", () => {
-    const identities = { type: "identities" };
-    return component.commands.syncIdentity.run({ identities }).then(result => {
-      expect(identityManager.sync).toHaveBeenCalledWith(identities);
+    const identity = { type: "identity" };
+    return component.commands.syncIdentity.run({ identity }).then(result => {
+      expect(identityManager.sync).toHaveBeenCalledWith(identity);
       expect(result).toBeUndefined();
     });
   });

--- a/test/unit/specs/components/Identity/validateSyncIdentityOptions.spec.js
+++ b/test/unit/specs/components/Identity/validateSyncIdentityOptions.spec.js
@@ -17,13 +17,13 @@ describeValidation(
   "Identity:validateSyncIdentityOptions",
   validateSyncIdentityOptions,
   [
-    { value: { identities: { email: { id: "example@adobe.com" } } } },
+    { value: { identity: { email: { id: "example@adobe.com" } } } },
     { value: { foo: { email: { id: "example@adobe.com" } } }, error: true },
-    { value: { identities: undefined }, error: true },
-    { value: { identities: null }, error: true },
-    { value: { identities: "foo" }, error: true },
+    { value: { identity: undefined }, error: true },
+    { value: { identity: null }, error: true },
+    { value: { identity: "foo" }, error: true },
     {
-      value: { identities: { email: { id: "example@adobe.com" } }, foo: "bar" },
+      value: { identity: { email: { id: "example@adobe.com" } }, foo: "bar" },
       error: true
     },
     { value: "in", error: true },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Renaming syncIdentity option from identities to identity. 

In my understanding, this is part of a larger nomenclature shift where the third-party "identifiers", for lack of a better term, are not identities on their own, but are instead identifiers as part of a single "identity". Notice that in this PR, I only renamed the option; I didn't rename a bunch of our internal variables. I logged this as a separate issue since we're crunched for GA, there are no functional tests yet for syncIdentity, etc.: https://jira.corp.adobe.com/browse/CORE-45622

I also logged an issue for moving some option validation logic: https://jira.corp.adobe.com/browse/CORE-45624

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-45621
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Request from PM to be consistent in our terminology.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
