### PR TITLE
CORE-53556 simplify referrer calculation to avoid cross domain iframe errors

### DIFF
--- a/src/components/Context/injectWeb.js
+++ b/src/components/Context/injectWeb.js
@@ -19,7 +19,7 @@ export default window => {
         URL: window.location.href || window.location
       },
       webReferrer: {
-        URL: window.top.document.referrer
+        URL: window.document.referrer
       }
     };
     deepAssign(xdm, { web });

--- a/test/functional/specs/Context/C2598.js
+++ b/test/functional/specs/Context/C2598.js
@@ -4,13 +4,15 @@ import { responseStatus } from "../../helpers/assertions/index";
 import createFixture from "../../helpers/createFixture";
 import webContextConfig from "../../helpers/constants/webContextConfig";
 import configureAlloyInstance from "../../helpers/configureAlloyInstance";
+import testServerUrl from "../../helpers/constants/testServerUrl";
 
 const networkLogger = createNetworkLogger();
 
 createFixture({
   title:
     "C2598 - Adds only web context data when only web is specified in configuration.",
-  requestHooks: [networkLogger.edgeEndpointLogs]
+  requestHooks: [networkLogger.edgeEndpointLogs],
+  url: testServerUrl
 });
 
 test.meta({
@@ -21,17 +23,16 @@ test.meta({
 
 const triggerAlloyEvent = ClientFunction(() => {
   return window.alloy("sendEvent", {
-    xdm: {
-      web: {
-        webPageDetails: {
-          URL: "https://alloyio.com/functional-test/alloyTestPage.html"
-        }
-      }
-    }
+    xdm: {}
   });
 });
 
 test("Test C2598 - Adds only web context data when only web is specified in configuration.", async () => {
+  // navigate to set the document.referrer
+  await t.eval(() => {
+    window.document.location = `${window.document.location}`;
+  });
+
   await configureAlloyInstance("alloy", webContextConfig);
   await triggerAlloyEvent();
 
@@ -43,6 +44,13 @@ test("Test C2598 - Adds only web context data when only web is specified in conf
 
   await t.expect(stringifyRequest.events[0].xdm.web).ok();
   await t.expect(stringifyRequest.events[0].xdm.web.webPageDetails).ok();
+  await t
+    .expect(stringifyRequest.events[0].xdm.web.webPageDetails.URL)
+    .eql(testServerUrl);
+  await t.expect(stringifyRequest.events[0].xdm.web.webReferrer).ok();
+  await t
+    .expect(stringifyRequest.events[0].xdm.web.webReferrer.URL)
+    .eql(testServerUrl);
 
   await t.expect(stringifyRequest.events[0].xdm.device).notOk();
   await t.expect(stringifyRequest.events[0].xdm.placeContext).notOk();

--- a/test/unit/specs/components/Context/injectWeb.spec.js
+++ b/test/unit/specs/components/Context/injectWeb.spec.js
@@ -3,10 +3,8 @@ import injectWeb from "../../../../../src/components/Context/injectWeb";
 describe("Context::injectWeb", () => {
   const window = {
     location: { href: "http://mylocation.com" },
-    top: {
-      document: {
-        referrer: "http://myreferrer.com"
-      }
+    document: {
+      referrer: "http://myreferrer.com"
     }
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Getting "window.top.document.referrer" throws an error when called within an iframe with a different domain than its parent. We could wrap it inside a try/catch, but the change in this PR is more straight-forward. For example, within an iframe it's not clear what the referrer should be. Should it be the referrer of the parent? Or if the user navigated within the iframe, should it be the referrer of the iframe?

## Related Issue

https://jira.corp.adobe.com/browse/CORE-53556
https://jira.corp.adobe.com/browse/CORE-53562
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
