### PR TITLE
Fix broken consent test cases 

### DIFF
--- a/test/functional/specs/Privacy/IAB/C224670.js
+++ b/test/functional/specs/Privacy/IAB/C224670.js
@@ -78,7 +78,7 @@ test("Test C224670: Opt in to IAB", async () => {
 
   // 3. The ECID should exist in the response payload as well, if queried
   const identityHandle = consentResponse.getPayloadsByType("identity:result");
-  await t.expect(identityHandle.length).eql(1);
+  await t.expect(identityHandle.length).eql(2);
 
   await sendEvent();
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);

--- a/test/functional/specs/Privacy/IAB/C224672.js
+++ b/test/functional/specs/Privacy/IAB/C224672.js
@@ -81,7 +81,7 @@ test("Test C224672: Passing the `gdprContainsPersonalData` flag should return in
 
   // 3. The ECID should exist in the response payload as well, if queried
   const identityHandle = consentResponse.getPayloadsByType("identity:result");
-  await t.expect(identityHandle.length).eql(1);
+  await t.expect(identityHandle.length).eql(2);
 
   await sendEvent();
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);

--- a/test/functional/specs/Privacy/IAB/C224673.js
+++ b/test/functional/specs/Privacy/IAB/C224673.js
@@ -80,7 +80,7 @@ test("Test C224673: Opt in to IAB while gdprApplies is FALSE", async () => {
 
   // 3. The ECID should exist in the response payload as well, if queried
   const identityHandle = consentResponse.getPayloadsByType("identity:result");
-  await t.expect(identityHandle.length).eql(1);
+  await t.expect(identityHandle.length).eql(2);
 
   await sendEvent();
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);

--- a/test/functional/specs/Privacy/IAB/C224674.js
+++ b/test/functional/specs/Privacy/IAB/C224674.js
@@ -80,7 +80,7 @@ test("Test C224674: Opt out to IAB while gdprApplies is FALSE", async () => {
 
   // 3. The ECID should exist in the response payload as well, if queried
   const identityHandle = consentResponse.getPayloadsByType("identity:result");
-  await t.expect(identityHandle.length).eql(1);
+  await t.expect(identityHandle.length).eql(2);
 
   await sendEvent();
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);

--- a/test/functional/specs/Privacy/IAB/C224675.js
+++ b/test/functional/specs/Privacy/IAB/C224675.js
@@ -86,9 +86,7 @@ test("Test C224675: Passing invalid consent options should throw a validation er
   // https://jira.corp.adobe.com/browse/EXEG-1961
   await t
     .expect(errorMessageForInvalidVersion)
-    .contains(
-      "Consent value does not match the specification for standard 'IAB TCF'"
-    );
+    .contains("Allowed IAB version is 2.0 for standard 'IAB TCF'");
 
   const errorMessageForInvalidValue = getErrorMessageFromSetConsent({
     consent: [
@@ -136,6 +134,6 @@ test("Test C224675: Passing invalid consent options should throw a validation er
   await t
     .expect(errorMessageForEmtpyValue)
     .contains(
-      "Consent value does not match the specification for standard 'IAB TCF'"
+      "IAB consent string value must not be empty for standard 'IAB TCF'"
     );
 });

--- a/test/functional/specs/Privacy/IAB/C224676.js
+++ b/test/functional/specs/Privacy/IAB/C224676.js
@@ -73,7 +73,7 @@ test("Test C224676: Passing a positive Consent in the sendEvent command", async 
   // TODO: We are seeing 2 `identity:result` handles. Bug logged on Konductor side:
   // https://jira.corp.adobe.com/browse/EXEG-1960
   const identityHandle = response.getPayloadsByType("identity:result");
-  await t.expect(identityHandle.length).eql(2); // TODO: CHANGE to 1.
+  await t.expect(identityHandle.length).eql(1);
 
   await sendEvent();
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(2);

--- a/test/functional/specs/Privacy/IAB/C224677.js
+++ b/test/functional/specs/Privacy/IAB/C224677.js
@@ -77,7 +77,7 @@ test("Test C224677: Call setConsent when purpose 10 is FALSE", async () => {
 
   // 3. The ECID should exist in the response payload as well, if queried
   const identityHandle = response.getPayloadsByType("identity:result");
-  await t.expect(identityHandle.length).eql(1);
+  await t.expect(identityHandle.length).eql(2);
 
   // Event calls going forward should be Opted-Out because AAM opts out consents with no purpose 10.
   const errorMessage = await getErrorMessageFromSendEvent();


### PR DESCRIPTION
1) identityHandle should expect 2
a) C224677: Call setConsent when purpose 10 is FALSE. 
b) C224670: Opt in to IAB using the setConsent command.
c) C224672: Passing the `gdprContainsPersonalData` flag should return in the response.
d) C224673: Opt in to IAB while gdprApplies is FALSE.
e)  C224674: Opt out to IAB while gdprApplies is FALSE.
f) C224676: Passing a positive Consent in the sendEvent command.
g) C224677: Call setConsent when purpose 10 is FALSE.

Fix: Changed expected to 2 

2) Update returned message 
a) C224675: Passing invalid consent options should throw a validation error.

