### PR TITLE
Add mapOfValuesValidator to validate identity map

### DIFF
--- a/src/utils/validation/createMapOfValuesValidator.js
+++ b/src/utils/validation/createMapOfValuesValidator.js
@@ -1,0 +1,39 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import isObject from "../isObject";
+import assertValid from "./assertValid";
+
+export default valueValidator => (value, path) => {
+  assertValid(isObject(value), value, path, "an object");
+
+  const errors = [];
+  const validatedObject = {};
+  Object.keys(value).forEach(subKey => {
+    const subValue = value[subKey];
+    const subPath = path ? `${path}.${subKey}` : subKey;
+    try {
+      const validatedValue = valueValidator(subValue, subPath);
+      if (validatedValue !== undefined) {
+        validatedObject[subKey] = validatedValue;
+      }
+    } catch (e) {
+      errors.push(e.message);
+    }
+  });
+
+  if (errors.length) {
+    throw new Error(errors.join("\n"));
+  }
+
+  return validatedObject;
+};

--- a/src/utils/validation/index.js
+++ b/src/utils/validation/index.js
@@ -19,6 +19,7 @@ import callbackValidator from "./callbackValidator";
 import createArrayOfValidator from "./createArrayOfValidator";
 import createDefaultValidator from "./createDefaultValidator";
 import createLiteralValidator from "./createLiteralValidator";
+import createMapOfValuesValidator from "./createMapOfValuesValidator";
 import createMinimumValidator from "./createMinimumValidator";
 import createNoUnknownFieldsValidator from "./createNoUnknownFieldsValidator";
 import createNonEmptyValidator from "./createNonEmptyValidator";
@@ -79,6 +80,9 @@ const anyOf = function anyOf(validators, message) {
   // one of the validators accept null or undefined.
   return chain(this, createAnyOfValidator(validators, message));
 };
+const anything = function anything() {
+  return nullSafeChain(this, base);
+};
 const arrayOf = function arrayOf(elementValidator) {
   return nullSafeChain(this, createArrayOfValidator(elementValidator), {
     nonEmpty: nonEmptyArray
@@ -100,6 +104,11 @@ const number = function number() {
     unique
   });
 };
+const mapOfValues = function mapOfValues(valuesValidator) {
+  return nullSafeChain(this, createMapOfValuesValidator(valuesValidator), {
+    nonEmpty: nonEmptyObject
+  });
+};
 const objectOf = function objectOf(schema) {
   const noUnknownFields = function noUnknownFields() {
     return nullSafeChain(this, createNoUnknownFieldsValidator(schema));
@@ -119,11 +128,13 @@ const string = function string() {
 };
 
 const boundAnyOf = anyOf.bind(base);
+const boundAnything = anything.bind(base);
 const boundArrayOf = arrayOf.bind(base);
 const boundBoolean = boolean.bind(base);
 const boundCallback = callback.bind(base);
 const boundLiteral = literal.bind(base);
 const boundNumber = number.bind(base);
+const boundMapOfValues = mapOfValues.bind(base);
 const boundObjectOf = objectOf.bind(base);
 const boundString = string.bind(base);
 
@@ -137,11 +148,13 @@ const boundEnumOf = function boundEnumOf(...values) {
 
 export {
   boundAnyOf as anyOf,
+  boundAnything as anything,
   boundArrayOf as arrayOf,
   boundBoolean as boolean,
   boundCallback as callback,
   boundLiteral as literal,
   boundNumber as number,
+  boundMapOfValues as mapOfValues,
   boundObjectOf as objectOf,
   boundString as string,
   boundEnumOf as enumOf

--- a/test/unit/specs/utils/validation/anythingValidator.spec.js
+++ b/test/unit/specs/utils/validation/anythingValidator.spec.js
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { anything } from "../../../../../src/utils/validation";
+import describeValidation from "../../../helpers/describeValidation";
+
+describe("validation::anything", () => {
+  describeValidation("optional anything", anything(), [
+    { value: {} },
+    { value: { a: 1 } },
+    { value: [] },
+    { value: ["hello"] },
+    { value: 1 },
+    { value: true },
+    { value: undefined },
+    { value: null },
+    { value: () => undefined }
+  ]);
+
+  describeValidation("required anything", anything().required(), [
+    { value: {} },
+    { value: { a: 1 } },
+    { value: [] },
+    { value: ["hello"] },
+    { value: 1 },
+    { value: true },
+    { value: undefined, error: true },
+    { value: null, error: true }
+  ]);
+
+  describeValidation("default anything", anything().default("foo"), [
+    { value: {} },
+    { value: { a: 1 } },
+    { value: [] },
+    { value: ["hello"] },
+    { value: 1 },
+    { value: true },
+    { value: undefined, expected: "foo" },
+    { value: null, expected: "foo" }
+  ]);
+});

--- a/test/unit/specs/utils/validation/createMapOfValuesValidator.spec.js
+++ b/test/unit/specs/utils/validation/createMapOfValuesValidator.spec.js
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+  mapOfValues,
+  arrayOf,
+  anything,
+  string
+} from "../../../../../src/utils/validation";
+import describeValidation from "../../../helpers/describeValidation";
+
+describe("validation::mapOfValues", () => {
+  describeValidation(
+    "map of required strings",
+    mapOfValues(string().required()).required(),
+    [
+      { value: {} },
+      { value: { a: "1" } },
+      { value: { a: "1", b: "2", c: "3" } },
+      { value: undefined, error: true },
+      { value: null, error: true },
+      { value: { a: 123 }, error: true },
+      { value: 123, error: true },
+      { value: { a: undefined }, error: true }
+    ]
+  );
+
+  describeValidation("map of arrays", mapOfValues(arrayOf(anything())), [
+    { value: { a: [], b: [true, 1, 0.1, "string", undefined, null] } },
+    { value: { a: "string" }, error: true },
+    { value: { a: undefined }, expected: {} },
+    { value: { a: null } },
+    { value: undefined },
+    { value: null }
+  ]);
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This validator maps arbitrary keys to a validator.  I also added an "anything" validator.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Martin wanted to validate the identityMap option.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
