### PR TITLE
Rename instanceName parameter inside the createInstance NPM package function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,19 +25,16 @@ const createNamespacedStorage = injectStorage(window);
 // eslint-disable-next-line no-underscore-dangle
 const defaultGetMonitors = () => window.__alloyMonitors || [];
 
-export const createInstance = ({
-  instanceName,
-  getMonitors = defaultGetMonitors
-}) => {
+export const createInstance = ({ name, getMonitors = defaultGetMonitors }) => {
   const logController = createLogController({
     console,
     locationSearch: window.location.search,
     createLogger,
-    instanceName,
+    instanceName: name,
     createNamespacedStorage,
     getMonitors
   });
-  const instance = createExecuteCommand({ instanceName, logController });
+  const instance = createExecuteCommand({ instanceName: name, logController });
   logController.logger.logOnInstanceCreated({ instance });
   return instance;
 };

--- a/test/functional/specs/Install SDK/C1338399.js
+++ b/test/functional/specs/Install SDK/C1338399.js
@@ -26,7 +26,7 @@ createFixture({
 
 const createAlloyInstance = ClientFunction(() => {
   window.npmLibraryAlloy = window.alloyCreateInstance({
-    instanceName: "npmLibraryAlloy"
+    name: "npmLibraryAlloy"
   });
 });
 


### PR DESCRIPTION

## Description

Having to call createInstance({ instanceName: "alloy"}) is a little redundant. This PR changes it to be createInstance({ name: "alloy" })

## Related Issue

https://github.com/adobe/reactor-extension-alloy/pull/120#pullrequestreview-596516702

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
