### PR TITLE
Add build to prod workflow so it will build dist/baseCode.js

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -24,6 +24,8 @@ jobs:
       - name: Install dependencies
         if: steps.npm-cache.outputs.cache-hit != 'true'
         run: npm ci
+      - name: Build
+        run: npm run test:functional:ci:build
       - name: 'BrowserStack Env Setup'
         uses: 'browserstack/github-actions/setup-env@master'
         with:


### PR DESCRIPTION

The prod workflow tests use dist/baseCode.js in their tests, and are failing because it is not there. The build step builds this file.
