### PR TITLE
CORE-45072 Fix functional test failure when running against Alloy prod.

### DIFF
--- a/test/functional/helpers/createFixture/clientScripts.js
+++ b/test/functional/helpers/createFixture/clientScripts.js
@@ -169,9 +169,14 @@ const injectAlloyDuringTestForInt = ClientFunction(
  */
 const injectAlloyDuringTestForProd = ClientFunction(
   () => {
-    const scriptElement = document.createElement("script");
-    scriptElement.src = remoteAlloyLibraryUrl;
-    document.getElementsByTagName("head")[0].appendChild(scriptElement);
+    return new Promise(resolve => {
+      const scriptElement = document.createElement("script");
+      scriptElement.src = remoteAlloyLibraryUrl;
+      scriptElement.addEventListener("load", () => {
+        resolve();
+      });
+      document.getElementsByTagName("head")[0].appendChild(scriptElement);
+    });
   },
   {
     dependencies: {

--- a/test/functional/specs/Data Collector/C8118.js
+++ b/test/functional/specs/Data Collector/C8118.js
@@ -33,6 +33,7 @@ test("Test C8118: Load page with link. Click link. Verify event.", async () => {
 
   await t.click(Selector("#alloy-link-test"));
   await t.expect(getLocation()).contains("blank.html");
+  await t.expect(networkLogger.edgeCollectEndpointLogs.requests.length).eql(1);
   const request = networkLogger.edgeCollectEndpointLogs.requests[0];
   const requestBody = JSON.parse(request.request.body);
   const eventXdm = requestBody.events[0].xdm;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes a functional tests that would incorrectly fail when run against Alloy prod. The test that was failing was C2580. Its source is as follows:

```
  await configureAlloy(debugEnabledConfig);
  await getLibraryInfoCommand();
  await t.expect(getAlloyCommandQueueLength()).eql(2);
  const logger = await createConsoleLogger();
  await injectAlloyDuringTest();
  await logger.info.expectMessageMatching(/Executing getLibraryInfo command/);
```

The problem here is that when we call `injectAlloyDuringTest()`, it wouldn't wait for the prod Alloy library to finish loading before moving on to `await logger.info.expectMessageMatching(/Executing getLibraryInfo command/);` and therefore that assertion would fail because the log message hadn't been seen yet. We don't have this problem when running tests against Alloy int, because the Alloy code in that case is added as an inline script, which means it would be executed before we run the logger assertion.

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-45072
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Failing tests are no good.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
