### PR TITLE
CORE-42833 - C28756 A form based offer should return if event command contains its scope

### DIFF
--- a/test/functional/specs/Personalization/C28756.js
+++ b/test/functional/specs/Personalization/C28756.js
@@ -1,0 +1,87 @@
+import { t, ClientFunction } from "testcafe";
+import createNetworkLogger from "../../helpers/networkLogger";
+import { responseStatus } from "../../helpers/assertions/index";
+import fixtureFactory from "../../helpers/fixtureFactory";
+import configureAlloyInstance from "../../helpers/configureAlloyInstance";
+import {
+  compose,
+  orgMainConfigMain,
+  debugEnabled
+} from "../../helpers/constants/configParts";
+import getResponseBody from "../../helpers/networkLogger/getResponseBody";
+import createResponse from "../../../../src/core/createResponse";
+
+const networkLogger = createNetworkLogger();
+const config = compose(
+  orgMainConfigMain,
+  debugEnabled
+);
+const scope = "alloy-test-scope-1";
+const decisionContent = "<h3>welcome to TARGET AWESOME WORLD!!! </h3>";
+
+fixtureFactory({
+  title:
+    "C28756: A form based offer should return if event command contains its scope",
+  requestHooks: [networkLogger.edgeEndpointLogs]
+});
+
+test.meta({
+  ID: "C28756",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+
+const triggerAlloyEvent = ClientFunction(decisionScope => {
+  return new Promise(resolve => {
+    window
+      .alloy("sendEvent", {
+        decisionScopes: [decisionScope]
+      })
+      .then(result => {
+        resolve(result);
+      });
+  });
+});
+
+test("Test C28756: A form based offer should return if event command contains its scope.", async () => {
+  await configureAlloyInstance("alloy", config);
+
+  const result = await triggerAlloyEvent(scope);
+
+  await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
+
+  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
+
+  const request = networkLogger.edgeEndpointLogs.requests[0];
+  const requestBody = JSON.parse(request.request.body);
+
+  await t
+    .expect(requestBody.events[0].query.personalization.decisionScopes)
+    .eql([scope]);
+  await t
+    .expect(requestBody.events[0].query.personalization.schemas)
+    .eql([
+      "https://ns.adobe.com/personalization/dom-action",
+      "https://ns.adobe.com/personalization/html-content-item",
+      "https://ns.adobe.com/personalization/json-content-item",
+      "https://ns.adobe.com/personalization/redirect-item"
+    ]);
+
+  const response = JSON.parse(
+    getResponseBody(networkLogger.edgeEndpointLogs.requests[0])
+  );
+  const personalizationPayload = createResponse(response).getPayloadsByType(
+    "personalization:decisions"
+  );
+
+  await t.expect(personalizationPayload[0].scope).eql(scope);
+  await t
+    .expect(personalizationPayload[0].items[0].data.content)
+    .eql(decisionContent);
+
+  await t.expect(result.decisions.length).eql(1);
+  await t.expect(result.decisions[0].scope).eql(scope);
+  await t
+    .expect(result.decisions[0].items[0].data.content)
+    .eql(decisionContent);
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a functional test which tests that `sendEvent` promise is resolved with a personalization decision for a specific decision scope.

<!--- Describe your changes in detail -->

## Related Issue
Tests that target form based composer offers are returned.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
