### PR TITLE
Use the local environment for the Visitor page when testing INT

### DIFF
--- a/test/functional/helpers/constants/testServerUrl.js
+++ b/test/functional/helpers/constants/testServerUrl.js
@@ -11,7 +11,7 @@ const alloyWithVisitorPages = {
   prod: "alloyVisitorTestPageProd.html"
 };
 
-const alloyWithVisitorTestPageUrl = `https://alloyio.com/functional-test/${alloyWithVisitorPages[env]}`;
+const alloyWithVisitorTestPageUrl = `https://alloyio.com/functional-test/${alloyWithVisitorPages[alloyEnv]}`;
 
 export { alloyWithVisitorTestPageUrl };
 

--- a/test/functional/helpers/constants/testServerUrl.js
+++ b/test/functional/helpers/constants/testServerUrl.js
@@ -11,21 +11,15 @@ const alloyWithVisitorPages = {
   prod: "alloyVisitorTestPageProd.html"
 };
 
-const alloyWithVisitorTestPageUrl = `https://alloyio.com/functional-test/${alloyWithVisitorPages[alloyEnv]}`;
+const envForPageUrl = alloyEnv || env;
 
+const alloyTestPageUrl = `https://alloyio.com/functional-test/${alloyPages[envForPageUrl]}`;
+export default alloyTestPageUrl;
+
+const alloyWithVisitorTestPageUrl = `https://alloyio.com/functional-test/${alloyWithVisitorPages[envForPageUrl]}`;
 export { alloyWithVisitorTestPageUrl };
 
-const getAlloyTestPageUrl = () => {
-  console.log("EDGE ENV:", env);
-  console.log("ALLOY ENV:", alloyEnv);
-  let pageUrl;
-  if (alloyEnv) {
-    pageUrl = alloyPages[alloyEnv];
-  } else {
-    pageUrl = alloyPages[env];
-  }
-  console.log("ALLOY PAGE:", pageUrl);
-  return pageUrl;
-};
-
-export default `https://alloyio.com/functional-test/${getAlloyTestPageUrl()}`;
+console.log("EDGE ENV:", env);
+console.log("ALLOY ENV:", alloyEnv);
+console.log("ALLOY PAGE:", alloyTestPageUrl);
+console.log("ALLOY VISITOR PAGE:", alloyWithVisitorTestPageUrl);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When testing locally, the functional test wasn't using the local version of alloy for the Visitor tests.

## Motivation and Context

The recent changes to environment exposed this bug.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
