### PR TITLE
Supporting overriding the dataset on sendEvent commands

### DIFF
--- a/sandbox/src/Home.js
+++ b/sandbox/src/Home.js
@@ -71,6 +71,12 @@ function HomeWithHistory({ history }) {
       });
   };
 
+  const sendDataToSecondaryDataset = () => {
+    window.alloy("sendEvent", {
+      datasetId: "5eb9aaa6a3b16e18a818e06f"
+    });
+  };
+
   return (
     <div>
       <section>
@@ -109,6 +115,14 @@ function HomeWithHistory({ history }) {
         <h1>Sync Identity</h1>
         <div>
           <button onClick={syncIdentity}>Sync declared IDs to Identity</button>
+        </div>
+      </section>
+      <section>
+        <h1>Collect data by overriding the Dataset configured in Config UI</h1>
+        <div>
+          <button onClick={sendDataToSecondaryDataset}>
+            Send Event to Secondary Dataset
+          </button>
         </div>
       </section>
     </div>

--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -28,7 +28,8 @@ const createDataCollector = ({ eventManager, logger }) => {
             type,
             mergeId,
             renderDecisions = false,
-            decisionScopes = []
+            decisionScopes = [],
+            datasetId
           } = options;
           const event = eventManager.createEvent();
 
@@ -48,6 +49,14 @@ const createDataCollector = ({ eventManager, logger }) => {
           if (mergeId) {
             event.mergeXdm({
               eventMergeId: mergeId
+            });
+          }
+
+          if (datasetId) {
+            event.mergeMeta({
+              collect: {
+                datasetId
+              }
             });
           }
 

--- a/src/components/DataCollector/validateUserEventOptions.js
+++ b/src/components/DataCollector/validateUserEventOptions.js
@@ -26,7 +26,8 @@ export default ({ options, logger }) => {
     }),
     data: objectOf({}),
     renderDecisions: boolean(),
-    decisionScopes: arrayOf(string())
+    decisionScopes: arrayOf(string()),
+    datasetId: string()
   }).required();
   const validatedOptions = eventOptionsValidator(options);
   const { type, xdm } = validatedOptions;

--- a/test/functional/specs/Data Collector/C2592.js
+++ b/test/functional/specs/Data Collector/C2592.js
@@ -27,7 +27,9 @@ test.meta({
 });
 
 const triggerAlloyEvent = ClientFunction(() => {
-  return window.alloy("sendEvent");
+  return window.alloy("sendEvent", {
+    datasetId: "5eb9aaa6a3b16e18a818e06f"
+  });
 });
 
 test("Test C2592: Event command sends a request.", async () => {
@@ -45,6 +47,9 @@ test("Test C2592: Event command sends a request.", async () => {
   await t
     .expect(request.events[0].xdm.implementationDetails.name)
     .eql("https://ns.adobe.com/experience/alloy");
+  await t
+    .expect(request.events[0].meta.collect.datasetId)
+    .eql("5eb9aaa6a3b16e18a818e06f");
   await t.expect(request.meta.state.cookiesEnabled).eql(true);
   await t.expect(request.meta.state.domain).ok();
 });

--- a/test/functional/specs/Data Collector/C75372.js
+++ b/test/functional/specs/Data Collector/C75372.js
@@ -19,7 +19,7 @@ test.meta({
 });
 
 const sendEvent = ClientFunction(() => {
-  const xdmDataLayer = { foo: "bar" };
+  const xdmDataLayer = { device: { screenHeight: 1 } };
   const nonXdmDataLayer = { baz: "quux" };
   // Using a merge ID is a decent test because it's one thing we know
   // gets merged with the XDM object.
@@ -40,6 +40,6 @@ const sendEvent = ClientFunction(() => {
 test("C75372 - XDM and data objects passed into event command should not be modified", async () => {
   await configureAlloyInstance("alloy", orgMainConfigMain);
   const { xdmDataLayer, nonXdmDataLayer } = await sendEvent();
-  await t.expect(xdmDataLayer).eql({ foo: "bar" });
+  await t.expect(xdmDataLayer).eql({ device: { screenHeight: 1 } });
   await t.expect(nonXdmDataLayer).eql({ baz: "quux" });
 });

--- a/test/unit/specs/components/DataCollector/index.spec.js
+++ b/test/unit/specs/components/DataCollector/index.spec.js
@@ -22,7 +22,8 @@ describe("Event Command", () => {
       "documentMayUnload",
       "setUserData",
       "setUserXdm",
-      "mergeXdm"
+      "mergeXdm",
+      "mergeMeta"
     ]);
     logger = jasmine.createSpyObj("logger", {
       warn: undefined
@@ -120,6 +121,20 @@ describe("Event Command", () => {
       .then(() => {
         expect(event.mergeXdm).toHaveBeenCalledWith({
           eventMergeId: "mymergeid"
+        });
+      });
+  });
+
+  it("merges datasetId", () => {
+    return sendEventCommand
+      .run({
+        datasetId: "mydatasetId"
+      })
+      .then(() => {
+        expect(event.mergeMeta).toHaveBeenCalledWith({
+          collect: {
+            datasetId: "mydatasetId"
+          }
         });
       });
   });

--- a/test/unit/specs/components/DataCollector/validateUserEventOptions.spec.js
+++ b/test/unit/specs/components/DataCollector/validateUserEventOptions.spec.js
@@ -18,7 +18,8 @@ describe("DataCollector::validateUserEventOptions", () => {
       { xdm: [] },
       { renderDecisions: "" },
       { data: [] },
-      { decisionScopes: {} }
+      { decisionScopes: {} },
+      { datasetId: 3634 }
     ].forEach(options => {
       expect(() => {
         validateUserEventOptions({ options });
@@ -43,7 +44,8 @@ describe("DataCollector::validateUserEventOptions", () => {
       { renderDecisions: true },
       { data: { test: "" } },
       { renderDecisions: true, data: { test: "" } },
-      { decisionScopes: ["test"] }
+      { decisionScopes: ["test"] },
+      { datasetId: "12432ewfr12" }
     ].forEach(options => {
       expect(() => {
         validateUserEventOptions({ options });


### PR DESCRIPTION
## Description

AEP has released a change to start accepting Datasets only, without schema IDs. That means this feature is unblocked.

We know support overriding datasets on the `sendEvent` command.

## Related Issue

https://jira.corp.adobe.com/browse/CORE-44945

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
