### PR TITLE
Fixing sendBeacon functional tests in IE.

### DIFF
--- a/test/functional/helpers/areThirdPartyCookiesSupported.js
+++ b/test/functional/helpers/areThirdPartyCookiesSupported.js
@@ -1,14 +1,19 @@
 import { t } from "testcafe";
+import {
+  CHROME,
+  CHROMIUM,
+  EDGE,
+  INTERNET_EXPLORER
+} from "./constants/browsers";
 
-// The names here match those listed in
-// https://github.com/lancedikson/bowser/blob/9ecf3e94c3269ef8bb4c8274dab6a31eea665aea/src/constants.js
-// which is the library that provides the value for t.browser.name.
 const browsersSupportingThirdPartyCookiesByDefault = [
-  "Chrome",
-  "Chromium",
-  "Microsoft Edge",
-  "Internet Explorer"
+  CHROME,
+  CHROMIUM,
+  EDGE,
+  INTERNET_EXPLORER
 ];
 
+// This must be a function called during the test, otherwise TestCafe will throw
+// an error about how it can't resolve the right context for "t".
 export default () =>
   browsersSupportingThirdPartyCookiesByDefault.indexOf(t.browser.name) !== -1;

--- a/test/functional/helpers/constants/browsers.js
+++ b/test/functional/helpers/constants/browsers.js
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+// The values here match those listed in
+// https://github.com/lancedikson/bowser/blob/9ecf3e94c3269ef8bb4c8274dab6a31eea665aea/src/constants.js
+// which is the library that provides the value for t.browser.name.
+export const CHROME = "Chrome";
+export const CHROMIUM = "Chromium";
+export const EDGE = "Microsoft Edge";
+export const INTERNET_EXPLORER = "Internet Explorer";

--- a/test/functional/helpers/isSendBeaconSupported.js
+++ b/test/functional/helpers/isSendBeaconSupported.js
@@ -1,0 +1,18 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { t } from "testcafe";
+import { INTERNET_EXPLORER } from "./constants/browsers";
+
+// This must be a function called during the test, otherwise TestCafe will throw
+// an error about how it can't resolve the right context for "t".
+export default () => t.browser.name !== INTERNET_EXPLORER;

--- a/test/functional/specs/Data Collector/C455258.js
+++ b/test/functional/specs/Data Collector/C455258.js
@@ -4,12 +4,13 @@ import createFixture from "../../helpers/createFixture";
 import sendBeaconMock from "../../helpers/sendBeaconMock";
 import configureAlloyInstance from "../../helpers/configureAlloyInstance";
 import { orgMainConfigMain } from "../../helpers/constants/configParts";
+import isSendBeaconSupported from "../../helpers/isSendBeaconSupported";
 
 const networkLogger = createNetworkLogger();
 
 createFixture({
   title:
-    "455258: sendEvent command sends a request to the collect endpoint using sendBeacon when documentUnloading is set to true.",
+    "C455258: sendEvent command sends a request to the collect endpoint using sendBeacon when documentUnloading is set to true.",
   requestHooks: [networkLogger.edgeCollectEndpointLogs]
 });
 
@@ -40,10 +41,14 @@ const sendEvent = ClientFunction(() => {
     });
 });
 
-test("Test 455258: sendEvent command sends a request to the collect endpoint using sendBeacon when documentUnloading is set to true.", async () => {
-  await sendBeaconMock.mock();
+test("Test C455258: sendEvent command sends a request to the collect endpoint using sendBeacon when documentUnloading is set to true.", async () => {
+  if (isSendBeaconSupported()) {
+    await sendBeaconMock.mock();
+  }
   await configureAlloyInstance("alloy", orgMainConfigMain);
   await sendEvent();
   await t.expect(networkLogger.edgeCollectEndpointLogs.requests.length).eql(1);
-  await t.expect(sendBeaconMock.getCallCount()).eql(1);
+  if (isSendBeaconSupported()) {
+    await t.expect(sendBeaconMock.getCallCount()).eql(1);
+  }
 });

--- a/test/functional/specs/Data Collector/C8118.js
+++ b/test/functional/specs/Data Collector/C8118.js
@@ -5,6 +5,7 @@ import addHtmlToBody from "../../helpers/dom/addHtmlToBody";
 import sendBeaconMock from "../../helpers/sendBeaconMock";
 import configureAlloyInstance from "../../helpers/configureAlloyInstance";
 import { orgMainConfigMain } from "../../helpers/constants/configParts";
+import isSendBeaconSupported from "../../helpers/isSendBeaconSupported";
 
 const networkLogger = createNetworkLogger();
 
@@ -22,7 +23,9 @@ test.meta({
 const getLocation = ClientFunction(() => document.location.href.toString());
 
 test("Test C8118: Load page with link. Click link. Verify event.", async () => {
-  await sendBeaconMock.mock();
+  if (isSendBeaconSupported()) {
+    await sendBeaconMock.mock();
+  }
   await configureAlloyInstance("alloy", orgMainConfigMain);
   await addHtmlToBody(
     `<a href="blank.html"><span id="alloy-link-test">Test Link</span></a>`
@@ -40,5 +43,7 @@ test("Test C8118: Load page with link. Click link. Verify event.", async () => {
     URL: "https://alloyio.com/functional-test/blank.html",
     linkClicks: { value: 1 }
   });
-  await t.expect(sendBeaconMock.getCallCount()).eql(1);
+  if (isSendBeaconSupported()) {
+    await t.expect(sendBeaconMock.getCallCount()).eql(1);
+  }
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I had added a couple functional tests that exercised sendBeacon, but since sendBeacon isn't supported in IE, the tests were failing. I've added some checks for IE so that we don't attempt to exercise sendBeacon for those cases.
<!--- Describe your changes in detail -->

## Related Issue
None.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Functioning functional tests are useful.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
