### PR TITLE
Fixes problem where reloadPage would result in local storage being cl…

### DIFF
--- a/test/functional/helpers/reloadPage.js
+++ b/test/functional/helpers/reloadPage.js
@@ -12,6 +12,26 @@ governing permissions and limitations under the License.
 
 import { t, ClientFunction } from "testcafe";
 
+const getLocalStorageEntries = ClientFunction(() => {
+  const entries = Object.keys(window.localStorage)
+    // It seems that TestCafe modifies localStorage in such a way that
+    // Object.keys() returns not just the entry names, but also some methods,
+    // so we have to filter down to only those keys that are actual
+    // storage entries.
+    .filter(key => localStorage.getItem(key) !== null)
+    .reduce((memo, entryName) => {
+      memo[entryName] = localStorage[entryName];
+      return memo;
+    }, {});
+  return entries;
+});
+
+const setLocalStorageEntries = ClientFunction(entries => {
+  Object.keys(entries).forEach(entryName => {
+    localStorage.setItem(entryName, entries[entryName]);
+  });
+});
+
 const getCurrentUrl = ClientFunction(() => {
   return document.location.href;
 });
@@ -21,9 +41,15 @@ export default async () => {
   // navigateTo waits for the server to respond after a redirect occurs,
   // which is why we use it instead of just calling document.location.reload()
   // in our client function.
-  // We have to navigate to a different page and then back to the current page,
+  // TestCafe + Safari have an issue where local storage is cleared when using
+  // t.navigateTo(), which is why we have to retrieve local storage entries
+  // and then restore them after navigation.
+  // https://github.com/DevExpress/testcafe/issues/5992
+  // Also, we have to navigate to a different page and then back to the current page,
   // because if we just tried to navigate to the same page we're on, TestCafe
-  // would hang.
+  // would hang in Safari (at least).
+  const localStorageEntries = await getLocalStorageEntries();
   await t.navigateTo("blank.html");
   await t.navigateTo(currentUrl);
+  await setLocalStorageEntries(localStorageEntries);
 };


### PR DESCRIPTION
…eared.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Supersedes https://github.com/adobe/alloy/pull/670. There appears to be a bug in TestCafe (https://github.com/DevExpress/testcafe/issues/5992) where using `t.navigateTo` in Safari clears local storage. We use `t.navigateTo` to reload the current page, so this bug was causing tests to fail. As a workound, this PR retrieves local storage entries before navigating, then restores local storage entries after navigation.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Tests passing in Safari!
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
