### PR TITLE
Handle consent errors in click collection

### DIFF
--- a/src/components/ActivityCollector/index.js
+++ b/src/components/ActivityCollector/index.js
@@ -14,14 +14,19 @@ import attachClickActivityCollector from "./attachClickActivityCollector";
 import configValidators from "./configValidators";
 import createLinkClick from "./createLinkClick";
 
-const createActivityCollector = ({ config, eventManager }) => {
+const createActivityCollector = ({ config, eventManager, handleError }) => {
   const linkClick = createLinkClick(window, config);
 
   return {
     lifecycle: {
       onComponentsRegistered(tools) {
         const { lifecycle } = tools;
-        attachClickActivityCollector(config, eventManager, lifecycle);
+        attachClickActivityCollector({
+          config,
+          eventManager,
+          lifecycle,
+          handleError
+        });
         // TODO: createScrollActivityCollector ...
       },
       onClick({ event, clickedElement }) {

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -124,9 +124,7 @@ if (instanceNames) {
         lifecycle,
         componentRegistry,
         getImmediatelyAvailableTools(componentName) {
-          const componentLogger = logController.createComponentLogger(
-            componentName
-          );
+          const componentLogger = createComponentLogger(componentName);
           return {
             config,
             consent,

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -119,26 +119,32 @@ if (instanceNames) {
         createDataCollectionRequestPayload,
         sendEdgeNetworkRequest
       });
-
       return initializeComponents({
         componentCreators,
         lifecycle,
         componentRegistry,
         getImmediatelyAvailableTools(componentName) {
+          const componentLogger = logController.createComponentLogger(
+            componentName
+          );
           return {
             config,
             consent,
             eventManager,
-            logger: createComponentLogger(componentName),
+            logger: componentLogger,
             lifecycle,
-            sendEdgeNetworkRequest
+            sendEdgeNetworkRequest,
+            handleError: injectHandleError({
+              errorPrefix: `[${instanceName}] [${componentName}]`,
+              logger: componentLogger
+            })
           };
         }
       });
     };
 
     const handleError = injectHandleError({
-      instanceName,
+      errorPrefix: `[${instanceName}]`,
       logger
     });
 

--- a/src/core/injectExecuteCommand.js
+++ b/src/core/injectExecuteCommand.js
@@ -100,7 +100,7 @@ export default ({
         return isObject(result) ? result : {};
       })
       .catch(error => {
-        return handleError(error, commandName);
+        return handleError(error, `${commandName} command`);
       });
   };
 };

--- a/src/core/injectHandleError.js
+++ b/src/core/injectHandleError.js
@@ -13,18 +13,18 @@ governing permissions and limitations under the License.
 import { toError } from "../utils";
 import { DECLINED_CONSENT_ERROR_CODE } from "./consent/createConsentStateMachine";
 
-export default ({ instanceName, logger }) => (error, commandName) => {
+export default ({ errorPrefix, logger }) => (error, operation) => {
   // In the case of declined consent, we've opted to not reject the promise
   // returned to the customer, but instead resolve the promise with an
   // empty result object.
   if (error.code === DECLINED_CONSENT_ERROR_CODE) {
     logger.warn(
-      `The ${commandName} command could not fully complete because the user declined consent.`
+      `The ${operation} could not fully complete because the user declined consent.`
     );
     return {};
   }
 
   const err = toError(error);
-  err.message = `[${instanceName}] ${err.message}`;
+  err.message = `${errorPrefix} ${err.message}`;
   throw err;
 };

--- a/test/functional/helpers/consoleLogger/index.js
+++ b/test/functional/helpers/consoleLogger/index.js
@@ -100,7 +100,8 @@ const createConsoleLogger = async () => {
     memo[logLevel] = {
       expectMessageMatching: expectMessageMatching.bind(null, logLevel),
       expectNoMessageMatching: expectNoMessageMatching.bind(null, logLevel),
-      expectNoMessages: expectNoMessages.bind(null, logLevel)
+      expectNoMessages: expectNoMessages.bind(null, logLevel),
+      getMessagesSinceReset: getMessagesSinceReset.bind(null, logLevel)
     };
     return memo;
   }, {});

--- a/test/functional/helpers/createUnhandledRejectionLogger.js
+++ b/test/functional/helpers/createUnhandledRejectionLogger.js
@@ -1,0 +1,72 @@
+import { t } from "testcafe";
+
+const containsMessageMatchingRegex = (messages, messageRegex) => {
+  return messages.find(message => messageRegex.test(message)) !== undefined;
+};
+
+const formatFoundMessages = messages => {
+  if (!messages.length) {
+    return "No messages found.";
+  }
+  return `Messages found:\n${messages.join("\n")}`;
+};
+
+/**
+ * Creates an object that can used for asserting messages from unhandled
+ * rejections. These are promises that were rejected, but unhandled.
+ *
+ * Example:
+ *
+ * const unhandledRejectionLogger = await createUnhandledRejectionLogger();
+ * await unhandledRejectionLogger.expectMessageMatching(/test/);
+ * await unhandledRejectionLogger.expectNoMessageMatching(/test/);
+ * await unhandledRejectionLogger.reset();
+ */
+export default async () => {
+  await t.eval(() => {
+    window.testcafe_unhandled_rejections = [];
+    window.addEventListener("unhandledrejection", ({ reason }) => {
+      window.testcafe_unhandled_rejections.push(reason);
+    });
+  });
+
+  const reset = async () => {
+    await t.eval(() => {
+      window.testcafe_unhandled_rejections.clear();
+    });
+  };
+
+  const getMessagesSinceReset = async () => {
+    return t.eval(() => {
+      return window.testcafe_unhandled_rejections || [];
+    });
+  };
+
+  const expectMessageMatching = async messageRegex => {
+    const messages = await getMessagesSinceReset();
+    await t
+      .expect(containsMessageMatchingRegex(messages, messageRegex))
+      .ok(
+        `No unhandled rejection message was found matching ${messageRegex}. ${formatFoundMessages(
+          messages
+        )}`
+      );
+  };
+
+  const expectNoMessageMatching = async messageRegex => {
+    const messages = await getMessagesSinceReset();
+    await t
+      .expect(containsMessageMatchingRegex(messages, messageRegex))
+      .notOk(
+        `An unhandled rejection message was found matching ${messageRegex} when none was expected. ${formatFoundMessages(
+          messages
+        )}`
+      );
+  };
+
+  return {
+    reset,
+    expectMessageMatching,
+    expectNoMessageMatching
+  };
+};

--- a/test/functional/specs/Data Collector/C225010.js
+++ b/test/functional/specs/Data Collector/C225010.js
@@ -1,0 +1,55 @@
+import { t, Selector, ClientFunction } from "testcafe";
+import createFixture from "../../helpers/createFixture";
+import addAnchorToBody from "../../helpers/dom/addAnchorToBody";
+import configureAlloyInstance from "../../helpers/configureAlloyInstance";
+import createConsoleLogger from "../../helpers/consoleLogger";
+import createUnhandledRejectionLogger from "../../helpers/createUnhandledRejectionLogger";
+import {
+  compose,
+  orgMainConfigMain,
+  consentPending,
+  debugEnabled
+} from "../../helpers/constants/configParts";
+
+const { CONSENT_OUT } = require("../../helpers/constants/consent");
+
+createFixture({
+  title: "C225010: Click collection handles errors when user declines consent"
+});
+
+test.meta({
+  ID: "C8118",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+
+test("Test C225010: Click collection handles errors when user declines consent", async () => {
+  const getLocation = ClientFunction(() => document.location.href.toString());
+  const testConfig = compose(
+    orgMainConfigMain,
+    consentPending,
+    debugEnabled
+  );
+  await configureAlloyInstance("alloy", testConfig);
+  await t.eval(
+    () => {
+      return window.alloy("setConsent", CONSENT_OUT);
+    },
+    { dependencies: { CONSENT_OUT } }
+  );
+  await addAnchorToBody({
+    text: "Test Link",
+    attributes: {
+      href: "#foo",
+      id: "alloy-link-test"
+    }
+  });
+  const consoleLogger = await createConsoleLogger();
+  const unhandledRejectionLogger = await createUnhandledRejectionLogger();
+  await t.click(Selector("#alloy-link-test"));
+  await t.expect(getLocation()).contains("#foo");
+  await consoleLogger.warn.expectMessageMatching(
+    /The click collection could not fully complete because the user declined consent/
+  );
+  await unhandledRejectionLogger.expectNoMessageMatching(/.*/);
+});

--- a/test/unit/specs/core/injectExecuteCommand.spec.js
+++ b/test/unit/specs/core/injectExecuteCommand.spec.js
@@ -40,7 +40,7 @@ describe("injectExecuteCommand", () => {
       .then(fail)
       .catch(error => {
         expect(error.message).toContain("The library must be configured first");
-        expect(handleError).toHaveBeenCalledWith(error, "event");
+        expect(handleError).toHaveBeenCalledWith(error, "event command");
       });
   });
 
@@ -59,7 +59,7 @@ describe("injectExecuteCommand", () => {
         expect(error.message).toContain(
           "The library has already been configured"
         );
-        expect(handleError).toHaveBeenCalledWith(error, "configure");
+        expect(handleError).toHaveBeenCalledWith(error, "configure command");
       });
   });
 
@@ -83,7 +83,7 @@ describe("injectExecuteCommand", () => {
         expect(error.message).toBe(
           "The bogus command does not exist. List of available commands: configure, setDebug, genuine."
         );
-        expect(handleError).toHaveBeenCalledWith(error, "bogus");
+        expect(handleError).toHaveBeenCalledWith(error, "bogus command");
       });
   });
 
@@ -134,7 +134,7 @@ describe("injectExecuteCommand", () => {
     return executeCommand("test", {}).catch(() => {
       expect(handleError).toHaveBeenCalledWith(
         new Error("Unexpected error"),
-        "test"
+        "test command"
       );
     });
   });

--- a/test/unit/specs/core/injectHandleError.spec.js
+++ b/test/unit/specs/core/injectHandleError.spec.js
@@ -17,36 +17,36 @@ const expectedMessage = "[testinstanceName] Bad thing happened.";
 describe("injectHandleError", () => {
   it("converts non-error to error and throws", () => {
     const handleError = injectHandleError({
-      instanceName: "testinstanceName"
+      errorPrefix: "[testinstanceName]"
     });
 
     expect(() => {
-      handleError("Bad thing happened.");
+      handleError("Bad thing happened.", "myoperation");
     }).toThrowError(expectedMessage);
   });
 
   it("rethrows error with instanceName prepended", () => {
     const handleError = injectHandleError({
-      instanceName: "testinstanceName"
+      errorPrefix: "[testinstanceName]"
     });
 
     expect(() => {
-      handleError(new Error("Bad thing happened."));
+      handleError(new Error("Bad thing happened."), "myoperation");
     }).toThrowError(expectedMessage);
   });
 
   it("logs an error and returns empty object if error is due to declined consent", () => {
     const logger = jasmine.createSpyObj("logger", ["warn"]);
     const handleError = injectHandleError({
-      instanceName: "testinstanceName",
+      errorPrefix: "[testinstanceName]",
       logger
     });
 
     const error = new Error("User declined consent.");
     error.code = "declinedConsent";
-    expect(handleError(error, "test")).toEqual({});
+    expect(handleError(error, "myoperation")).toEqual({});
     expect(logger.warn).toHaveBeenCalledWith(
-      "The test command could not fully complete because the user declined consent."
+      "The myoperation could not fully complete because the user declined consent."
     );
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Re-use the handleError logic inside the ActivityMap component.  This function was used previously in core, but I've made it into a tool that is passed to each component. This function contains a check to log instead of throw if the error is that the user declined consent.

## Related Issue

https://jira.corp.adobe.com/browse/CORE-39185
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

As outlined in https://github.com/adobe/alloy/pull/323#discussion_r362657480, when a promises is rejected while tracking clicks (for example, if the user opted into no purposes), the rejection goes unhandled. The customer has no way to handle the rejection, because it wasn't actuated by the customer calling a command. Alloy's generic error-massaging logic isn't handling it either. This means the error is not muted when the customer has configured `errorsEnabled: false`. Also, the error has no indication that it's coming from Alloy or which Alloy instance it came from. We need to figure out a better way of addressing this.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
