### PR TITLE
Support the EDGE_BASE_PATH env var in e2e tests.

### DIFF
--- a/test/functional/helpers/constants/configParts/orgAltConfigAlt.js
+++ b/test/functional/helpers/constants/configParts/orgAltConfigAlt.js
@@ -1,6 +1,5 @@
 // TODO: Use a real config ID since 9999999 is going away.
 // TODO: Need configs in `int` & prod`.
-export default {
-  edgeConfigId: "9999999",
-  orgId: "53A16ACB5CC1D3760A495C99@AdobeOrg"
-};
+import getBaseConfig from "../../getBaseConfig";
+
+export default getBaseConfig("53A16ACB5CC1D3760A495C99@AdobeOrg", "9999999");

--- a/test/functional/helpers/constants/configParts/orgMainConfigMain.js
+++ b/test/functional/helpers/constants/configParts/orgMainConfigMain.js
@@ -1,9 +1,3 @@
-import { edgeConfigId } from "../../edgeInfo";
-import edgeDomainThirdParty from "./edgeDomainThirdParty";
+import getBaseConfig from "../../getBaseConfig";
 
-// Default `edgeDomain` to 3rd party; override in specific test if needed.
-export default {
-  edgeConfigId,
-  orgId: "334F60F35E1597910A495EC2@AdobeOrg",
-  ...edgeDomainThirdParty
-};
+export default getBaseConfig();

--- a/test/functional/helpers/getBaseConfig.js
+++ b/test/functional/helpers/getBaseConfig.js
@@ -1,0 +1,19 @@
+import { edgeConfigId } from "./edgeInfo";
+import edgeDomainThirdParty from "./constants/configParts/edgeDomainThirdParty";
+
+const edgeBasePath = process.env.EDGE_BASE_PATH;
+
+export default (orgId, configId = edgeConfigId) => {
+  const config = {
+    edgeConfigId: configId,
+    orgId: orgId || "334F60F35E1597910A495EC2@AdobeOrg",
+    // Default `edgeDomain` to 3rd party; override in specific test if needed.
+    ...edgeDomainThirdParty
+  };
+
+  if (edgeBasePath) {
+    config.edgeBasePath = edgeBasePath;
+  }
+
+  return config;
+};


### PR DESCRIPTION
This will be used to test against the pre prod Konductor env.

## Related Issue

https://jira.corp.adobe.com/browse/CORE-48842

## Screenshots:

![ci_cd](https://user-images.githubusercontent.com/1738196/88306810-30633900-ccd9-11ea-98a4-1d9f8c350891.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
