### PR TITLE
Build alloy before running the api triggered functional test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ jobs:
         if: type == api
         script: 
         - npm ci
+        - npm run build:prod
         - npm run functional:api
 
 notifications:


### PR DESCRIPTION
The Travis builds are failing when the Konductor api builds are triggered. Added the build script to the API/Konductor Build stage.  