### PR TITLE
Properly handle undefined and null in merging methods.

### DIFF
--- a/src/core/createEvent.js
+++ b/src/core/createEvent.js
@@ -39,15 +39,21 @@ export default () => {
     },
     mergeXdm(xdm) {
       throwIfEventFinalized("mergeXdm");
-      deepAssign(content, { xdm });
+      if (xdm) {
+        deepAssign(content, { xdm });
+      }
     },
     mergeMeta(meta) {
       throwIfEventFinalized("mergeMeta");
-      deepAssign(content, { meta });
+      if (meta) {
+        deepAssign(content, { meta });
+      }
     },
     mergeQuery(query) {
       throwIfEventFinalized("mergeQuery");
-      deepAssign(content, { query });
+      if (query) {
+        deepAssign(content, { query });
+      }
     },
     documentMayUnload() {
       documentMayUnload = true;

--- a/test/unit/specs/core/createEvent.spec.js
+++ b/test/unit/specs/core/createEvent.spec.js
@@ -36,6 +36,8 @@ describe("createEvent", () => {
         type: "basketball"
       }
     });
+    event.mergeXdm();
+    event.mergeXdm(null);
     event.mergeXdm({
       sport: {
         type: "football"
@@ -138,6 +140,8 @@ describe("createEvent", () => {
         type: "clue"
       }
     });
+    event.mergeMeta();
+    event.mergeMeta(null);
     event.finalize();
     expect(event.toJSON()).toEqual({
       meta: {
@@ -171,6 +175,8 @@ describe("createEvent", () => {
         type: "clue"
       }
     });
+    event.mergeQuery();
+    event.mergeQuery(null);
     event.finalize();
     expect(event.toJSON()).toEqual({
       query: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When something called `event.mergeXdm`, `event.mergeMeta`, or `event.mergeQuery` with `undefined` or `null` (this would happen in Personalization), it would wipe out the previous state. Instead, we want to make these method calls a no-op.
<!--- Describe your changes in detail -->

## Related Issue
None
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Ensure that we get the expected merge result.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
