### PR TITLE
Konductor responds with RFC 7807 for fatal errors

### DIFF
--- a/test/functional/specs/Privacy/C14410.js
+++ b/test/functional/specs/Privacy/C14410.js
@@ -56,7 +56,11 @@ test("Test C14410: Setting consent for unknown purposes fails", async t => {
     .ok("Expected the setConsent command to be rejected");
   await t
     .expect(errorMessage)
-    .contains("The server responded with the following errors");
+    .contains("Unexpected server response with status code 400")
+    .expect(errorMessage)
+    .contains(
+      "Invalid request. The value supplied for field 'consent.[0].value' does not match your input schema"
+    );
 
   // make sure we can call it again with the correct values
   await t.eval(() => {

--- a/test/functional/specs/Privacy/IAB/C224675.js
+++ b/test/functional/specs/Privacy/IAB/C224675.js
@@ -55,7 +55,11 @@ test("Test C224675: Passing invalid consent options should throw a validation er
 
   await t
     .expect(errorMessageForInvalidStandard)
-    .contains("The server responded with the following errors");
+    .contains("Unexpected server response with status code 400")
+    .expect(errorMessageForInvalidStandard)
+    .contains(
+      "The value supplied for field 'consent.[0]' does not match your input schema"
+    );
 
   await t.expect(errorMessageForInvalidStandard).contains("EXEG-0102-400");
 
@@ -75,15 +79,11 @@ test("Test C224675: Passing invalid consent options should throw a validation er
 
   await t
     .expect(errorMessageForInvalidVersion)
-    .contains("The server responded with the following errors");
-
-  // TODO: The error message below is not consistent with the way `standard` is being validated.
-  // Discussed it with the Konductor team, they will re-work it.
-  // https://jira.corp.adobe.com/browse/EXEG-1961
-  await t
+    .contains("Unexpected server response with status code 422")
     .expect(errorMessageForInvalidVersion)
-    // TODO: log ticket - Konductor error just says "Invalid request"
-    .contains("EXEG-0104-422");
+    .contains("Allowed IAB version is 2.0 for standard 'IAB TCF' at index 0");
+
+  await t.expect(errorMessageForInvalidVersion).contains("EXEG-0104-422");
 
   const errorMessageForInvalidValue = await getErrorMessageFromSetConsent({
     consent: [
@@ -100,10 +100,12 @@ test("Test C224675: Passing invalid consent options should throw a validation er
 
   await t
     .expect(errorMessageForInvalidValue)
-    .contains("The server responded with the following errors");
+    .contains("Unexpected server response with status code 400")
+    .expect(errorMessageForInvalidValue)
+    .contains(
+      "Invalid request. No value supplied for field 'consent.[0].value'"
+    );
 
-  // TODO: The error message below is not consistent with the way `standard` is being validated.
-  // Discussed it with the Konductor team, they will re-work it.
   await t.expect(errorMessageForInvalidValue).contains("EXEG-0103-400");
 
   const errorMessageForEmptyValue = await getErrorMessageFromSetConsent({
@@ -122,9 +124,11 @@ test("Test C224675: Passing invalid consent options should throw a validation er
 
   await t
     .expect(errorMessageForEmptyValue)
-    .contains("The server responded with the following errors");
+    .contains("Unexpected server response with status code 422")
+    .expect(errorMessageForEmptyValue)
+    .contains(
+      "IAB consent string value must not be empty for standard 'IAB TCF' at index 0"
+    );
 
-  // TODO: The error message below is not consistent with the way `standard` is being validated.
-  // Discussed it with the Konductor team, they will re-work it.
   await t.expect(errorMessageForEmptyValue).contains("EXEG-0104-422");
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Fixed tests to properly assert the new error response
- Opt-out is no longer considered an error (is a warning)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Updates test asserts to comply with upcoming Konductor changes.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
