### PR TITLE
Relax consent validation

### DIFF
--- a/src/components/Audiences/index.js
+++ b/src/components/Audiences/index.js
@@ -18,12 +18,17 @@ const createAudiences = ({ logger }) => {
     fireReferrerHideableImage,
     logger
   });
+  const handleResponse = ({ response }) => {
+    if (!response) {
+      return undefined;
+    }
+    const destinations = response.getPayloadsByType("activation:push");
+    return processDestinations(destinations);
+  };
   return {
     lifecycle: {
-      onResponse({ response }) {
-        const destinations = response.getPayloadsByType("activation:push");
-        return processDestinations(destinations);
-      }
+      onResponse: handleResponse,
+      onRequestFailure: handleResponse
     },
     commands: {}
   };

--- a/src/components/Identity/createComponent.js
+++ b/src/components/Identity/createComponent.js
@@ -18,8 +18,8 @@ export default ({
       onBeforeEvent({ event }) {
         addEcidQueryToEvent(event);
       },
-      onBeforeRequest({ payload, onResponse }) {
-        return ensureSingleIdentity({ payload, onResponse });
+      onBeforeRequest({ payload, onResponse, onRequestFailure }) {
+        return ensureSingleIdentity({ payload, onResponse, onRequestFailure });
       },
       onResponse({ response }) {
         if (!ecid) {

--- a/src/components/Identity/injectAwaitIdentityCookie.js
+++ b/src/components/Identity/injectAwaitIdentityCookie.js
@@ -16,7 +16,7 @@ export default ({ orgId, doesIdentityCookieExist }) => {
    * If an identity cookie doesn't already exist, it should always exist after
    * the first response.
    */
-  return onResponse => {
+  return ({ onResponse, onRequestFailure }) => {
     return new Promise((resolve, reject) => {
       onResponse(() => {
         if (doesIdentityCookieExist()) {
@@ -36,6 +36,15 @@ export default ({ orgId, doesIdentityCookieExist }) => {
           // Throwing an error will reject the event command that initiated
           // the request.
           throw noIdentityCookieError;
+        }
+      });
+      onRequestFailure(() => {
+        if (doesIdentityCookieExist()) {
+          resolve();
+        } else {
+          // The error from the request failure will be logged separately. Rejecting this here
+          // will tell ensureSingleIdentity to send the next request without identity
+          reject(new Error("No identity was set on response."));
         }
       });
     });

--- a/src/components/Identity/injectEnsureSingleIdentity.js
+++ b/src/components/Identity/injectEnsureSingleIdentity.js
@@ -44,7 +44,7 @@ export default ({
    * an identity is to prevent a single malformed request causing all other
    * requests to never send.
    */
-  return ({ payload, onResponse }) => {
+  return ({ payload, onResponse, onRequestFailure }) => {
     if (doesIdentityCookieExist()) {
       return Promise.resolve();
     }
@@ -62,7 +62,7 @@ export default ({
       // requests are chained together so that only one is sent at a time
       // until we have the identity cookie.
       obtainedIdentityPromise = previousObtainedIdentityPromise.catch(() => {
-        return awaitIdentityCookie(onResponse);
+        return awaitIdentityCookie({ onResponse, onRequestFailure });
       });
 
       // When this returned promise resolves, the request will go out.
@@ -84,7 +84,10 @@ export default ({
     // to ensure we don't mint new ECIDs for requests that would otherwise
     // be sent in parallel, we'll let this request go out to fetch the
     // cookie
-    obtainedIdentityPromise = awaitIdentityCookie(onResponse);
+    obtainedIdentityPromise = awaitIdentityCookie({
+      onResponse,
+      onRequestFailure
+    });
     return allowRequestToGoWithoutIdentity(payload);
   };
 };

--- a/src/components/Privacy/validateSetConsentOptions.js
+++ b/src/components/Privacy/validateSetConsentOptions.js
@@ -1,44 +1,9 @@
-import {
-  enumOf,
-  objectOf,
-  literal,
-  arrayOf,
-  anyOf,
-  string,
-  boolean
-} from "../../utils/validation";
-import { IN, OUT } from "../../constants/consentStatus";
-import { GENERAL } from "../../constants/consentPurpose";
+import { objectOf, anything, arrayOf } from "../../utils/validation";
 
 export default objectOf({
-  consent: arrayOf(
-    anyOf(
-      [
-        objectOf({
-          standard: literal("Adobe").required(),
-          version: literal("1.0").required(),
-          value: objectOf({
-            [GENERAL]: enumOf(IN, OUT).required()
-          })
-            .noUnknownFields()
-            .required()
-        })
-          .noUnknownFields()
-          .required(),
-        objectOf({
-          standard: literal("IAB").required(),
-          version: literal("2.0").required(),
-          value: string().required(),
-          gdprApplies: boolean().required()
-        })
-          .noUnknownFields()
-          .required()
-      ],
-      "a valid consent object"
-    )
-  )
-    .nonEmpty()
+  consent: arrayOf(anything())
     .required()
+    .nonEmpty()
 })
   .noUnknownFields()
   .required();

--- a/src/core/edgeNetwork/injectSendEdgeNetworkRequest.js
+++ b/src/core/edgeNetwork/injectSendEdgeNetworkRequest.js
@@ -74,11 +74,18 @@ export default ({
           .call({ error })
           .then(throwError, throwError);
       })
-      .then(networkResponse => {
+      .then(({ parsedBody, statusCode }) => {
         // Note that networkResponse.parsedBody may be undefined if it was a
         // 204 No Content response. That's fine.
-        const response = createResponse(networkResponse.parsedBody);
+        const response = createResponse(parsedBody);
         cookieTransfer.responseToCookies(response);
+
+        if (statusCode >= 400) {
+          const throwError = () => processWarningsAndErrors(response);
+          return onRequestFailureCallbackAggregator
+            .call({ response })
+            .then(throwError, throwError);
+        }
         return onResponseCallbackAggregator
           .call({
             response

--- a/test/functional/specs/Privacy/C14410.js
+++ b/test/functional/specs/Privacy/C14410.js
@@ -49,28 +49,19 @@ test("Test C14410: Setting consent for unknown purposes fails", async t => {
     ...orgMainConfigMain
   });
   const errorMessage = getErrorMessageFromSetConsent({
-    consent: [
-      { standard: "Adobe", version: "1.0", value: { analytics: "pending" } }
-    ]
+    consent: [{ standard: "Adobe", version: "1.0", value: { analytics: "in" } }]
   });
   await t
     .expect(errorMessage)
     .ok("Expected the setConsent command to be rejected");
-  await t.expect(errorMessage).contains("Expected a valid consent object");
-});
+  await t
+    .expect(errorMessage)
+    .contains("The server responded with the following errors");
 
-test("Test C14410: Setting consent to 'pending' fails", async t => {
-  await configureAlloyInstance("alloy", {
-    defaultConsent: "pending",
-    ...orgMainConfigMain
+  // make sure we can call it again with the correct values
+  await t.eval(() => {
+    window.alloy("setConsent", {
+      consent: [{ standard: "Adobe", version: "1.0", value: { general: "in" } }]
+    });
   });
-  const errorMessage = getErrorMessageFromSetConsent({
-    consent: [
-      { standard: "Adobe", version: "1.0", value: { general: "pending" } }
-    ]
-  });
-  await t
-    .expect(errorMessage)
-    .ok("Expected the setConsent command to be rejected");
-  await t.expect(errorMessage).contains("Expected a valid consent object");
 });

--- a/test/unit/specs/components/Identity/createComponent.spec.js
+++ b/test/unit/specs/components/Identity/createComponent.spec.js
@@ -60,12 +60,18 @@ describe("Identity::createComponent", () => {
   it("ensures request has identity", () => {
     const payload = { type: "payload" };
     const onResponse = jasmine.createSpy("onResponse");
+    const onRequestFailure = jasmine.createSpy("onRequestFailure");
     const ensureSingleIdentityPromise = Promise.resolve();
     ensureSingleIdentity.and.returnValue(ensureSingleIdentityPromise);
-    const result = component.lifecycle.onBeforeRequest({ payload, onResponse });
+    const result = component.lifecycle.onBeforeRequest({
+      payload,
+      onResponse,
+      onRequestFailure
+    });
     expect(ensureSingleIdentity).toHaveBeenCalledWith({
       payload,
-      onResponse
+      onResponse,
+      onRequestFailure
     });
     expect(result).toBe(ensureSingleIdentityPromise);
   });

--- a/test/unit/specs/components/Privacy/validateSetConsentOptions.spec.js
+++ b/test/unit/specs/components/Privacy/validateSetConsentOptions.spec.js
@@ -12,59 +12,6 @@ describeValidation(
         ]
       }
     },
-    {
-      value: {
-        consent: [
-          { standard: "Adobe", version: "1.0", value: { general: "out" } }
-        ]
-      }
-    },
-    {
-      value: {
-        consent: [{ standard: "Adobe", version: "1.0", value: { foo: "in" } }]
-      },
-      error: true
-    },
-    {
-      value: {
-        consent: [
-          {
-            standard: "Adobe",
-            version: "1.0",
-            value: { general: "in", foo: "in" }
-          }
-        ]
-      },
-      error: true
-    },
-    {
-      value: {
-        consent: [
-          { standard: "Mine", version: "1.0", value: { general: "in" } }
-        ]
-      },
-      error: true
-    },
-    {
-      value: { consent: [{ version: "1.0", value: { general: "in" } }] },
-      error: true
-    },
-    {
-      value: {
-        consent: [
-          { standard: "Adobe", version: "2.0", value: { general: "in" } }
-        ]
-      },
-      error: true
-    },
-    {
-      value: { consent: [{ standard: "Adobe", value: { general: "in" } }] },
-      error: true
-    },
-    {
-      value: { consent: [{ standard: "Adobe", version: "1.0" }] },
-      error: true
-    },
     { value: { consent: [] }, error: true },
     { value: { consent: null }, error: true },
     { value: { consent: undefined }, error: true },
@@ -82,24 +29,6 @@ describeValidation(
           }
         ]
       }
-    },
-    {
-      value: {
-        consent: [{ standard: "IAB", value: "1234abcd", gdprApplies: true }]
-      },
-      error: true
-    },
-    {
-      value: {
-        consent: [{ standard: "IAB", version: "2.0", gdprApplies: true }]
-      },
-      error: true
-    },
-    {
-      value: {
-        consent: [{ standard: "IAB", version: "2.0", value: "1234abcd" }]
-      },
-      error: true
     },
     {
       value: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove consent object validation. Change functional test to look for Konductor's errors.  (This builds off of #547 so once that is merged only changes related to this PR will show up here)

## Related Issue

https://jira.corp.adobe.com/browse/CORE-47120
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Since Alloy doesn't care about the consent objects, let Konductor do the validation.  That way we don't have to update Alloy every time a consent version changes.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
