### PR TITLE
PDCL-4210 - fixing the click storage not to have duplicates

### DIFF
--- a/src/components/Personalization/createClickStorage.js
+++ b/src/components/Personalization/createClickStorage.js
@@ -10,6 +10,15 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+const metasToArray = metas => {
+  return Object.keys(metas).map(key => {
+    return {
+      id: key,
+      scope: metas[key]
+    };
+  });
+};
+
 export default () => {
   const clickStorage = {};
 
@@ -20,8 +29,20 @@ export default () => {
     clickStorage[value.selector][value.meta.id] = value.meta.scope;
   };
 
+  const getClickSelectors = () => {
+    return Object.keys(clickStorage);
+  };
+
+  const getClickMetasBySelector = selector => {
+    const metas = clickStorage[selector];
+    if (!metas) {
+      return {};
+    }
+    return metasToArray(clickStorage[selector]);
+  };
   return {
     store,
-    clickStorage
+    getClickSelectors,
+    getClickMetasBySelector
   };
 };

--- a/src/components/Personalization/createClickStorage.js
+++ b/src/components/Personalization/createClickStorage.js
@@ -22,7 +22,7 @@ const metasToArray = metas => {
 export default () => {
   const clickStorage = {};
 
-  const store = value => {
+  const storeClickMetrics = value => {
     if (!clickStorage[value.selector]) {
       clickStorage[value.selector] = {};
     }
@@ -41,7 +41,7 @@ export default () => {
     return metasToArray(clickStorage[selector]);
   };
   return {
-    store,
+    storeClickMetrics,
     getClickSelectors,
     getClickMetasBySelector
   };

--- a/src/components/Personalization/createClickStorage.js
+++ b/src/components/Personalization/createClickStorage.js
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+export default () => {
+  const clickStorage = {};
+
+  const store = value => {
+    if (!clickStorage[value.selector]) {
+      clickStorage[value.selector] = {};
+    }
+    clickStorage[value.selector][value.meta.id] = value.meta.scope;
+  };
+
+  return {
+    store,
+    clickStorage
+  };
+};

--- a/src/components/Personalization/createOnClickHandler.js
+++ b/src/components/Personalization/createOnClickHandler.js
@@ -12,14 +12,26 @@ governing permissions and limitations under the License.
 
 import { isNonEmptyArray } from "../../utils";
 
-export default ({ mergeDecisionsMeta, collectClicks, clickStorage }) => {
+export default ({
+  mergeDecisionsMeta,
+  collectClicks,
+  getClickSelectors,
+  getClickMetasBySelector
+}) => {
   // Called when an element qualifying for conversion within an offer is clicked.
   return ({ event, clickedElement }) => {
-    const decisionsMeta = collectClicks(clickedElement, clickStorage);
+    const selectors = getClickSelectors();
+    if (isNonEmptyArray(selectors)) {
+      const decisionsMeta = collectClicks(
+        clickedElement,
+        selectors,
+        getClickMetasBySelector
+      );
 
-    if (isNonEmptyArray(decisionsMeta)) {
-      event.mergeXdm({ eventType: "click" });
-      mergeDecisionsMeta(event, decisionsMeta);
+      if (isNonEmptyArray(decisionsMeta)) {
+        event.mergeXdm({ eventType: "click" });
+        mergeDecisionsMeta(event, decisionsMeta);
+      }
     }
   };
 };

--- a/src/components/Personalization/dom-actions/clicks/collectClicks.js
+++ b/src/components/Personalization/dom-actions/clicks/collectClicks.js
@@ -12,14 +12,21 @@ governing permissions and limitations under the License.
 
 import matchesSelectorWithEq from "../dom/matchesSelectorWithEq";
 
-const getMetaIfMatches = (clickedElement, value) => {
+const metasToArray = metas => {
+  return Object.keys(metas).map(key => {
+    return {
+      id: key,
+      scope: metas[key]
+    };
+  });
+};
+const getMetasIfMatches = (clickedElement, selector, metas) => {
   const { documentElement } = document;
-  const { selector, meta } = value;
   let element = clickedElement;
 
   while (element && element !== documentElement) {
     if (matchesSelectorWithEq(selector, element)) {
-      return meta;
+      return metasToArray(metas);
     }
 
     element = element.parentNode;
@@ -34,12 +41,16 @@ export default (clickedElement, values) => {
   }
 
   const result = [];
+  const selectors = Object.keys(values);
+  for (let i = 0; i < selectors.length; i += 1) {
+    const metas = getMetasIfMatches(
+      clickedElement,
+      selectors[i],
+      values[selectors[i]]
+    );
 
-  for (let i = 0; i < values.length; i += 1) {
-    const meta = getMetaIfMatches(clickedElement, values[i]);
-
-    if (meta) {
-      result.push(meta);
+    if (metas) {
+      result.push(...metas);
     }
   }
 

--- a/src/components/Personalization/dom-actions/clicks/collectClicks.js
+++ b/src/components/Personalization/dom-actions/clicks/collectClicks.js
@@ -12,21 +12,17 @@ governing permissions and limitations under the License.
 
 import matchesSelectorWithEq from "../dom/matchesSelectorWithEq";
 
-const metasToArray = metas => {
-  return Object.keys(metas).map(key => {
-    return {
-      id: key,
-      scope: metas[key]
-    };
-  });
-};
-const getMetasIfMatches = (clickedElement, selector, metas) => {
+const getMetasIfMatches = (
+  clickedElement,
+  selector,
+  getClickMetasBySelector
+) => {
   const { documentElement } = document;
   let element = clickedElement;
 
   while (element && element !== documentElement) {
     if (matchesSelectorWithEq(selector, element)) {
-      return metasToArray(metas);
+      return getClickMetasBySelector(selector);
     }
 
     element = element.parentNode;
@@ -35,18 +31,13 @@ const getMetasIfMatches = (clickedElement, selector, metas) => {
   return null;
 };
 
-export default (clickedElement, values) => {
-  if (values.length === 0) {
-    return [];
-  }
-
+export default (clickedElement, selectors, getClickMetasBySelector) => {
   const result = [];
-  const selectors = Object.keys(values);
   for (let i = 0; i < selectors.length; i += 1) {
     const metas = getMetasIfMatches(
       clickedElement,
       selectors[i],
-      values[selectors[i]]
+      getClickMetasBySelector
     );
 
     if (metas) {

--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -32,7 +32,11 @@ import createClickStorage from "./createClickStorage";
 const createPersonalization = ({ config, logger, eventManager }) => {
   const collect = createCollect({ eventManager, mergeDecisionsMeta });
   const viewCollect = createViewCollect({ eventManager, mergeDecisionsMeta });
-  const clickStorage = [];
+  const {
+    getClickMetasBySelector,
+    getClickSelectors,
+    store
+  } = createClickStorage();
   const viewCache = createViewCacheManager();
   const modules = initDomActionsModules(store);
   const executeDecisions = createExecuteDecisions({
@@ -68,7 +72,8 @@ const createPersonalization = ({ config, logger, eventManager }) => {
   const onClickHandler = createOnClickHandler({
     mergeDecisionsMeta,
     collectClicks,
-    clickStorage
+    getClickSelectors,
+    getClickMetasBySelector
   });
   const viewChangeHandler = createViewChangeHandler({
     executeCachedViewDecisions,

--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -27,13 +27,13 @@ import createViewCacheManager from "./createViewCacheManager";
 import createViewChangeHandler from "./createViewChangeHandler";
 import decisionsExtractor from "./decisionsExtractor";
 import createOnResponseHandler from "./createOnResponseHandler";
+import createClickStorage from "./createClickStorage";
 
 const createPersonalization = ({ config, logger, eventManager }) => {
   const collect = createCollect({ eventManager, mergeDecisionsMeta });
   const viewCollect = createViewCollect({ eventManager, mergeDecisionsMeta });
   const clickStorage = [];
   const viewCache = createViewCacheManager();
-  const store = value => clickStorage.push(value);
   const modules = initDomActionsModules(store);
   const executeDecisions = createExecuteDecisions({
     modules,

--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -35,10 +35,10 @@ const createPersonalization = ({ config, logger, eventManager }) => {
   const {
     getClickMetasBySelector,
     getClickSelectors,
-    store
+    storeClickMetrics
   } = createClickStorage();
   const viewCache = createViewCacheManager();
-  const modules = initDomActionsModules(store);
+  const modules = initDomActionsModules(storeClickMetrics);
   const executeDecisions = createExecuteDecisions({
     modules,
     logger,

--- a/test/unit/specs/components/Personalization/createClickStorage.spec.js
+++ b/test/unit/specs/components/Personalization/createClickStorage.spec.js
@@ -32,6 +32,7 @@ describe("Personalization::createClickStorage", () => {
     }
   };
 
+  /*  this is how the clickStorage map should look like
   const expectedClicksInStorage = {
     "div:123:h1": {
       "AT:123": "consent"
@@ -40,21 +41,28 @@ describe("Personalization::createClickStorage", () => {
       "AT:123": "consent",
       "AT:234": "consent"
     }
-  };
+  }; */
   beforeEach(() => {
     clickStorageManager = createClickStorage();
   });
 
-  it("initializes the clickStorage with an empty object", () => {
-    expect(clickStorageManager.clickStorage).toEqual({});
+  it("returns empty array if empty storage", () => {
+    expect(clickStorageManager.getClickSelectors()).toEqual([]);
   });
 
-  it("stores clicks as a map in the click storage", () => {
+  it("returns empty object when no metadata for this selector", () => {
+    expect(clickStorageManager.getClickMetasBySelector("123")).toEqual({});
+  });
+
+  it("stores clicks as a map in the click storage and returns the selectors and metadata", () => {
     clickStorageManager.store(FIRST_CLICK);
     clickStorageManager.store(SECOND_CLICK);
     clickStorageManager.store(THIRD_CLICK);
     clickStorageManager.store(FORTH_CLICK);
 
-    expect(clickStorageManager.clickStorage).toEqual(expectedClicksInStorage);
+    expect(clickStorageManager.getClickSelectors().length).toEqual(2);
+    expect(
+      clickStorageManager.getClickMetasBySelector("div:123:h2").length
+    ).toEqual(2);
   });
 });

--- a/test/unit/specs/components/Personalization/createClickStorage.spec.js
+++ b/test/unit/specs/components/Personalization/createClickStorage.spec.js
@@ -1,0 +1,60 @@
+import createClickStorage from "../../../../../src/components/Personalization/createClickStorage";
+
+describe("Personalization::createClickStorage", () => {
+  let clickStorageManager;
+
+  const FIRST_CLICK = {
+    selector: "div:123:h2",
+    meta: {
+      id: "AT:123",
+      scope: "__view__"
+    }
+  };
+  const SECOND_CLICK = {
+    selector: "div:123:h2",
+    meta: {
+      id: "AT:123",
+      scope: "consent"
+    }
+  };
+  const THIRD_CLICK = {
+    selector: "div:123:h2",
+    meta: {
+      id: "AT:234",
+      scope: "consent"
+    }
+  };
+  const FORTH_CLICK = {
+    selector: "div:123:h1",
+    meta: {
+      id: "AT:123",
+      scope: "consent"
+    }
+  };
+
+  const expectedClicksInStorage = {
+    "div:123:h1": {
+      "AT:123": "consent"
+    },
+    "div:123:h2": {
+      "AT:123": "consent",
+      "AT:234": "consent"
+    }
+  };
+  beforeEach(() => {
+    clickStorageManager = createClickStorage();
+  });
+
+  it("initializes the clickStorage with an empty object", () => {
+    expect(clickStorageManager.clickStorage).toEqual({});
+  });
+
+  it("stores clicks as a map in the click storage", () => {
+    clickStorageManager.store(FIRST_CLICK);
+    clickStorageManager.store(SECOND_CLICK);
+    clickStorageManager.store(THIRD_CLICK);
+    clickStorageManager.store(FORTH_CLICK);
+
+    expect(clickStorageManager.clickStorage).toEqual(expectedClicksInStorage);
+  });
+});

--- a/test/unit/specs/components/Personalization/createClickStorage.spec.js
+++ b/test/unit/specs/components/Personalization/createClickStorage.spec.js
@@ -1,7 +1,7 @@
 import createClickStorage from "../../../../../src/components/Personalization/createClickStorage";
 
 describe("Personalization::createClickStorage", () => {
-  let clickStorageManager;
+  let clickStorage;
 
   const FIRST_CLICK = {
     selector: "div:123:h2",
@@ -43,26 +43,26 @@ describe("Personalization::createClickStorage", () => {
     }
   }; */
   beforeEach(() => {
-    clickStorageManager = createClickStorage();
+    clickStorage = createClickStorage();
   });
 
   it("returns empty array if empty storage", () => {
-    expect(clickStorageManager.getClickSelectors()).toEqual([]);
+    expect(clickStorage.getClickSelectors()).toEqual([]);
   });
 
   it("returns empty object when no metadata for this selector", () => {
-    expect(clickStorageManager.getClickMetasBySelector("123")).toEqual({});
+    expect(clickStorage.getClickMetasBySelector("123")).toEqual({});
   });
 
   it("stores clicks as a map in the click storage and returns the selectors and metadata", () => {
-    clickStorageManager.store(FIRST_CLICK);
-    clickStorageManager.store(SECOND_CLICK);
-    clickStorageManager.store(THIRD_CLICK);
-    clickStorageManager.store(FORTH_CLICK);
+    clickStorage.storeClickMetrics(FIRST_CLICK);
+    clickStorage.storeClickMetrics(SECOND_CLICK);
+    clickStorage.storeClickMetrics(THIRD_CLICK);
+    clickStorage.storeClickMetrics(FORTH_CLICK);
 
-    expect(clickStorageManager.getClickSelectors().length).toEqual(2);
-    expect(
-      clickStorageManager.getClickMetasBySelector("div:123:h2").length
-    ).toEqual(2);
+    expect(clickStorage.getClickSelectors().length).toEqual(2);
+    expect(clickStorage.getClickMetasBySelector("div:123:h2").length).toEqual(
+      2
+    );
   });
 });

--- a/test/unit/specs/components/Personalization/createOnClickHandler.spec.js
+++ b/test/unit/specs/components/Personalization/createOnClickHandler.spec.js
@@ -14,11 +14,9 @@ import createOnClickHandler from "../../../../../src/components/Personalization/
 describe("Personalization::createOnClickHandler", () => {
   let mergeDecisionsMeta;
   let collectClicks;
-  const event = {
-    mergeXdm: jasmine.createSpy("mergeXdm"),
-    mergeMeta: jasmine.createSpy("mergeMeta")
-  };
-  const clickStorage = [];
+  let getClickSelectors;
+  let getClickMetasBySelector;
+  const event = {};
   const decisionsMeta = [
     {
       id: 1,
@@ -30,13 +28,25 @@ describe("Personalization::createOnClickHandler", () => {
     collectClicks = jasmine
       .createSpy("collectClicks")
       .and.returnValue(decisionsMeta);
+    event.mergeXdm = jasmine.createSpy("mergeXdm");
+    event.mergeMeta = jasmine.createSpy("mergeMeta");
+    mergeDecisionsMeta = jasmine.createSpy("mergeDecisionsMeta");
+    collectClicks = jasmine
+      .createSpy("collectClicks")
+      .and.returnValue(decisionsMeta);
+    getClickSelectors = jasmine.createSpy("getClickSelectors");
+    getClickMetasBySelector = jasmine.createSpy("getClickMetasBySelector");
   });
 
   it("collects clicks", () => {
+    const selectors = ["foo", "foo2"];
+    collectClicks.and.returnValue(decisionsMeta);
+    getClickSelectors.and.returnValue(selectors);
     const handleOnClick = createOnClickHandler({
       mergeDecisionsMeta,
       collectClicks,
-      clickStorage
+      getClickSelectors,
+      getClickMetasBySelector
     });
     const clickedElement = "foo";
 
@@ -44,6 +54,27 @@ describe("Personalization::createOnClickHandler", () => {
 
     expect(event.mergeXdm).toHaveBeenCalledWith({ eventType: "click" });
     expect(mergeDecisionsMeta).toHaveBeenCalledWith(event, decisionsMeta);
-    expect(collectClicks).toHaveBeenCalledWith(clickedElement, clickStorage);
+    expect(collectClicks).toHaveBeenCalledWith(
+      clickedElement,
+      selectors,
+      getClickMetasBySelector
+    );
+  });
+
+  it("collects clicks shouldn't be called when clickStorage is empty", () => {
+    getClickSelectors.and.returnValue([]);
+    const handleOnClick = createOnClickHandler({
+      mergeDecisionsMeta,
+      collectClicks,
+      getClickSelectors,
+      getClickMetasBySelector
+    });
+    const clickedElement = "foo";
+
+    handleOnClick({ event, clickedElement });
+
+    expect(event.mergeXdm).not.toHaveBeenCalled();
+    expect(mergeDecisionsMeta).not.toHaveBeenCalled();
+    expect(collectClicks).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/specs/components/Personalization/dom-actions/clicks/collectClicks.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/clicks/collectClicks.spec.js
@@ -42,8 +42,15 @@ describe("Personalization::tracking::clicks", () => {
     appendNode(document.body, node);
 
     const selector = "#abc:eq(0) > div.b:eq(0) > div.c";
-    const meta = { a: 1 };
-    const values = [{ selector, meta }];
+    const meta = {
+      id: "AT:1234",
+      scope: "example_scope"
+    };
+
+    const values = {};
+    values[selector] = {};
+    values[selector][meta.id] = meta.scope;
+
     const element = document.getElementById("one");
     const result = collectClicks(element, values);
 

--- a/test/unit/specs/components/Personalization/dom-actions/clicks/collectClicks.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/clicks/collectClicks.spec.js
@@ -24,6 +24,15 @@ describe("Personalization::tracking::clicks", () => {
   });
 
   it("should collect clicks", () => {
+    const meta = [
+      {
+        id: "AT:1234",
+        scope: "example_scope"
+      }
+    ];
+    const getClickMetasBySelector = jasmine
+      .createSpy("getClickMetasBySelector")
+      .and.returnValue(meta);
     const content = `
       <div class="b">
         <div id="one" class="c">first</div>
@@ -41,19 +50,11 @@ describe("Personalization::tracking::clicks", () => {
 
     appendNode(document.body, node);
 
-    const selector = "#abc:eq(0) > div.b:eq(0) > div.c";
-    const meta = {
-      id: "AT:1234",
-      scope: "example_scope"
-    };
-
-    const values = {};
-    values[selector] = {};
-    values[selector][meta.id] = meta.scope;
+    const selectors = ["#abc:eq(0) > div.b:eq(0) > div.c"];
 
     const element = document.getElementById("one");
-    const result = collectClicks(element, values);
+    const result = collectClicks(element, selectors, getClickMetasBySelector);
 
-    expect(result).toEqual([meta]);
+    expect(result).toEqual(meta);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
In this PR I'm fixing 2 bugs:
- @Aaronius discovered that at `viewChange` we will collect duplicates of the clicks and then include those duplicates in the `meta` sent to konductor
- While manual testing it I have discovered that when having an SPA and same element in both of the pages, while navigating from one page to another we'll have again duplicates of clicks but this time for diferent `scope`
This is happening because a `click` metric will be collected only when we'll render a decision. At `viewChange` we will collect clicks for that specific view. Now if we navigate from Home -> Consent -> Links -> Consent we will have the Consent metrics duplicated. Also if Consent and Links has an `h2` element right next to the body tag, VEC will compute the same selector for both of the views. This means that whenever we'll click on it while on Links view, the conversion will increase for both Links and Consent metrics for that specific selector. This is an edge case because it will happen only when specific navigation occurs but still I don't consider that Is quite right because our reports will be inconsistent.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
