### PR TITLE
Revert support for dataset ID.

### DIFF
--- a/sandbox/src/Home.js
+++ b/sandbox/src/Home.js
@@ -38,12 +38,6 @@ function HomeWithHistory({ history }) {
       });
   };
 
-  const sendDataToSecondaryDataset = () => {
-    window.alloy("sendEvent", {
-      datasetId: "5eb9aaa6a3b16e18a818e06f"
-    });
-  };
-
   const syncIdentity = () => {
     window
       .alloy("syncIdentity", {
@@ -99,7 +93,9 @@ function HomeWithHistory({ history }) {
             <h2>Placeholder for Decision 2</h2>
           </div>
           <div>
-            <button onClick={getDecisions}>Fetch & Render Decisions</button>
+            <button onClick={getDecisions}>
+              Send Event, Fetch & Render Decisions
+            </button>
           </div>
         </div>
       </section>
@@ -107,14 +103,6 @@ function HomeWithHistory({ history }) {
         <h1>Get Identity</h1>
         <div>
           <button onClick={getIdentity}>Get ECID</button>
-        </div>
-      </section>
-      <section>
-        <h1>Collect data into a specific Dataset</h1>
-        <div>
-          <button onClick={sendDataToSecondaryDataset}>
-            Send Event to Secondary Dataset
-          </button>
         </div>
       </section>
       <section>

--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -28,8 +28,7 @@ const createDataCollector = ({ eventManager, logger }) => {
             type,
             mergeId,
             renderDecisions = false,
-            decisionScopes = [],
-            datasetId
+            decisionScopes = []
           } = options;
           const event = eventManager.createEvent();
 
@@ -49,14 +48,6 @@ const createDataCollector = ({ eventManager, logger }) => {
           if (mergeId) {
             event.mergeXdm({
               eventMergeId: mergeId
-            });
-          }
-
-          if (datasetId) {
-            event.mergeMeta({
-              collect: {
-                datasetId
-              }
             });
           }
 

--- a/src/components/DataCollector/validateUserEventOptions.js
+++ b/src/components/DataCollector/validateUserEventOptions.js
@@ -26,8 +26,7 @@ export default ({ options, logger }) => {
     }),
     data: objectOf({}),
     renderDecisions: boolean(),
-    decisionScopes: arrayOf(string()),
-    datasetId: string()
+    decisionScopes: arrayOf(string())
   }).required();
   const validatedOptions = eventOptionsValidator(options);
   const { type, xdm } = validatedOptions;

--- a/test/functional/specs/Data Collector/C2592.js
+++ b/test/functional/specs/Data Collector/C2592.js
@@ -28,8 +28,7 @@ test.meta({
 
 const triggerAlloyEvent = ClientFunction(() => {
   return window.alloy("sendEvent", {
-    xdm: { key: "value" },
-    datasetId: "5eb83a3f634d1618a8a1d3df"
+    xdm: { key: "value" }
   });
 });
 
@@ -46,9 +45,6 @@ test("Test C2592: Event command sends a request.", async () => {
   );
 
   await t.expect(request.events[0].xdm.key).eql("value");
-  await t
-    .expect(request.events[0].meta.collect.datasetId)
-    .eql("5eb83a3f634d1618a8a1d3df");
   await t.expect(request.meta.state.cookiesEnabled).eql(true);
   await t.expect(request.meta.state.domain).ok();
 });

--- a/test/unit/specs/components/DataCollector/index.spec.js
+++ b/test/unit/specs/components/DataCollector/index.spec.js
@@ -22,8 +22,7 @@ describe("Event Command", () => {
       "documentMayUnload",
       "setUserData",
       "setUserXdm",
-      "mergeXdm",
-      "mergeMeta"
+      "mergeXdm"
     ]);
     logger = jasmine.createSpyObj("logger", {
       warn: undefined
@@ -121,20 +120,6 @@ describe("Event Command", () => {
       .then(() => {
         expect(event.mergeXdm).toHaveBeenCalledWith({
           eventMergeId: "mymergeid"
-        });
-      });
-  });
-
-  it("merges datasetId", () => {
-    return sendEventCommand
-      .run({
-        datasetId: "mydatasetId"
-      })
-      .then(() => {
-        expect(event.mergeMeta).toHaveBeenCalledWith({
-          collect: {
-            datasetId: "mydatasetId"
-          }
         });
       });
   });

--- a/test/unit/specs/components/DataCollector/validateUserEventOptions.spec.js
+++ b/test/unit/specs/components/DataCollector/validateUserEventOptions.spec.js
@@ -18,8 +18,7 @@ describe("DataCollector::validateUserEventOptions", () => {
       { xdm: [] },
       { renderDecisions: "" },
       { data: [] },
-      { decisionScopes: {} },
-      { datasetId: 3634 }
+      { decisionScopes: {} }
     ].forEach(options => {
       expect(() => {
         validateUserEventOptions({ options });
@@ -44,8 +43,7 @@ describe("DataCollector::validateUserEventOptions", () => {
       { renderDecisions: true },
       { data: { test: "" } },
       { renderDecisions: true, data: { test: "" } },
-      { decisionScopes: ["test"] },
-      { datasetId: "12432ewfr12" }
+      { decisionScopes: ["test"] }
     ].forEach(options => {
       expect(() => {
         validateUserEventOptions({ options });


### PR DESCRIPTION
## Description

Passing a dataset ID without a schema is not supported yet in AEP.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
