### PR TITLE
Personalization is rejecting an uncatchable promise

### DIFF
--- a/src/components/Personalization/createExecuteCachedViewDecisions.js
+++ b/src/components/Personalization/createExecuteCachedViewDecisions.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { isNonEmptyArray, isNonEmptyString } from "../../utils";
+import { isNonEmptyArray } from "../../utils";
 
 export default ({ viewCache, executeViewDecisions, collect }) => {
   return ({ viewName }) => {
@@ -19,12 +19,9 @@ export default ({ viewCache, executeViewDecisions, collect }) => {
         executeViewDecisions(viewDecisions);
         return;
       }
+      const xdm = { web: { webPageDetails: { viewName } } };
 
-      if (isNonEmptyString(viewName)) {
-        const xdm = { web: { webPageDetails: { viewName } } };
-
-        collect({ meta: {}, xdm });
-      }
+      collect({ meta: {}, xdm });
     });
   };
 };

--- a/src/components/Personalization/createExecuteCachedViewDecisions.js
+++ b/src/components/Personalization/createExecuteCachedViewDecisions.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { isNonEmptyArray } from "../../utils";
+import isNonEmptyArray from "../../utils/isNonEmptyArray";
 
 export default ({ viewCache, executeViewDecisions, collect }) => {
   return ({ viewName }) => {

--- a/src/components/Personalization/createExecuteCachedViewDecisions.js
+++ b/src/components/Personalization/createExecuteCachedViewDecisions.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import isNonEmptyArray from "../../utils/isNonEmptyArray";
+import { isNonEmptyArray, isNonEmptyString } from "../../utils";
 
 export default ({ viewCache, executeViewDecisions, collect }) => {
   return ({ viewName }) => {
@@ -19,9 +19,12 @@ export default ({ viewCache, executeViewDecisions, collect }) => {
         executeViewDecisions(viewDecisions);
         return;
       }
-      const xdm = { web: { webPageDetails: { viewName } } };
 
-      collect({ meta: {}, xdm });
+      if (isNonEmptyString(viewName)) {
+        const xdm = { web: { webPageDetails: { viewName } } };
+
+        collect({ meta: {}, xdm });
+      }
     });
   };
 };

--- a/src/components/Personalization/createPersonalizationDetails.js
+++ b/src/components/Personalization/createPersonalizationDetails.js
@@ -18,6 +18,7 @@ import {
   JSON_CONTENT_ITEM,
   REDIRECT_ITEM
 } from "./constants/schema";
+import isNonEmptyString from "../../utils/isNonEmptyString";
 
 export default ({ renderDecisions, decisionScopes, event, viewCache }) => {
   const viewName = event.getViewName();
@@ -32,7 +33,7 @@ export default ({ renderDecisions, decisionScopes, event, viewCache }) => {
       return decisionScopes.length > 0;
     },
     hasViewName() {
-      return viewName !== undefined;
+      return isNonEmptyString(viewName);
     },
     createQueryDetails() {
       const scopes = [...decisionScopes];

--- a/src/components/Personalization/createViewCacheManager.js
+++ b/src/components/Personalization/createViewCacheManager.js
@@ -18,13 +18,17 @@ export default () => {
   const viewStorageDeferred = defer();
 
   const storeViews = decisionsPromise => {
-    decisionsPromise.then(decisions => {
-      if (viewStorage === undefined) {
-        viewStorage = {};
-      }
-      assign(viewStorage, decisions);
-      viewStorageDeferred.resolve();
-    });
+    decisionsPromise
+      .then(decisions => {
+        if (viewStorage === undefined) {
+          viewStorage = {};
+        }
+        assign(viewStorage, decisions);
+        viewStorageDeferred.resolve();
+      })
+      .catch(() => {
+        viewStorageDeferred.resolve();
+      });
   };
 
   const getView = viewName => {

--- a/test/unit/specs/components/Personalization/createPersonalizationDetails.spec.js
+++ b/test/unit/specs/components/Personalization/createPersonalizationDetails.spec.js
@@ -280,4 +280,17 @@ describe("Personalization::createPersonalizationDetails", () => {
     expect(personalizationDetails.shouldFetchData()).toEqual(true);
     expect(personalizationDetails.hasViewName()).toEqual(true);
   });
+  it("hasViewName should return false when viewName is empty", () => {
+    const decisionScopes = [];
+    const renderDecisions = true;
+    event.getViewName.and.returnValue("");
+    const personalizationDetails = createPersonalizationDetails({
+      renderDecisions,
+      decisionScopes,
+      event,
+      viewCache
+    });
+    expect(personalizationDetails.isRenderDecisions()).toEqual(true);
+    expect(personalizationDetails.hasViewName()).toEqual(false);
+  });
 });

--- a/test/unit/specs/components/Personalization/createViewCacheManager.spec.js
+++ b/test/unit/specs/components/Personalization/createViewCacheManager.spec.js
@@ -14,6 +14,8 @@ import createViewCacheManager from "../../../../../src/components/Personalizatio
 import { defer } from "../../../../../src/utils";
 
 describe("Personalization::createCacheManager", () => {
+  const cartView = "cart";
+  const homeView = "home";
   const viewDecisions = {
     home: [
       {
@@ -38,16 +40,27 @@ describe("Personalization::createCacheManager", () => {
 
   it("stores and gets the decisions based on a viewName", () => {
     const viewCacheManager = createViewCacheManager();
-
     const decisionsDeferred = defer();
+
     viewCacheManager.storeViews(decisionsDeferred.promise);
     decisionsDeferred.resolve(viewDecisions);
 
-    viewCacheManager.getView("cart").then(decisions => {
-      expect(decisions.length).toEqual(1);
-    });
-    viewCacheManager.getView("home").then(decisions => {
-      expect(decisions.length).toEqual(2);
-    });
+    expectAsync(viewCacheManager.getView(cartView)).toBeResolvedTo(
+      viewDecisions[cartView]
+    );
+
+    expectAsync(viewCacheManager.getView(homeView)).toBeResolvedTo(
+      viewDecisions[homeView]
+    );
+  });
+
+  it("should be no views when decisions deferred is rejected", () => {
+    const viewCacheManager = createViewCacheManager();
+    const decisionsDeferred = defer();
+
+    viewCacheManager.storeViews(decisionsDeferred.promise);
+    decisionsDeferred.reject();
+
+    expectAsync(viewCacheManager.getView("cart")).toBeResolvedTo(undefined);
   });
 });

--- a/test/unit/specs/utils/isNonEmptyString.spec.js
+++ b/test/unit/specs/utils/isNonEmptyString.spec.js
@@ -20,4 +20,8 @@ describe("isNonEmptyString", () => {
   it("returns false when empty string", () => {
     expect(isNonEmptyString("")).toBe(false);
   });
+
+  it("returns false when undefined string", () => {
+    expect(isNonEmptyString(undefined)).toBe(false);
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
We'll resolve the `viewStorageDeferred` promise when the request has failed. When we call the `getView` and the promise has been fulfilled we will just return whatever we have in cache already or `undefined`.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
