### PR TITLE
Update test to match Konductor error messages

### DIFF
--- a/test/functional/specs/Privacy/IAB/C224675.js
+++ b/test/functional/specs/Privacy/IAB/C224675.js
@@ -58,7 +58,7 @@ test("Test C224675: Passing invalid consent options should throw a validation er
     .contains("Unexpected server response with status code 400")
     .expect(errorMessageForInvalidStandard)
     .contains(
-      "The value supplied for field 'consent.[0]' does not match your input schema"
+      "The value supplied for field 'consent[0]' does not match your input schema"
     );
 
   await t.expect(errorMessageForInvalidStandard).contains("EXEG-0102-400");
@@ -79,11 +79,13 @@ test("Test C224675: Passing invalid consent options should throw a validation er
 
   await t
     .expect(errorMessageForInvalidVersion)
-    .contains("Unexpected server response with status code 422")
+    .contains("Unexpected server response with status code 400")
     .expect(errorMessageForInvalidVersion)
-    .contains("Allowed IAB version is 2.0 for standard 'IAB TCF' at index 0");
+    .contains(
+      "The value supplied for field 'consent[0]' does not match your input schema"
+    );
 
-  await t.expect(errorMessageForInvalidVersion).contains("EXEG-0104-422");
+  await t.expect(errorMessageForInvalidVersion).contains("EXEG-0102-400");
 
   const errorMessageForInvalidValue = await getErrorMessageFromSetConsent({
     consent: [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Noticed this test failure while working on the npmLibrary changes. Looks like Konductor changed the format of some of their error messages.

## Related Issue

None
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Reviewing the failures the changes are reasonable.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
