### PR TITLE
PDCL-4595 fix "Unknown consent value: undefined" warning

### DIFF
--- a/src/components/Privacy/createComponent.js
+++ b/src/components/Privacy/createComponent.js
@@ -44,7 +44,7 @@ export default ({
       const storedConsentObject = storedConsent.read();
       // Only read cookies when there are no outstanding setConsent
       // requests. This helps with race conditions.
-      if (storedConsentObject) {
+      if (storedConsentObject[GENERAL] !== undefined) {
         consent.setConsent(storedConsentObject);
       }
     }

--- a/test/unit/specs/components/Privacy/createComponent.spec.js
+++ b/test/unit/specs/components/Privacy/createComponent.spec.js
@@ -256,4 +256,18 @@ describe("privacy:createComponent", () => {
     expect(consentHashStore.clear).toHaveBeenCalled();
     expect(storedConsent.clear).not.toHaveBeenCalled();
   });
+
+  it("doesn't call setConsent when there is no cookie after onResponse", () => {
+    clearConsentCookie();
+    build();
+    component.lifecycle.onResponse();
+    expect(consent.setConsent).not.toHaveBeenCalled();
+  });
+
+  it("doesn't call setConsent when there is no cookie after onRequestFailure", () => {
+    clearConsentCookie();
+    build();
+    component.lifecycle.onRequestFailure();
+    expect(consent.setConsent).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As part of the consent changes, I changed the code that reads the consent cookie to always return an object. Before, if the cookie wasn't there, it returned undefined. There was a guard in the Privacy component that checked the cookie for undefined. This PR changes that guard to check for the "general" property of the parsed consent cookie.

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-4595

## Motivation and Context

Before this change a warning was logged to the console when the request was canceled or returned without setting a consent cookie.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
