### PR TITLE
Adding support for redirect items (DON'T MERGE YET)

### DIFF
--- a/src/components/Personalization/createCollect.js
+++ b/src/components/Personalization/createCollect.js
@@ -11,9 +11,14 @@ governing permissions and limitations under the License.
 */
 
 export default ({ eventManager, mergeMeta }) => {
-  return meta => {
+  return (meta, documentMayUnload = false) => {
     const event = eventManager.createEvent();
     event.mergeXdm({ eventType: "display" });
+
+    if (documentMayUnload) {
+      event.documentMayUnload();
+    }
+
     mergeMeta(event, meta);
 
     return eventManager.sendEvent(event);

--- a/src/components/Personalization/createDomActionDecisionHandler.js
+++ b/src/components/Personalization/createDomActionDecisionHandler.js
@@ -1,0 +1,67 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { assign, flatMap, isNonEmptyArray } from "../../utils";
+
+const identity = item => item;
+
+const buildActions = decision => {
+  const meta = { id: decision.id, scope: decision.scope };
+
+  return decision.items.map(item => assign({}, item.data, { meta }));
+};
+
+const processMetas = (collect, logger, actionResults) => {
+  const results = flatMap(actionResults, identity);
+  const finalMetas = [];
+  const set = new Set();
+
+  results.forEach(item => {
+    // for click actions we don't return an item
+    if (!item) {
+      return;
+    }
+
+    if (item.error) {
+      logger.warn(item);
+      return;
+    }
+
+    const { meta } = item;
+
+    if (set.has(meta.id)) {
+      return;
+    }
+
+    set.add(meta.id);
+    finalMetas.push(meta);
+  });
+
+  if (isNonEmptyArray(finalMetas)) {
+    collect({ decisions: finalMetas });
+  }
+};
+
+export default ({ modules, logger, executeActions, collect }) => {
+  return renderableDecisions => {
+    const actionResultsPromises = renderableDecisions.map(decision => {
+      const actions = buildActions(decision);
+
+      return executeActions(actions, modules, logger);
+    });
+    return Promise.all(actionResultsPromises)
+      .then(results => processMetas(collect, logger, results))
+      .catch(error => {
+        logger.error(error);
+      });
+  };
+};

--- a/src/components/Personalization/createDomActionDecisionHandler.js
+++ b/src/components/Personalization/createDomActionDecisionHandler.js
@@ -58,6 +58,7 @@ export default ({ modules, logger, executeActions, collect }) => {
 
       return executeActions(actions, modules, logger);
     });
+
     return Promise.all(actionResultsPromises)
       .then(results => processMetas(collect, logger, results))
       .catch(error => {

--- a/src/components/Personalization/createExecuteDecisions.js
+++ b/src/components/Personalization/createExecuteDecisions.js
@@ -11,14 +11,20 @@ governing permissions and limitations under the License.
 */
 import { isNonEmptyArray } from "../../utils";
 
-export default ({ redirectDecisionHandler, domActionDecisionHandler }) => {
+export default ({
+  showContainers,
+  handleRedirectDecisions,
+  handleDomActionDecisions
+}) => {
   return ({ redirectDecisions, renderableDecisions }) => {
     if (isNonEmptyArray(redirectDecisions)) {
-      redirectDecisionHandler(redirectDecisions);
+      handleRedirectDecisions(redirectDecisions);
       return;
     }
+
     if (isNonEmptyArray(renderableDecisions)) {
-      domActionDecisionHandler(renderableDecisions);
+      handleDomActionDecisions(renderableDecisions);
+      showContainers();
     }
   };
 };

--- a/src/components/Personalization/createOnResponseHandler.js
+++ b/src/components/Personalization/createOnResponseHandler.js
@@ -13,17 +13,19 @@ governing permissions and limitations under the License.
 export default ({ extractDecisions, executeDecisions, showContainers }) => {
   return ({ renderDecisions, response }) => {
     const [
+      redirectDecisions,
       renderableDecisions,
-      decisions,
+      restOfDecisions,
       unprocessedDecisions
     ] = extractDecisions(response);
 
-    if (renderDecisions) {
-      executeDecisions(renderableDecisions);
-      showContainers();
-      return { decisions };
+    if (!renderDecisions) {
+      return { decisions: unprocessedDecisions };
     }
 
-    return { decisions: unprocessedDecisions };
+    executeDecisions({ redirectDecisions, renderableDecisions });
+    showContainers();
+
+    return { decisions: restOfDecisions };
   };
 };

--- a/src/components/Personalization/createOnResponseHandler.js
+++ b/src/components/Personalization/createOnResponseHandler.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export default ({ extractDecisions, executeDecisions, showContainers }) => {
+export default ({ extractDecisions, executeDecisions }) => {
   return ({ renderDecisions, response }) => {
     const [
       redirectDecisions,
@@ -24,7 +24,6 @@ export default ({ extractDecisions, executeDecisions, showContainers }) => {
     }
 
     executeDecisions({ redirectDecisions, renderableDecisions });
-    showContainers();
 
     return { decisions: restOfDecisions };
   };

--- a/src/components/Personalization/createRedirectDecisionHandler.js
+++ b/src/components/Personalization/createRedirectDecisionHandler.js
@@ -9,16 +9,21 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { isNonEmptyArray } from "../../utils";
 
-export default ({ redirectDecisionHandler, domActionDecisionHandler }) => {
-  return ({ redirectDecisions, renderableDecisions }) => {
-    if (isNonEmptyArray(redirectDecisions)) {
-      redirectDecisionHandler(redirectDecisions);
-      return;
-    }
-    if (isNonEmptyArray(renderableDecisions)) {
-      domActionDecisionHandler(renderableDecisions);
-    }
+const getRedirectDetails = redirectDecisions => {
+  const decision = redirectDecisions[0];
+  const { items, id, scope } = decision;
+  const { content } = items[0].data;
+
+  return { content, meta: { id, scope } };
+};
+
+export default ({ collect, win = window }) => {
+  return redirectDecisions => {
+    const { content, meta } = getRedirectDetails(redirectDecisions);
+
+    return collect({ decisions: [meta] }, true).then(() => {
+      win.location.replace(content);
+    });
   };
 };

--- a/src/components/Personalization/dom-actions/click.js
+++ b/src/components/Personalization/dom-actions/click.js
@@ -14,5 +14,6 @@ export default (settings, store) => {
   const { selector, meta } = settings;
 
   store({ selector, meta });
+
   return Promise.resolve();
 };

--- a/src/components/Personalization/extractDecisions.js
+++ b/src/components/Personalization/extractDecisions.js
@@ -11,13 +11,12 @@ governing permissions and limitations under the License.
 */
 
 import { isNonEmptyArray } from "../../utils";
-import * as SCHEMAS from "../../constants/schemas";
-
-const DECISIONS_HANDLE = "personalization:decisions";
-
-const isDomActionItem = item => item.schema === SCHEMAS.DOM_ACTION;
-const isRedirectItem = item => item.schema === SCHEMAS.REDIRECT_ITEM;
-const isPageWideScope = decision => decision.scope === "__view__";
+import {
+  getDecisions,
+  isPageWideScope,
+  isDomActionItem,
+  isRedirectItem
+} from "./utils";
 
 const splitItems = (items, predicate) => {
   const matched = [];
@@ -71,7 +70,7 @@ const splitDecisions = (decisions, domActionPredicate, redirectPredicate) => {
 };
 
 export default response => {
-  const decisions = response.getPayloadsByType(DECISIONS_HANDLE);
+  const decisions = getDecisions(response);
 
   return splitDecisions(decisions, isDomActionItem, isRedirectItem);
 };

--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -22,17 +22,24 @@ import collectClicks from "./dom-actions/clicks/collectClicks";
 import { hasScopes, isAuthoringModeEnabled, getDecisionScopes } from "./utils";
 import { mergeMeta, mergeQuery, createQueryDetails } from "./event";
 import createOnClickHandler from "./createOnClickHandler";
+import createRedirectDecisionHandler from "./createRedirectDecisionHandler";
+import createDomActionDecisionHandler from "./createDomActionDecisionHandler";
 
 const createPersonalization = ({ config, logger, eventManager }) => {
-  const collect = createCollect({ eventManager, mergeMeta });
   const clickStorage = [];
+  const collect = createCollect({ eventManager, mergeMeta });
   const store = value => clickStorage.push(value);
   const modules = initDomActionsModules(store);
-  const executeDecisions = createExecuteDecisions({
+  const redirectDecisionHandler = createRedirectDecisionHandler({ collect });
+  const domActionDecisionHandler = createDomActionDecisionHandler({
     modules,
     logger,
     executeActions,
     collect
+  });
+  const executeDecisions = createExecuteDecisions({
+    redirectDecisionHandler,
+    domActionDecisionHandler
   });
   const onResponseHandler = createOnResponseHandler({
     extractDecisions,

--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -30,21 +30,21 @@ const createPersonalization = ({ config, logger, eventManager }) => {
   const collect = createCollect({ eventManager, mergeMeta });
   const store = value => clickStorage.push(value);
   const modules = initDomActionsModules(store);
-  const redirectDecisionHandler = createRedirectDecisionHandler({ collect });
-  const domActionDecisionHandler = createDomActionDecisionHandler({
+  const handleRedirectDecisions = createRedirectDecisionHandler({ collect });
+  const handleDomActionDecisions = createDomActionDecisionHandler({
     modules,
     logger,
     executeActions,
     collect
   });
   const executeDecisions = createExecuteDecisions({
-    redirectDecisionHandler,
-    domActionDecisionHandler
+    showContainers,
+    handleRedirectDecisions,
+    handleDomActionDecisions
   });
   const onResponseHandler = createOnResponseHandler({
     extractDecisions,
-    executeDecisions,
-    showContainers
+    executeDecisions
   });
   const onClickHandler = createOnClickHandler({
     mergeMeta,

--- a/src/components/Personalization/utils.js
+++ b/src/components/Personalization/utils.js
@@ -11,10 +11,17 @@ governing permissions and limitations under the License.
 */
 
 import { includes, isNonEmptyArray } from "../../utils";
+import * as SCHEMAS from "../../constants/schemas";
 
 const PAGE_WIDE_SCOPE = "__view__";
+const DECISIONS_HANDLE = "personalization:decisions";
 
+export const isDomActionItem = item => item.schema === SCHEMAS.DOM_ACTION;
+export const isRedirectItem = item => item.schema === SCHEMAS.REDIRECT_ITEM;
+export const isPageWideScope = decision => decision.scope === PAGE_WIDE_SCOPE;
 export const hasScopes = scopes => isNonEmptyArray(scopes);
+export const getDecisions = response =>
+  response.getPayloadsByType(DECISIONS_HANDLE);
 
 export const isAuthoringModeEnabled = (doc = document) =>
   doc.location.href.indexOf("mboxEdit") !== -1;

--- a/test/unit/specs/components/Personalization/createDomActionDecisionHandler.spec.js
+++ b/test/unit/specs/components/Personalization/createDomActionDecisionHandler.spec.js
@@ -1,0 +1,157 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import createDomActionDecisionHandler from "../../../../../src/components/Personalization/createDomActionDecisionHandler";
+
+describe("Personalization::createDomActionDecisionHandler", () => {
+  const logger = jasmine.createSpyObj("logger", ["log", "warn", "error"]);
+  let executeActions;
+  let collect;
+
+  const decisions = [
+    {
+      id: 1,
+      scope: "foo",
+      items: [
+        {
+          schema: "https://ns.adobe.com/personalization/dom-action",
+          data: {
+            type: "setHtml",
+            selector: "#foo",
+            content: "<div>Hola Mundo</div>"
+          }
+        }
+      ]
+    },
+    {
+      id: 5,
+      scope: "__view__",
+      items: [
+        {
+          schema: "https://ns.adobe.com/personalization/dom-action",
+          data: {
+            type: "setHtml",
+            selector: "#foo2",
+            content: "<div>offer 2</div>"
+          }
+        }
+      ]
+    }
+  ];
+  const expectedAction = [
+    {
+      type: "setHtml",
+      selector: "#foo",
+      content: "<div>Hola Mundo</div>",
+      meta: {
+        id: decisions[0].id,
+        scope: "foo"
+      }
+    }
+  ];
+  const metas = [
+    {
+      id: decisions[0].id,
+      scope: decisions[0].scope
+    },
+    {
+      id: decisions[1].id,
+      scope: decisions[1].scope
+    }
+  ];
+  const modules = {
+    foo() {}
+  };
+
+  beforeEach(() => {
+    collect = jasmine.createSpy();
+  });
+
+  it("should trigger executeActions and collect when provided with an array of actions", () => {
+    executeActions = jasmine
+      .createSpy()
+      .and.returnValues(
+        [{ meta: metas[0] }, { meta: metas[0] }],
+        [{ meta: metas[1], error: "could not render this item" }]
+      );
+    const handleDomActionDecisions = createDomActionDecisionHandler({
+      modules,
+      logger,
+      executeActions,
+      collect
+    });
+    return handleDomActionDecisions(decisions).then(() => {
+      expect(executeActions).toHaveBeenCalledWith(
+        expectedAction,
+        modules,
+        logger
+      );
+      expect(logger.warn).toHaveBeenCalledWith({
+        meta: metas[1],
+        error: "could not render this item"
+      });
+      expect(collect).toHaveBeenCalledWith({ decisions: [metas[0]] });
+    });
+  });
+
+  it("shouldn't trigger executeActions and collect when provided with empty array of actions", () => {
+    executeActions = jasmine.createSpy().and.callThrough();
+    const handleDomActionDecisions = createDomActionDecisionHandler({
+      modules,
+      logger,
+      executeActions,
+      collect
+    });
+    return handleDomActionDecisions([]).then(() => {
+      expect(executeActions).not.toHaveBeenCalled();
+      expect(collect).not.toHaveBeenCalled();
+    });
+  });
+  it("should log an error when collect call fails", () => {
+    const error = new Error("test error");
+    collect = jasmine.createSpy().and.throwError("test error");
+    executeActions = jasmine
+      .createSpy()
+      .and.returnValues([{ meta: metas[0] }], [{ meta: metas[1] }]);
+    const handleDomActionDecisions = createDomActionDecisionHandler({
+      modules,
+      logger,
+      executeActions,
+      collect
+    });
+    return handleDomActionDecisions(decisions).then(() => {
+      expect(executeActions).toHaveBeenCalled();
+      expect(collect).toThrowError();
+      expect(logger.error).toHaveBeenCalledWith(error);
+    });
+  });
+
+  it("should not trigger collect when dom-action click", () => {
+    executeActions = jasmine
+      .createSpy()
+      .and.returnValues([undefined], [undefined]);
+    const handleDomActionDecisions = createDomActionDecisionHandler({
+      modules,
+      logger,
+      executeActions,
+      collect
+    });
+    return handleDomActionDecisions(decisions).then(() => {
+      expect(executeActions).toHaveBeenCalledWith(
+        expectedAction,
+        modules,
+        logger
+      );
+      expect(collect).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/unit/specs/components/Personalization/createExecuteDecisions.spec.js
+++ b/test/unit/specs/components/Personalization/createExecuteDecisions.spec.js
@@ -13,12 +13,14 @@ governing permissions and limitations under the License.
 import createExecuteDecisions from "../../../../../src/components/Personalization/createExecuteDecisions";
 
 describe("Personalization::createExecuteDecisions", () => {
-  let redirectDecisionHandler;
-  let domActionDecisionHandler;
+  let handleRedirectDecisions;
+  let handleDomActionDecisions;
+  let showContainers;
 
   beforeEach(() => {
-    redirectDecisionHandler = jasmine.createSpy();
-    domActionDecisionHandler = jasmine.createSpy();
+    showContainers = jasmine.createSpy();
+    handleRedirectDecisions = jasmine.createSpy();
+    handleDomActionDecisions = jasmine.createSpy();
   });
 
   it("should trigger redirectDecisionHandler when provided with an array of redirect decisions", () => {
@@ -29,12 +31,16 @@ describe("Personalization::createExecuteDecisions", () => {
     ];
     const renderableDecisions = [];
     const executeDecisions = createExecuteDecisions({
-      redirectDecisionHandler,
-      domActionDecisionHandler
+      showContainers,
+      handleRedirectDecisions,
+      handleDomActionDecisions
     });
+
     executeDecisions({ redirectDecisions, renderableDecisions });
-    expect(redirectDecisionHandler).toHaveBeenCalledWith(redirectDecisions);
-    expect(domActionDecisionHandler).not.toHaveBeenCalled();
+
+    expect(handleRedirectDecisions).toHaveBeenCalledWith(redirectDecisions);
+    expect(handleDomActionDecisions).not.toHaveBeenCalled();
+    expect(showContainers).not.toHaveBeenCalled();
   });
 
   it("should trigger domActionDecisionHandler when provided with an array of renderable decisions", () => {
@@ -45,12 +51,15 @@ describe("Personalization::createExecuteDecisions", () => {
       }
     ];
     const executeDecisions = createExecuteDecisions({
-      redirectDecisionHandler,
-      domActionDecisionHandler
+      showContainers,
+      handleRedirectDecisions,
+      handleDomActionDecisions
     });
+
     executeDecisions({ redirectDecisions, renderableDecisions });
 
-    expect(redirectDecisionHandler).not.toHaveBeenCalled();
-    expect(domActionDecisionHandler).toHaveBeenCalledWith(renderableDecisions);
+    expect(handleRedirectDecisions).not.toHaveBeenCalled();
+    expect(handleDomActionDecisions).toHaveBeenCalledWith(renderableDecisions);
+    expect(showContainers).toHaveBeenCalled();
   });
 });

--- a/test/unit/specs/components/Personalization/createOnResponseHandler.spec.js
+++ b/test/unit/specs/components/Personalization/createOnResponseHandler.spec.js
@@ -25,7 +25,6 @@ describe("Personalization::onResponseHandler", () => {
   const unprocessedDecisions = PAGE_WIDE_SCOPE_DECISIONS;
   let extractDecisions;
   let executeDecisions;
-  let showContainers;
 
   beforeEach(() => {
     extractDecisions = jasmine
@@ -37,7 +36,6 @@ describe("Personalization::onResponseHandler", () => {
         unprocessedDecisions
       ]);
     executeDecisions = jasmine.createSpy("executeDecisions");
-    showContainers = jasmine.createSpy("showContainers");
   });
 
   it("should execute DOM ACTION decisions and return rest of decisions when renderDecisions is true", () => {
@@ -47,14 +45,12 @@ describe("Personalization::onResponseHandler", () => {
     const renderDecisions = true;
     const onResponse = createOnResponseHandler({
       extractDecisions,
-      executeDecisions,
-      showContainers
+      executeDecisions
     });
 
     const result = onResponse({ renderDecisions, response });
 
     expect(extractDecisions).toHaveBeenCalledWith(response);
-    expect(showContainers).toHaveBeenCalled();
     expect(executeDecisions).toHaveBeenCalledWith({
       redirectDecisions,
       renderableDecisions
@@ -69,14 +65,12 @@ describe("Personalization::onResponseHandler", () => {
     const renderDecisions = false;
     const onResponse = createOnResponseHandler({
       extractDecisions,
-      executeDecisions,
-      showContainers
+      executeDecisions
     });
 
     const result = onResponse({ renderDecisions, response });
 
     expect(extractDecisions).toHaveBeenCalledWith(response);
-    expect(showContainers).not.toHaveBeenCalled();
     expect(executeDecisions).not.toHaveBeenCalled();
     expect(result).toEqual(expectedResult);
   });

--- a/test/unit/specs/components/Personalization/createOnResponseHandler.spec.js
+++ b/test/unit/specs/components/Personalization/createOnResponseHandler.spec.js
@@ -19,6 +19,7 @@ import createOnResponseHandler from "../../../../../src/components/Personalizati
 
 describe("Personalization::onResponseHandler", () => {
   const response = {};
+  const redirectDecisions = [];
   const renderableDecisions = PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS;
   const decisions = PAGE_WIDE_SCOPE_DECISIONS_WITHOUT_DOM_ACTION_SCHEMA_ITEMS;
   const unprocessedDecisions = PAGE_WIDE_SCOPE_DECISIONS;
@@ -29,7 +30,12 @@ describe("Personalization::onResponseHandler", () => {
   beforeEach(() => {
     extractDecisions = jasmine
       .createSpy("extractDecisions")
-      .and.returnValue([renderableDecisions, decisions, unprocessedDecisions]);
+      .and.returnValue([
+        [],
+        renderableDecisions,
+        decisions,
+        unprocessedDecisions
+      ]);
     executeDecisions = jasmine.createSpy("executeDecisions");
     showContainers = jasmine.createSpy("showContainers");
   });
@@ -49,7 +55,10 @@ describe("Personalization::onResponseHandler", () => {
 
     expect(extractDecisions).toHaveBeenCalledWith(response);
     expect(showContainers).toHaveBeenCalled();
-    expect(executeDecisions).toHaveBeenCalledWith(renderableDecisions);
+    expect(executeDecisions).toHaveBeenCalledWith({
+      redirectDecisions,
+      renderableDecisions
+    });
     expect(result).toEqual(expectedResult);
   });
 

--- a/test/unit/specs/components/Personalization/createRedirectDecisionHandler.spec.js
+++ b/test/unit/specs/components/Personalization/createRedirectDecisionHandler.spec.js
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { REDIRECT_PAGE_WIDE_SCOPE_DECISION } from "./responsesMock/eventResponses";
+import createRedirectDecisionHandler from "../../../../../src/components/Personalization/createRedirectDecisionHandler";
+
+describe("Personalization::createRedirectDecisionHandler", () => {
+  let collect;
+
+  const decisions = REDIRECT_PAGE_WIDE_SCOPE_DECISION;
+  const metas = [
+    {
+      id: decisions[0].id,
+      scope: decisions[0].scope
+    }
+  ];
+  const replace = jasmine.createSpy();
+
+  beforeEach(() => {
+    collect = jasmine.createSpy().and.returnValue(Promise.resolve());
+  });
+
+  it("should trigger collect before redirect", () => {
+    const win = {
+      location: { replace }
+    };
+    const handleRedirectDecisions = createRedirectDecisionHandler({
+      collect,
+      win
+    });
+    return handleRedirectDecisions(decisions).then(() => {
+      expect(collect).toHaveBeenCalledWith({ decisions: metas }, true);
+      expect(replace).toHaveBeenCalledWith(decisions[0].items[0].data.content);
+    });
+  });
+});

--- a/test/unit/specs/components/Personalization/responsesMock/eventResponses.js
+++ b/test/unit/specs/components/Personalization/responsesMock/eventResponses.js
@@ -128,3 +128,18 @@ export const PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS = [
     ]
   }
 ];
+export const REDIRECT_PAGE_WIDE_SCOPE_DECISION = [
+  {
+    id: "TNT:activity15:experience1",
+    scope: "__view__",
+    items: [
+      {
+        schema: "https://ns.adobe.com/personalization/redirect-item",
+        data: {
+          type: "redirect",
+          content: "http://example.com/redirect/offer"
+        }
+      }
+    ]
+  }
+];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding support for redirect items

## Description

<!--- Describe your changes in detail -->
The personalization component is now able to handle redirect items. The way this is implemented is the following:
- if we have `renderDecisions` and we get a redirect item for page-wide scope, then we will skip all other items processing, we will mark the notification event as `documentMayUnload` and we will execute a `window.location.replace()`.
- in all other cases, we will just return a list of decisions with all the items

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Supporting redirect items is one of the basic uses cases

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
