### PR TITLE
Fix functional tests runner for IE

### DIFF
--- a/test/functional/helpers/createFixture/clientScripts.js
+++ b/test/functional/helpers/createFixture/clientScripts.js
@@ -98,7 +98,7 @@ const getFixtureClientScriptsForInt = options => {
     // like to simulate that. To do so, we'll wrap our Alloy code in a
     // setTimeout with a small arbitrary delay.
     clientScripts.push({
-      content: `setTimeout(() => {\n${localAlloyCode}\n}, 10);`
+      content: `setTimeout(function() {\n${localAlloyCode}\n}, 10);`
     });
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We added a "setTimeout(() => {" to the beginning of the injected alloy script, but this won't run in IE.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
