### PR TITLE
Fix set consent validation tests

### DIFF
--- a/src/components/Privacy/validateSetConsentOptions.js
+++ b/src/components/Privacy/validateSetConsentOptions.js
@@ -12,27 +12,30 @@ import { GENERAL } from "../../constants/consentPurpose";
 
 export default objectOf({
   consent: arrayOf(
-    anyOf([
-      objectOf({
-        standard: literal("Adobe").required(),
-        version: literal("1.0").required(),
-        value: objectOf({
-          [GENERAL]: enumOf(IN, OUT).required()
+    anyOf(
+      [
+        objectOf({
+          standard: literal("Adobe").required(),
+          version: literal("1.0").required(),
+          value: objectOf({
+            [GENERAL]: enumOf(IN, OUT).required()
+          })
+            .noUnknownFields()
+            .required()
+        })
+          .noUnknownFields()
+          .required(),
+        objectOf({
+          standard: literal("IAB").required(),
+          version: literal("2.0").required(),
+          value: string().required(),
+          gdprApplies: boolean().required()
         })
           .noUnknownFields()
           .required()
-      })
-        .noUnknownFields()
-        .required(),
-      objectOf({
-        standard: literal("IAB").required(),
-        version: literal("2.0").required(),
-        value: string().required(),
-        gdprApplies: boolean().required()
-      })
-        .noUnknownFields()
-        .required()
-    ])
+      ],
+      "a valid consent object"
+    )
   )
     .nonEmpty()
     .required()

--- a/src/utils/validation/assertValid.js
+++ b/src/utils/validation/assertValid.js
@@ -12,6 +12,8 @@ governing permissions and limitations under the License.
 
 export default (isValid, value, path, message) => {
   if (!isValid) {
-    throw new Error(`'${path}': Expected ${message}, but got '${value}'.`);
+    throw new Error(
+      `'${path}': Expected ${message}, but got ${JSON.stringify(value)}.`
+    );
   }
 };

--- a/test/functional/specs/Privacy/C14410.js
+++ b/test/functional/specs/Privacy/C14410.js
@@ -36,7 +36,11 @@ test("Test C14410: Configuring default consent to 'out' fails", async t => {
     .expect(errorMessage)
     .ok("Expected the configure command to be rejected");
   await t.expect(errorMessage).contains("'defaultConsent':");
-  await t.expect(errorMessage).contains("'out'");
+  await t
+    .expect(errorMessage)
+    .contains(
+      `Expected one of these values: [["in","pending"]], but got "out"`
+    );
 });
 
 test("Test C14410: Setting consent for unknown purposes fails", async t => {
@@ -52,7 +56,7 @@ test("Test C14410: Setting consent for unknown purposes fails", async t => {
   await t
     .expect(errorMessage)
     .ok("Expected the setConsent command to be rejected");
-  await t.expect(errorMessage).contains("general' is a required option");
+  await t.expect(errorMessage).contains("Expected a valid consent object");
 });
 
 test("Test C14410: Setting consent to 'pending' fails", async t => {
@@ -68,5 +72,5 @@ test("Test C14410: Setting consent to 'pending' fails", async t => {
   await t
     .expect(errorMessage)
     .ok("Expected the setConsent command to be rejected");
-  await t.expect(errorMessage).contains("'pending'");
+  await t.expect(errorMessage).contains("Expected a valid consent object");
 });

--- a/test/unit/specs/components/Identity/getIdentity/getIdentityOptionsValidator.spec.js
+++ b/test/unit/specs/components/Identity/getIdentity/getIdentityOptionsValidator.spec.js
@@ -16,12 +16,12 @@ describe("Identity::getIdentityOptionsValidator", () => {
     expect(() => {
       getIdentityOptionsValidator({ namespaces: [] });
     }).toThrow(
-      new Error("'namespaces': Expected a non-empty array, but got ''.")
+      new Error("'namespaces': Expected a non-empty array, but got [].")
     );
 
     expect(() => {
       getIdentityOptionsValidator({ namespaces: ["ACD"] });
-    }).toThrow(new Error("'namespaces[0]': Expected ECID, but got 'ACD'."));
+    }).toThrow(new Error(`'namespaces[0]': Expected ECID, but got "ACD".`));
   });
 
   it("should return valid options when no options are passed", () => {

--- a/test/unit/specs/utils/validation/assertValid.spec.js
+++ b/test/unit/specs/utils/validation/assertValid.spec.js
@@ -18,7 +18,7 @@ describe("validation::assertValid", () => {
       assertValid(false, "myValue", "myPath", "myMessage")
     ).toThrowMatching(e => {
       expect(e.message).toEqual(
-        "'myPath': Expected myMessage, but got 'myValue'."
+        `'myPath': Expected myMessage, but got "myValue".`
       );
       return true;
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

These tests broke when we changed the validation of setConsent to accept IAB strings.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
