### PR TITLE
CORE-47269 - Unhide the body if no personalization payload

### DIFF
--- a/src/components/Personalization/createComponent.js
+++ b/src/components/Personalization/createComponent.js
@@ -47,6 +47,7 @@ export default ({
         const scopes = getDecisionScopes(renderDecisions, decisionScopes);
 
         if (!hasScopes(scopes)) {
+          showContainers();
           return;
         }
 

--- a/src/components/Personalization/createOnResponseHandler.js
+++ b/src/components/Personalization/createOnResponseHandler.js
@@ -15,16 +15,14 @@ const DECISIONS_HANDLE = "personalization:decisions";
 
 export default ({ extractDecisions, executeDecisions, showContainers }) => {
   return ({ renderDecisions, response }) => {
-    const decisionsResponse = response.getPayloadsByType(DECISIONS_HANDLE);
-    if (!isNonEmptyArray(decisionsResponse)) {
+    const unprocessedDecisions = response.getPayloadsByType(DECISIONS_HANDLE);
+    if (!isNonEmptyArray(unprocessedDecisions)) {
       showContainers();
       return { decisions: [] };
     }
-    const [
-      renderableDecisions,
-      decisions,
+    const [renderableDecisions, decisions] = extractDecisions(
       unprocessedDecisions
-    ] = extractDecisions(decisionsResponse);
+    );
 
     if (renderDecisions) {
       executeDecisions(renderableDecisions);

--- a/src/components/Personalization/createOnResponseHandler.js
+++ b/src/components/Personalization/createOnResponseHandler.js
@@ -9,14 +9,22 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
+import isNonEmptyArray from "../../utils/isNonEmptyArray";
+
+const DECISIONS_HANDLE = "personalization:decisions";
 
 export default ({ extractDecisions, executeDecisions, showContainers }) => {
   return ({ renderDecisions, response }) => {
+    const decisionsResponse = response.getPayloadsByType(DECISIONS_HANDLE);
+    if (!isNonEmptyArray(decisionsResponse)) {
+      showContainers();
+      return { decisions: [] };
+    }
     const [
       renderableDecisions,
       decisions,
       unprocessedDecisions
-    ] = extractDecisions(response);
+    ] = extractDecisions(decisionsResponse);
 
     if (renderDecisions) {
       executeDecisions(renderableDecisions);

--- a/src/components/Personalization/extractDecisions.js
+++ b/src/components/Personalization/extractDecisions.js
@@ -13,8 +13,6 @@ governing permissions and limitations under the License.
 import { isNonEmptyArray } from "../../utils";
 import * as SCHEMA from "./constants/schema";
 
-const DECISIONS_HANDLE = "personalization:decisions";
-
 const isDomActionItem = item => item.schema === SCHEMA.DOM_ACTION;
 
 const splitItems = (items, predicate) => {
@@ -56,8 +54,6 @@ const splitDecisions = (decisions, predicate) => {
   return [matchedDecisions, nonMatchedDecisions, decisions];
 };
 
-export default response => {
-  const decisions = response.getPayloadsByType(DECISIONS_HANDLE);
-
+export default decisions => {
   return splitDecisions(decisions, isDomActionItem);
 };

--- a/src/components/Personalization/extractDecisions.js
+++ b/src/components/Personalization/extractDecisions.js
@@ -51,7 +51,7 @@ const splitDecisions = (decisions, predicate) => {
     }
   });
 
-  return [matchedDecisions, nonMatchedDecisions, decisions];
+  return [matchedDecisions, nonMatchedDecisions];
 };
 
 export default decisions => {

--- a/test/unit/specs/components/Personalization/createComponent.spec.js
+++ b/test/unit/specs/components/Personalization/createComponent.spec.js
@@ -106,12 +106,12 @@ describe("Personalization", () => {
     expect(isAuthoringModeEnabled).toHaveBeenCalled();
     expect(getDecisionScopes).toHaveBeenCalled();
     expect(hasScopes).toHaveBeenCalled();
+    expect(showContainers).toHaveBeenCalled();
 
     expect(mergeQuery).not.toHaveBeenCalled();
     expect(onResponseHandler).not.toHaveBeenCalled();
     expect(onClickHandler).not.toHaveBeenCalled();
     expect(hideContainers).not.toHaveBeenCalled();
-    expect(showContainers).not.toHaveBeenCalled();
     expect(createQueryDetails).not.toHaveBeenCalled();
   });
 

--- a/test/unit/specs/components/Personalization/extractDecisions.spec.js
+++ b/test/unit/specs/components/Personalization/extractDecisions.spec.js
@@ -22,11 +22,7 @@ describe("Personalization::extractDecisions", () => {
   const response = PAGE_WIDE_SCOPE_DECISIONS.concat(SCOPES_FOO1_FOO2_DECISIONS);
 
   it("extracts dom action decisions and rest of decisions", () => {
-    const [
-      domActionDecisions,
-      decisions,
-      unprocessedDecisions
-    ] = extractDecisions(response);
+    const [domActionDecisions, decisions] = extractDecisions(response);
     expect(decisions).toEqual(
       PAGE_WIDE_SCOPE_DECISIONS_WITHOUT_DOM_ACTION_SCHEMA_ITEMS.concat(
         SCOPES_FOO1_FOO2_DECISIONS
@@ -34,9 +30,6 @@ describe("Personalization::extractDecisions", () => {
     );
     expect(domActionDecisions).toEqual(
       PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS
-    );
-    expect(unprocessedDecisions).toEqual(
-      PAGE_WIDE_SCOPE_DECISIONS.concat(SCOPES_FOO1_FOO2_DECISIONS)
     );
   });
 });

--- a/test/unit/specs/components/Personalization/extractDecisions.spec.js
+++ b/test/unit/specs/components/Personalization/extractDecisions.spec.js
@@ -19,17 +19,9 @@ import {
 import extractDecisions from "../../../../../src/components/Personalization/extractDecisions";
 
 describe("Personalization::extractDecisions", () => {
-  let response;
-
-  beforeEach(() => {
-    response = jasmine.createSpyObj("response", ["getPayloadsByType"]);
-  });
+  const response = PAGE_WIDE_SCOPE_DECISIONS.concat(SCOPES_FOO1_FOO2_DECISIONS);
 
   it("extracts dom action decisions and rest of decisions", () => {
-    response.getPayloadsByType.and.returnValue(
-      PAGE_WIDE_SCOPE_DECISIONS.concat(SCOPES_FOO1_FOO2_DECISIONS)
-    );
-
     const [
       domActionDecisions,
       decisions,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The issue was happening on the pages with the prehiding snippet and where `sendEvent` command fires at page load with `renderDecisions: false; decisionsScope:[]`.
Also, I have changed the behavior of `onResponsehandler` so that if personalization payload is empty we unhide the body immediately and return from the lifecycle.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
