### PR TITLE
CORE-53571 use regular object prototype for config objects

### DIFF
--- a/src/core/config/createConfig.js
+++ b/src/core/config/createConfig.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 import { assign } from "../../utils";
 
 const createConfig = options => {
-  return assign(Object.create(null), options);
+  return assign({}, options);
 };
 
 export default createConfig;

--- a/test/functional/specs/Logging/C532204.js
+++ b/test/functional/specs/Logging/C532204.js
@@ -12,6 +12,12 @@ const debugEnabledConfig = compose(
   debugEnabled
 );
 
+/*
+ * Some pages will redefine the console logging methods with implementations
+ * that aren't as forgiving as the built in logger. We ran into this issue
+ * on a Shopify site with a redefined logger. This test runs through some basic
+ * scenarios and makes sure the logged objects can be stringified
+ */
 createFixture({
   title: "C532204: Logged objects can be stringified"
 });

--- a/test/functional/specs/Logging/C532204.js
+++ b/test/functional/specs/Logging/C532204.js
@@ -1,0 +1,45 @@
+import { ClientFunction } from "testcafe";
+import createFixture from "../../helpers/createFixture";
+import configureAlloyInstance from "../../helpers/configureAlloyInstance";
+import {
+  compose,
+  orgMainConfigMain,
+  debugEnabled
+} from "../../helpers/constants/configParts";
+
+const debugEnabledConfig = compose(
+  orgMainConfigMain,
+  debugEnabled
+);
+
+createFixture({
+  title: "C532204: Logged objects can be stringified"
+});
+
+test.meta({
+  ID: "C532204",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+
+const setupLogger = ClientFunction(() => {
+  ["log", "info", "warn", "error"].forEach(methodName => {
+    const origConsoleMethod = console[methodName];
+    console[methodName] = (...args) => {
+      args.forEach(arg => {
+        String(arg);
+      });
+      origConsoleMethod.apply(console, args);
+    };
+  });
+});
+
+const triggerAlloyEvent = ClientFunction(() => {
+  return window.alloy("sendEvent");
+});
+
+test("Test C532204: Logged objects can be stringified", async () => {
+  await setupLogger();
+  await configureAlloyInstance("alloy", debugEnabledConfig);
+  await triggerAlloyEvent();
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
We were logging an object created with Object.create(null) which caused problems on a Shopify site where the logging was overwritten. This change fixes that case and adds a functional test to make sure it doesn't happen again.

## Related Issue

https://github.com/adobe/alloy/issues/611
https://jira.corp.adobe.com/browse/CORE-53571

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
