### PR TITLE
HOLD: CORE-56247 Encoding web.webpageDetails.URL and web.webReferrer.URL to conform with URI spec.

### DIFF
--- a/src/components/Context/injectWeb.js
+++ b/src/components/Context/injectWeb.js
@@ -12,14 +12,20 @@ governing permissions and limitations under the License.
 
 import { deepAssign } from "../../utils";
 
+// URLs reported by browser APIs may not be URI-compliant because browsers are more lenient
+// than the URI RFC (https://tools.ietf.org/html/rfc3986). The XDM fields we're populating,
+// however, should conform to the URI spec. For this reason, we need to encode the URL.
+// We decode the URL first so it doesn't end up double encoded if it was previously encoded.
+const encode = url => encodeURI(decodeURI(url));
+
 export default window => {
   return xdm => {
     const web = {
       webPageDetails: {
-        URL: window.location.href || window.location
+        URL: encode(window.location.href || window.location)
       },
       webReferrer: {
-        URL: window.document.referrer
+        URL: encode(window.document.referrer)
       }
     };
     deepAssign(xdm, { web });

--- a/test/unit/specs/components/Context/injectWeb.spec.js
+++ b/test/unit/specs/components/Context/injectWeb.spec.js
@@ -1,23 +1,43 @@
 import injectWeb from "../../../../../src/components/Context/injectWeb";
 
-describe("Context::injectWeb", () => {
-  const window = {
-    location: { href: "http://mylocation.com" },
-    document: {
-      referrer: "http://myreferrer.com"
-    }
-  };
-
+fdescribe("Context::injectWeb", () => {
   it("works", () => {
+    const window = {
+      location: { href: "http://mylocation.com?campaign=123|456" },
+      document: {
+        referrer: "http://myreferrer.com?product=123|456"
+      }
+    };
     const xdm = {};
     injectWeb(window)(xdm);
     expect(xdm).toEqual({
       web: {
         webPageDetails: {
-          URL: "http://mylocation.com"
+          URL: "http://mylocation.com?campaign=123%7C456"
         },
         webReferrer: {
-          URL: "http://myreferrer.com"
+          URL: "http://myreferrer.com?product=123%7C456"
+        }
+      }
+    });
+  });
+
+  it("does not double encode URLs", () => {
+    const window = {
+      location: { href: "http://mylocation.com?campaign=123%7C456" },
+      document: {
+        referrer: "http://myreferrer.com?product=123%7C456"
+      }
+    };
+    const xdm = {};
+    injectWeb(window)(xdm);
+    expect(xdm).toEqual({
+      web: {
+        webPageDetails: {
+          URL: "http://mylocation.com?campaign=123%7C456"
+        },
+        webReferrer: {
+          URL: "http://myreferrer.com?product=123%7C456"
         }
       }
     });

--- a/test/unit/specs/components/Context/injectWeb.spec.js
+++ b/test/unit/specs/components/Context/injectWeb.spec.js
@@ -1,6 +1,6 @@
 import injectWeb from "../../../../../src/components/Context/injectWeb";
 
-fdescribe("Context::injectWeb", () => {
+describe("Context::injectWeb", () => {
   it("works", () => {
     const window = {
       location: { href: "http://mylocation.com?campaign=123|456" },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
URLs reported by browser APIs may not be URI-compliant because browsers are more lenient than the [URI RFC](https://tools.ietf.org/html/rfc3986). The XDM fields we're populating, however, should conform to the URI spec. For this reason, we need to encode the URL.  We decode the URL first so it doesn't end up double encoded if it was previously encoded.

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CORE-56247
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Ingestion would fail when non-URI complaint URLs were encountered.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
