### PR TITLE
CORE-53556 Don't attempt to change the message on a error with a read-only message property.

### DIFF
--- a/src/core/createComponentRegistry.js
+++ b/src/core/createComponentRegistry.js
@@ -19,12 +19,12 @@ const wrapForErrorHandling = (fn, stackMessage) => {
     try {
       result = fn(...args);
     } catch (error) {
-      throw stackError(stackMessage, error);
+      throw stackError({ error, message: stackMessage });
     }
 
     if (result instanceof Promise) {
       result = result.catch(error => {
-        throw stackError(stackMessage, error);
+        throw stackError({ error, message: stackMessage });
       });
     }
 

--- a/src/core/initializeComponents.js
+++ b/src/core/initializeComponents.js
@@ -26,10 +26,10 @@ export default ({
     try {
       component = createComponent(tools);
     } catch (error) {
-      throw stackError(
-        `[${namespace}] An error occurred during component creation.`,
-        error
-      );
+      throw stackError({
+        error,
+        message: `[${namespace}] An error occurred during component creation.`
+      });
     }
     componentRegistry.register(namespace, component);
   });

--- a/src/core/injectHandleError.js
+++ b/src/core/injectHandleError.js
@@ -10,21 +10,25 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { toError } from "../utils";
+import { toError, updateErrorMessage } from "../utils";
 import { DECLINED_CONSENT_ERROR_CODE } from "./consent/createConsentStateMachine";
 
 export default ({ errorPrefix, logger }) => (error, operation) => {
+  const err = toError(error);
+
   // In the case of declined consent, we've opted to not reject the promise
   // returned to the customer, but instead resolve the promise with an
   // empty result object.
-  if (error.code === DECLINED_CONSENT_ERROR_CODE) {
+  if (err.code === DECLINED_CONSENT_ERROR_CODE) {
     logger.warn(
       `The ${operation} could not fully complete because the user declined consent.`
     );
     return {};
   }
 
-  const err = toError(error);
-  err.message = `${errorPrefix} ${err.message}`;
+  updateErrorMessage({
+    error: err,
+    message: `${errorPrefix} ${err.message}`
+  });
   throw err;
 };

--- a/src/core/network/injectSendNetworkRequest.js
+++ b/src/core/network/injectSendNetworkRequest.js
@@ -79,7 +79,7 @@ export default ({ logger, networkStrategy, isRetryableHttpStatusCode }) => {
         payload: JSON.parse(stringifiedPayload),
         error
       });
-      throw stackError("Network request failed.", error);
+      throw stackError({ error, message: "Network request failed." });
     });
   };
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -66,5 +66,6 @@ export { default as toArray } from "./toArray";
 export { default as toError } from "./toError";
 export { default as toISOStringLocal } from "./toISOStringLocal";
 export { default as uuid } from "./uuid";
+export { default as updateErrorMessage } from "./updateErrorMessage";
 export { default as validateIdentityMap } from "./validateIdentityMap";
 export { default as values } from "./values";

--- a/src/utils/stackError.js
+++ b/src/utils/stackError.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import toError from "./toError";
+import updateErrorMessage from "./updateErrorMessage";
 
 /**
  * Augments an error's message with additional context as it bubbles up the call stack.
@@ -19,8 +20,12 @@ import toError from "./toError";
  * this is used as the basis for the message of a newly created Error instance.
  * @returns {*}
  */
-export default (message, error) => {
-  const stackedError = toError(error);
-  stackedError.message = `${message}\nCaused by: ${stackedError.message}`;
-  return stackedError;
+export default ({ error, message }) => {
+  const errorToStack = toError(error);
+  const newMessage = `${message}\nCaused by: ${errorToStack.message}`;
+  updateErrorMessage({
+    error: errorToStack,
+    message: newMessage
+  });
+  return errorToStack;
 };

--- a/src/utils/updateErrorMessage.js
+++ b/src/utils/updateErrorMessage.js
@@ -1,0 +1,20 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+export default ({ error, message }) => {
+  try {
+    error.message = message;
+  } catch (e) {
+    // We'll set a new message when we can, but some errors, like DOMException,
+    // have a read-only message property, which limits our options.
+  }
+};

--- a/test/unit/specs/utils/stackError.spec.js
+++ b/test/unit/specs/utils/stackError.spec.js
@@ -15,7 +15,7 @@ import stackError from "../../../../src/utils/stackError";
 describe("stackError", () => {
   it("stacks message onto error instance", () => {
     const error = new Error("Conundrum encountered.");
-    const result = stackError("Predicament discovered.", error);
+    const result = stackError({ error, message: "Predicament discovered." });
     expect(result).toEqual(jasmine.any(Error));
     expect(result.message).toBe(
       "Predicament discovered.\nCaused by: Conundrum encountered."
@@ -24,7 +24,7 @@ describe("stackError", () => {
 
   it("stacks message onto non-error instance", () => {
     const error = "Conundrum encountered.";
-    const result = stackError("Predicament discovered.", error);
+    const result = stackError({ error, message: "Predicament discovered." });
     expect(result).toEqual(jasmine.any(Error));
     expect(result.message).toBe(
       "Predicament discovered.\nCaused by: Conundrum encountered."

--- a/test/unit/specs/utils/updateErrorMessage.spec.js
+++ b/test/unit/specs/utils/updateErrorMessage.spec.js
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import updateErrorMessage from "../../../../src/utils/updateErrorMessage";
+
+describe("updateErrorMessage", () => {
+  it("updates error message if the message property is writeable", () => {
+    const error = new Error("Conundrum encountered.");
+    const message = "Predicament discovered.";
+    updateErrorMessage({ error, message });
+    expect(error.message).toEqual("Predicament discovered.");
+  });
+
+  it("does not update error message if the message property is read-only", () => {
+    let error;
+    try {
+      // This will cause a DOMException, which has a read-only message property.
+      const invalidSelector = "div:foo";
+      document.querySelectorAll(invalidSelector);
+    } catch (e) {
+      error = e;
+    }
+    updateErrorMessage({ error, message: "Predicament discovered." });
+    expect(error.message).not.toContain("Predicament discovered.");
+  });
+});


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

As errors are bubbling up through Alloy, we modify the message of the error to provide additional context. Some errors, like DOMExceptions, have a `message` property that is read-only. When trying to change the `message` property value on these types of errors, a new error is thrown because doing so is not allowed.

This PR modified the behavior so that if we _can_ modify the `message` property, we'll add context. If we can't, we leave the error as it is.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-53556
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
In certain cases, a DOMException is thrown (one case is due to a bug when Alloy is running within an iframe that has a different origin than the parent). We cause more issues by trying to update its `message` property which masks the underlying error.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] (some functional tests fail due to pending error code changes in konductor) I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
