### PR TITLE
Handle the case where Konductor responds without an identity

### DIFF
--- a/src/components/Identity/createComponent.js
+++ b/src/components/Identity/createComponent.js
@@ -2,7 +2,7 @@ import getIdentityOptionsValidator from "./getIdentity/getIdentityOptionsValidat
 
 export default ({
   addEcidQueryToEvent,
-  ensureRequestHasIdentity,
+  ensureSingleIdentity,
   setLegacyEcid,
   handleResponseForIdSyncs,
   getEcidFromResponse,
@@ -19,7 +19,7 @@ export default ({
         addEcidQueryToEvent(event);
       },
       onBeforeRequest({ payload, onResponse }) {
-        return ensureRequestHasIdentity({ payload, onResponse });
+        return ensureSingleIdentity({ payload, onResponse });
       },
       onResponse({ response }) {
         if (!ecid) {

--- a/src/components/Identity/index.js
+++ b/src/components/Identity/index.js
@@ -22,7 +22,7 @@ import createLegacyIdentity from "./createLegacyIdentity";
 import awaitVisitorOptIn from "./visitorService/awaitVisitorOptIn";
 import injectGetEcidFromVisitor from "./visitorService/injectGetEcidFromVisitor";
 import injectHandleResponseForIdSyncs from "./injectHandleResponseForIdSyncs";
-import injectEnsureRequestHasIdentity from "./injectEnsureRequestHasIdentity";
+import injectEnsureSingleIdentity from "./injectEnsureSingleIdentity";
 import addEcidQueryToEvent from "./addEcidQueryToEvent";
 import injectDoesIdentityCookieExist from "./injectDoesIdentityCookieExist";
 import injectSetDomainForInitialIdentityPayload from "./injectSetDomainForInitialIdentityPayload";
@@ -69,7 +69,7 @@ const createIdentity = ({
     orgId,
     doesIdentityCookieExist
   });
-  const ensureRequestHasIdentity = injectEnsureRequestHasIdentity({
+  const ensureSingleIdentity = injectEnsureSingleIdentity({
     doesIdentityCookieExist,
     setDomainForInitialIdentityPayload,
     addLegacyEcidToPayload,
@@ -85,7 +85,7 @@ const createIdentity = ({
   });
   return createComponent({
     addEcidQueryToEvent,
-    ensureRequestHasIdentity,
+    ensureSingleIdentity,
     setLegacyEcid: legacyIdentity.setEcid,
     handleResponseForIdSyncs,
     getEcidFromResponse,

--- a/src/components/Identity/injectEnsureSingleIdentity.js
+++ b/src/components/Identity/injectEnsureSingleIdentity.js
@@ -40,8 +40,9 @@ export default ({
    * no events recorded so we don't need to worry about multiple ECIDs
    * being minted for each user.
    *
-   * If we only allowed one request through without an identity, a single
-   * malformed request causes all other requests to never send.
+   * The reason we allow for multiple sequential requests to be sent without
+   * an identity is to prevent a single malformed request causing all other
+   * requests to never send.
    */
   return ({ payload, onResponse }) => {
     if (doesIdentityCookieExist()) {

--- a/test/unit/specs/components/Identity/createComponent.spec.js
+++ b/test/unit/specs/components/Identity/createComponent.spec.js
@@ -16,7 +16,7 @@ import flushPromiseChains from "../../../helpers/flushPromiseChains";
 
 describe("Identity::createComponent", () => {
   let addEcidQueryToEvent;
-  let ensureRequestHasIdentity;
+  let ensureSingleIdentity;
   let setLegacyEcid;
   let handleResponseForIdSyncs;
   let getEcidFromResponse;
@@ -28,7 +28,7 @@ describe("Identity::createComponent", () => {
 
   beforeEach(() => {
     addEcidQueryToEvent = jasmine.createSpy("addEcidQueryToEvent");
-    ensureRequestHasIdentity = jasmine.createSpy("ensureRequestHasIdentity");
+    ensureSingleIdentity = jasmine.createSpy("ensureSingleIdentity");
     setLegacyEcid = jasmine.createSpy("setLegacyEcid");
     handleResponseForIdSyncs = jasmine.createSpy("handleResponseForIdSyncs");
     getEcidFromResponse = jasmine.createSpy("getEcidFromResponse");
@@ -42,7 +42,7 @@ describe("Identity::createComponent", () => {
       .and.returnValue(getIdentityDeferred.promise);
     component = createComponent({
       addEcidQueryToEvent,
-      ensureRequestHasIdentity,
+      ensureSingleIdentity,
       setLegacyEcid,
       handleResponseForIdSyncs,
       getEcidFromResponse,
@@ -60,14 +60,14 @@ describe("Identity::createComponent", () => {
   it("ensures request has identity", () => {
     const payload = { type: "payload" };
     const onResponse = jasmine.createSpy("onResponse");
-    const ensureRequestHasIdentityPromise = Promise.resolve();
-    ensureRequestHasIdentity.and.returnValue(ensureRequestHasIdentityPromise);
+    const ensureSingleIdentityPromise = Promise.resolve();
+    ensureSingleIdentity.and.returnValue(ensureSingleIdentityPromise);
     const result = component.lifecycle.onBeforeRequest({ payload, onResponse });
-    expect(ensureRequestHasIdentity).toHaveBeenCalledWith({
+    expect(ensureSingleIdentity).toHaveBeenCalledWith({
       payload,
       onResponse
     });
-    expect(result).toBe(ensureRequestHasIdentityPromise);
+    expect(result).toBe(ensureSingleIdentityPromise);
   });
 
   it("does not create legacy identity cookie if response does not contain ECID", () => {

--- a/test/unit/specs/components/Identity/injectEnsureSingleIdentity.spec.js
+++ b/test/unit/specs/components/Identity/injectEnsureSingleIdentity.spec.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import injectEnsureRequestHasIdentity from "../../../../../src/components/Identity/injectEnsureRequestHasIdentity";
+import injectEnsureSingleIdentity from "../../../../../src/components/Identity/injectEnsureSingleIdentity";
 // By using the real injectAwaitIdentityCookie, this isn't a true unit test. The interactions between these
 // functions are so tightly coupled that it was much easier to understand the tests if I just included the
 // real one.
@@ -18,13 +18,13 @@ import injectAwaitIdentityCookie from "../../../../../src/components/Identity/in
 import { createCallbackAggregator } from "../../../../../src/utils";
 import flushPromiseChains from "../../../helpers/flushPromiseChains";
 
-describe("Identity::injectEnsureRequestHasIdentity", () => {
+describe("Identity::injectEnsureSingleIdentity", () => {
   let doesIdentityCookieExist;
   let setDomainForInitialIdentityPayload;
   let addLegacyEcidToPayload;
   let awaitIdentityCookie;
   let logger;
-  let ensureRequestHasIdentity;
+  let ensureSingleIdentity;
 
   let sentIndex;
   let recievedIndex;
@@ -55,7 +55,7 @@ describe("Identity::injectEnsureRequestHasIdentity", () => {
       orgId: "myorg",
       doesIdentityCookieExist
     });
-    ensureRequestHasIdentity = injectEnsureRequestHasIdentity({
+    ensureSingleIdentity = injectEnsureSingleIdentity({
       doesIdentityCookieExist,
       setDomainForInitialIdentityPayload,
       addLegacyEcidToPayload,
@@ -72,7 +72,7 @@ describe("Identity::injectEnsureRequestHasIdentity", () => {
 
     const i = sentIndex;
     requestsSentYet.push(false);
-    ensureRequestHasIdentity({
+    ensureSingleIdentity({
       payload,
       onResponse: onResponseCallbackAggregator.add
     }).then(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixes one part of the Jira Ticket. The changes make it so that if the first request without an ecid failed to get one, the next request will be sent and request the ecid. I will add addition changes and tests to handle errors differently as outlined in the Jira ticket to a separate PR.

## Related Issue

https://jira.corp.adobe.com/browse/CORE-47161

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Previously if Konductor came back without an identity, no other requests could be sent through Alloy. You would have to do a page refresh to start making requests again. This was found when we were testing the validation logic for consent. If an invalid consent object was provided, Konductor returned an error without identity information.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
