### PR TITLE
CORE-54518 Support not calling setConsent

### DIFF
--- a/src/constants/consentPurpose.js
+++ b/src/constants/consentPurpose.js
@@ -12,3 +12,4 @@ governing permissions and limitations under the License.
 
 // eslint-disable-next-line import/prefer-default-export
 export const GENERAL = "general";
+export const CONSENT_HASH = "consentHash";

--- a/src/core/config/createCoreConfigs.js
+++ b/src/core/config/createCoreConfigs.js
@@ -14,11 +14,11 @@ import { boolean, string, callback, enumOf } from "../../utils/validation";
 import { noop } from "../../utils";
 import { EDGE as EDGE_DOMAIN } from "../../constants/domain";
 import EDGE_BASE_PATH from "../../constants/edgeBasePath";
-import { IN, PENDING } from "../../constants/consentStatus";
+import { IN, OUT, PENDING } from "../../constants/consentStatus";
 
 export default () => ({
   debugEnabled: boolean().default(false),
-  defaultConsent: enumOf(IN, PENDING).default(IN),
+  defaultConsent: enumOf(IN, PENDING, OUT).default(IN),
   edgeConfigId: string()
     .unique()
     .required(),

--- a/src/core/consent/createConsent.js
+++ b/src/core/consent/createConsent.js
@@ -12,33 +12,30 @@ governing permissions and limitations under the License.
 
 import { DECLINED_CONSENT } from "./createConsentStateMachine";
 import { IN, OUT, PENDING } from "../../constants/consentStatus";
-import { GENERAL } from "../../constants/consentPurpose";
+import { GENERAL, CONSENT_HASH } from "../../constants/consentPurpose";
 
 export default ({ generalConsentState, logger }) => {
   return {
-    setConsent(consentByPurpose) {
-      switch (consentByPurpose[GENERAL]) {
+    setConsent({ [GENERAL]: generalConsent, [CONSENT_HASH]: consentHash }) {
+      switch (generalConsent) {
         case IN:
-          generalConsentState.in();
+          generalConsentState.in(consentHash);
           break;
         case OUT:
-          logger.warn(`Some commands may fail. ${DECLINED_CONSENT}`);
-          generalConsentState.out();
-          break;
         case PENDING:
-          logger.warn("Some commands may be delayed until the user consents.");
-          generalConsentState.pending();
+          logger.warn(`Some commands may fail. ${DECLINED_CONSENT}`);
+          generalConsentState.out(consentHash);
           break;
         default:
-          logger.warn(`Unknown consent value: ${consentByPurpose[GENERAL]}`);
+          logger.warn(`Unknown consent value: ${generalConsent}`);
           break;
       }
     },
     suspend() {
-      generalConsentState.pending();
+      generalConsentState.suspend();
     },
-    awaitConsent() {
-      return generalConsentState.awaitConsent();
+    awaitConsent(event) {
+      return generalConsentState.awaitConsent(event);
     }
   };
 };

--- a/src/core/consent/hash.js
+++ b/src/core/consent/hash.js
@@ -1,0 +1,1 @@
+export default object => JSON.stringify(object);

--- a/src/core/createEvent.js
+++ b/src/core/createEvent.js
@@ -52,6 +52,13 @@ export default () => {
 
       return userXdm.web.webPageDetails.viewName;
     },
+    getConsent() {
+      if (!userXdm || !userXdm.consentStrings) {
+        return undefined;
+      }
+
+      return userXdm.consentStrings;
+    },
     toJSON() {
       if (userXdm) {
         event.mergeXdm(userXdm);

--- a/src/core/createEventManager.js
+++ b/src/core/createEventManager.js
@@ -68,7 +68,7 @@ export default ({
           // it's important to add the event here because the payload object will call toJSON
           // which applies the userData, userXdm, and lastChanceCallback
           payload.addEvent(event);
-          return consent.awaitConsent();
+          return consent.awaitConsent(event);
         })
         .then(() => {
           return lifecycle.onBeforeDataCollectionRequest({

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -13,21 +13,27 @@ governing permissions and limitations under the License.
 /* eslint-disable import/prefer-default-export */
 
 // Please keep in alphabetical order.
-export { default as areThirdPartyCookiesSupportedByDefault } from "./areThirdPartyCookiesSupportedByDefault";
+export {
+  default as areThirdPartyCookiesSupportedByDefault
+} from "./areThirdPartyCookiesSupportedByDefault";
 export { default as assign } from "./assign";
 export { default as assignIf } from "./assignIf";
 export { default as clone } from "./clone";
 export { default as convertTimes } from "./convertTimes";
 export { default as cookieJar } from "./cookieJar";
 export { default as createMerger } from "./createMerger";
-export { default as createCallbackAggregator } from "./createCallbackAggregator";
+export {
+  default as createCallbackAggregator
+} from "./createCallbackAggregator";
 export { default as createTaskQueue } from "./createTaskQueue";
 export { default as defer } from "./defer";
 export { default as deepAssign } from "./deepAssign";
 export { default as endsWith } from "./endsWith";
 export { default as find } from "./find";
 export { default as fireImage } from "./fireImage";
-export { default as fireReferrerHideableImage } from "./fireReferrerHideableImage";
+export {
+  default as fireReferrerHideableImage
+} from "./fireReferrerHideableImage";
 export { default as flatMap } from "./flatMap";
 export { default as getApexDomain } from "./getApexDomain";
 export { default as getLastArrayItems } from "./getLastArrayItems";
@@ -50,7 +56,9 @@ export { default as memoize } from "./memoize";
 export { default as noop } from "./noop";
 export { default as padStart } from "./padStart";
 export { default as queryString } from "./querystring";
-export { default as sanitizeOrgIdForCookieName } from "./sanitizeOrgIdForCookieName";
+export {
+  default as sanitizeOrgIdForCookieName
+} from "./sanitizeOrgIdForCookieName";
 export { default as stackError } from "./stackError";
 export { default as injectStorage } from "./injectStorage";
 export { default as stringToBoolean } from "./stringToBoolean";

--- a/test/functional/specs/Privacy/C14410.js
+++ b/test/functional/specs/Privacy/C14410.js
@@ -27,9 +27,9 @@ const getErrorMessageFromSetConsent = ClientFunction(consent =>
 // state isn't reset, so when I had this all in one test, the third part here was failing because
 // an instance was already configured with that orgId.
 
-test("Test C14410: Configuring default consent to 'out' fails", async t => {
+test("Test C14410: Configuring default consent to 'other' fails", async t => {
   const errorMessage = getErrorMessageFromConfigure({
-    defaultConsent: "out",
+    defaultConsent: "other",
     ...orgMainConfigMain
   });
   await t
@@ -39,7 +39,7 @@ test("Test C14410: Configuring default consent to 'out' fails", async t => {
   await t
     .expect(errorMessage)
     .contains(
-      `Expected one of these values: [["in","pending"]], but got "out"`
+      `Expected one of these values: [["in","pending","out"]], but got "other"`
     );
 });
 

--- a/test/functional/specs/Privacy/C2660.js
+++ b/test/functional/specs/Privacy/C2660.js
@@ -39,7 +39,8 @@ const getContextUrlFromRequest = request => {
   return parsedBody.events[0].xdm.web.webPageDetails.URL;
 };
 
-test("C2660 - Context data is captured before user consents.", async () => {
+// We need to find a different way to test this if "pending" consent is no longer supported.
+test.skip("C2660 - Context data is captured before user consents.", async () => {
   await configureAlloyInstance(
     compose(
       orgMainConfigMain,

--- a/test/unit/specs/core/config/createCoreConfigs.spec.js
+++ b/test/unit/specs/core/config/createCoreConfigs.spec.js
@@ -78,12 +78,11 @@ describe("createCoreConfigs", () => {
       }).toThrowError();
     });
     it("validates defaultConsent='out'", () => {
-      expect(() => {
-        objectOf(createCoreConfigs())({
-          defaultConsent: OUT,
-          ...baseConfig
-        });
-      }).toThrowError();
+      const config = objectOf(createCoreConfigs())({
+        defaultConsent: OUT,
+        ...baseConfig
+      });
+      expect(config.defaultConsent).toEqual(OUT);
     });
   });
 

--- a/test/unit/specs/core/consent/createConsent.spec.js
+++ b/test/unit/specs/core/consent/createConsent.spec.js
@@ -21,7 +21,7 @@ describe("createConsent", () => {
     state = jasmine.createSpyObj("state", [
       "in",
       "out",
-      "pending",
+      "suspend",
       "awaitConsent"
     ]);
     logger = jasmine.createSpyObj("logger", ["warn"]);
@@ -32,14 +32,14 @@ describe("createConsent", () => {
     subject.setConsent({ general: "in" });
     expect(state.in).toHaveBeenCalled();
     expect(state.out).not.toHaveBeenCalled();
-    expect(state.pending).not.toHaveBeenCalled();
+    expect(state.suspend).not.toHaveBeenCalled();
     expect(logger.warn).not.toHaveBeenCalled();
   });
   it("sets consent to out", () => {
     subject.setConsent({ general: "out" });
     expect(state.in).not.toHaveBeenCalled();
     expect(state.out).toHaveBeenCalled();
-    expect(state.pending).not.toHaveBeenCalled();
+    expect(state.suspend).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledWith(
       "Some commands may fail. The user declined consent."
     );
@@ -48,7 +48,7 @@ describe("createConsent", () => {
     subject.setConsent({ general: "pending" });
     expect(state.in).not.toHaveBeenCalled();
     expect(state.out).toHaveBeenCalled();
-    expect(state.pending).not.toHaveBeenCalled();
+    expect(state.suspend).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledWith(
       "Some commands may fail. The user declined consent."
     );
@@ -57,14 +57,14 @@ describe("createConsent", () => {
     subject.setConsent({ general: "foo" });
     expect(state.in).not.toHaveBeenCalled();
     expect(state.out).not.toHaveBeenCalled();
-    expect(state.pending).not.toHaveBeenCalled();
+    expect(state.suspend).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledWith("Unknown consent value: foo");
   });
   it("suspends", () => {
     subject.suspend();
     expect(state.in).not.toHaveBeenCalled();
     expect(state.out).not.toHaveBeenCalled();
-    expect(state.pending).toHaveBeenCalled();
+    expect(state.suspend).toHaveBeenCalled();
     expect(logger.warn).not.toHaveBeenCalled();
   });
   it("calls await consent", () => {

--- a/test/unit/specs/core/consent/createConsent.spec.js
+++ b/test/unit/specs/core/consent/createConsent.spec.js
@@ -47,10 +47,10 @@ describe("createConsent", () => {
   it("sets consent to pending", () => {
     subject.setConsent({ general: "pending" });
     expect(state.in).not.toHaveBeenCalled();
-    expect(state.out).not.toHaveBeenCalled();
-    expect(state.pending).toHaveBeenCalled();
+    expect(state.out).toHaveBeenCalled();
+    expect(state.pending).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledWith(
-      "Some commands may be delayed until the user consents."
+      "Some commands may fail. The user declined consent."
     );
   });
   it("logs unknown consent values", () => {

--- a/test/unit/specs/core/consent/createConsentStateMachine.spec.js
+++ b/test/unit/specs/core/consent/createConsentStateMachine.spec.js
@@ -155,10 +155,4 @@ describe("createConsentStateMachine", () => {
     setOut(events[0].getHash());
     return promisesAre([RESOLVED, RESOLVED, PENDING]);
   });
-
-  it("does not resolve promise if consent is pending", () => {
-    subject.pending();
-    eventWithConsent();
-    return promisesAre([PENDING]);
-  });
 });

--- a/test/unit/specs/core/consent/createConsentStateMachine.spec.js
+++ b/test/unit/specs/core/consent/createConsentStateMachine.spec.js
@@ -13,76 +13,152 @@ governing permissions and limitations under the License.
 import createConsentStateMachine from "../../../../../src/core/consent/createConsentStateMachine";
 import flushPromiseChains from "../../../helpers/flushPromiseChains";
 
-const DECLINED_CONSENT_ERROR_CODE = "declinedConsent";
-
 describe("createConsentStateMachine", () => {
+  let events;
+  let promises;
   let subject;
 
+  const RESOLVED = "resolved";
+  const PENDING = "pending";
+  const REJECTED = "rejected";
+  const promisesAre = expected => {
+    const state = promises.map((promise, i) => {
+      promise.then(
+        () => {
+          state[i] = RESOLVED;
+        },
+        () => {
+          state[i] = REJECTED;
+        }
+      );
+      return PENDING;
+    });
+    return flushPromiseChains().then(() => {
+      expect(state).toEqual(expected);
+    });
+  };
+
+  const createEvent = i => {
+    let hash;
+    return {
+      getConsent() {
+        if (i === undefined) {
+          return undefined;
+        }
+        return { index: i };
+      },
+      mergeMeta({ consentHash }) {
+        hash = consentHash;
+      },
+      getHash() {
+        return hash;
+      }
+    };
+  };
+
+  const setIn = hash => subject.in(hash);
+  const setOut = hash => subject.out(hash);
+  const eventWithNoConsent = () => {
+    const event = createEvent();
+    events.push(event);
+    promises.push(subject.awaitConsent(event));
+  };
+  const eventWithConsent = i => {
+    const event = createEvent(i);
+    events.push(event);
+    promises.push(subject.awaitConsent(event));
+  };
+
   beforeEach(() => {
+    events = [];
+    promises = [];
     subject = createConsentStateMachine();
+  });
+
+  it("sends an event when defaultConsent is in and request doesn't have consent", () => {
+    setIn();
+    eventWithNoConsent();
+    expect(events[0].getHash()).toBeUndefined();
+    return promisesAre([RESOLVED]);
+  });
+
+  it("sends an event when defaultConsent is in and request has consent", () => {
+    setIn();
+    eventWithConsent(1);
+    expect(events[0].getHash()).toBeDefined();
+    return promisesAre([RESOLVED]);
+  });
+
+  it("sends an event when defaultConsent is out and request has consent", () => {
+    setOut();
+    eventWithConsent(1);
+    expect(events[0].getHash()).toBeDefined();
+    return promisesAre([RESOLVED]);
+  });
+
+  it("sends an event when defaultConsent is out and request has consent", () => {
+    setOut();
+    eventWithNoConsent();
+    expect(events[0].getHash()).toBeUndefined();
+    return promisesAre([REJECTED]);
+  });
+
+  it("waits for a cookie before resuming requests", () => {
+    setIn();
+    eventWithConsent(1);
+    eventWithConsent(1);
+    return promisesAre([RESOLVED, PENDING]);
+  });
+
+  it("resumes requests", () => {
+    setIn();
+    eventWithConsent(1);
+    eventWithConsent(1);
+    setIn(events[0].getHash());
+    return promisesAre([RESOLVED, RESOLVED]);
+  });
+
+  it("doesn't wait when consent is the same", () => {
+    setIn();
+    eventWithConsent(1);
+    setIn(events[0].getHash());
+    eventWithConsent(1);
+    eventWithConsent(1);
+    return promisesAre([RESOLVED, RESOLVED, RESOLVED]);
+  });
+
+  it("doesn't send requests when the consent is the same or undefined", () => {
+    setOut();
+    eventWithConsent(1);
+    eventWithConsent(1);
+    eventWithConsent();
+    setOut(events[0].getHash());
+    eventWithConsent(1);
+    eventWithConsent();
+    return promisesAre([RESOLVED, REJECTED, REJECTED, REJECTED, REJECTED]);
+  });
+
+  it("sends a request when the consent is different", () => {
+    setOut();
+    eventWithConsent(1);
+    setOut(events[0].getHash());
+    eventWithConsent(2);
+    eventWithConsent();
+    return promisesAre([RESOLVED, RESOLVED, PENDING]);
+  });
+
+  it("sends a request when the consent is different and event is queued", () => {
+    setOut();
+    eventWithConsent(1);
+    eventWithConsent(2);
+    eventWithConsent();
+    setOut(events[0].getHash());
+    return promisesAre([RESOLVED, RESOLVED, PENDING]);
   });
 
   it("does not resolve promise if consent is pending", () => {
     subject.pending();
-    const onFulfilled = jasmine.createSpy("onFulfilled");
-    subject.awaitConsent().then(onFulfilled);
-
-    return flushPromiseChains().then(() => {
-      expect(onFulfilled).not.toHaveBeenCalled();
-    });
-  });
-
-  it("resolves promise if user consented to all purposes", () => {
-    subject.in();
-    const onFulfilled = jasmine.createSpy("onFulfilled");
-    subject.awaitConsent().then(onFulfilled);
-
-    return flushPromiseChains().then(() => {
-      expect(onFulfilled).toHaveBeenCalled();
-    });
-  });
-
-  it("rejects promise if user consented to no purposes", () => {
-    subject.out();
-    const onRejected = jasmine.createSpy("onRejected");
-    subject.awaitConsent().catch(onRejected);
-
-    return flushPromiseChains().then(() => {
-      const error = onRejected.calls.argsFor(0)[0];
-      expect(error.code).toBe(DECLINED_CONSENT_ERROR_CODE);
-    });
-  });
-
-  it("resolves queued promises when consent set to in", () => {
-    subject.pending();
-    const onFulfilled = jasmine.createSpy("onFulfilled");
-    subject.awaitConsent().then(onFulfilled);
-
-    return flushPromiseChains()
-      .then(() => {
-        expect(onFulfilled).not.toHaveBeenCalled();
-        subject.in();
-        return flushPromiseChains();
-      })
-      .then(() => {
-        expect(onFulfilled).toHaveBeenCalled();
-      });
-  });
-
-  it("rejects queued promises when consent set to out", () => {
-    subject.pending();
-    const onRejected = jasmine.createSpy("onRejected");
-    subject.awaitConsent().catch(onRejected);
-
-    return flushPromiseChains()
-      .then(() => {
-        expect(onRejected).not.toHaveBeenCalled();
-        subject.out();
-        return flushPromiseChains();
-      })
-      .then(() => {
-        const error = onRejected.calls.argsFor(0)[0];
-        expect(error.code).toBe(DECLINED_CONSENT_ERROR_CODE);
-      });
+    eventWithConsent();
+    return promisesAre([PENDING]);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is a proof of concept to find any problems with the idea of removing the need for the setConsent call. This PR changes Alloy to support only two default consents ("in", and "out"). When consent is out, only events that have different consents are sent to experience edge. While an event with different consent is outstanding, other requests are held up. When Alloy detects a consent change, it passes the new consent hash under the meta key. Alloy expects this hash to be written to the consent cookie.

## Related Issue

https://jira.corp.adobe.com/browse/CORE-54518
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

With Safari's newest security change cookies set from a CNAME domain are only allowed to last for 7 days. Currently we are telling customers to call setConsent only when the consent changes, but if the consent cookie expires, Alloy will not know what the current consent level is. If consent is always passed in through the event XDM, Alloy can determine when it needs to get a refreshed consent cookie from conductor.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
