### PR TITLE
Re-enabled sendBeacon tests after fixing them for Safari.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4330,57 +4330,87 @@
       "dev": true
     },
     "cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
       "requires": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
           "dev": true
         },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
         "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^5.0.0"
           }
         },
         "wrap-ansi": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
           }
         }
       }
@@ -4502,10 +4532,82 @@
         "yargs": "^13.3.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
         "date-fns": {
           "version": "2.16.1",
           "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
           "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         },
         "read-pkg": {
@@ -4519,6 +4621,26 @@
             "pify": "^3.0.0"
           }
         },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
@@ -4526,6 +4648,51 @@
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+          "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -13952,9 +14119,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
       "dev": true
     },
     "yallist": {
@@ -13970,117 +14137,65 @@
       "dev": true
     },
     "yargs": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "dev": true,
       "requires": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
         },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
         "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^5.0.0"
           }
         }
       }
     },
     "yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        }
-      }
+      "version": "20.2.7",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+      "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+      "dev": true
     },
     "yauzl": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:unit:browserstack:ci": "karma start karma.browserstack.conf.js --single-run",
     "test:unit:coverage": "karma start --single-run --reporters spec,coverage",
     "test:functional": "rollup -c --environment BASE_CODE,NPM_PACKAGE_LOCAL && EDGE_BASE_PATH=\"ee-pre-prd\" ALLOY_ENV=\"int\" testcafe chrome",
-    "test:functional:watch": "EDGE_BASE_PATH=\"ee-pre-prd\" ALLOY_ENV=\"int\" ./scripts/watchFunctionalTests.js",
+    "test:functional:watch": "EDGE_BASE_PATH=\"ee-pre-prd\" ALLOY_ENV=\"int\" ./scripts/watchFunctionalTests.js --browsers chrome",
     "test:functional:ci:build": "rollup -c --environment BASE_CODE,NPM_PACKAGE_LOCAL",
     "test:functional:ci:predeploy": "ALLOY_ENV=\"int\" testcafe -c 1 'browserstack:chrome@87:Windows 10','browserstack:ie@11:Windows 10','browserstack:firefox@85:Windows 10','browserstack:safari@14.0:OS X Big Sur'",
     "test:functional:ci:dev": "EDGE_BASE_PATH=\"ee-pre-prd\" ALLOY_ENV=\"int\" testcafe -c 1 'browserstack:chrome@87:Windows 10','browserstack:ie@11:Windows 10','browserstack:firefox@85:Windows 10','browserstack:safari@14.0:OS X Big Sur'",
@@ -126,6 +126,7 @@
     "testcafe": "^1.10.0",
     "testcafe-browser-provider-browserstack": "^1.13.0-alpha.1",
     "ua-parser": "^0.3.5",
-    "url-parse": "^1.4.7"
+    "url-parse": "^1.4.7",
+    "yargs": "^16.2.0"
   }
 }

--- a/scripts/watchFunctionalTests.js
+++ b/scripts/watchFunctionalTests.js
@@ -16,6 +16,13 @@ const path = require("path");
 const rollup = require("rollup");
 const loadConfigFile = require("rollup/dist/loadConfigFile");
 const createTestCafe = require("testcafe");
+const yargs = require("yargs/yargs");
+const { hideBin } = require("yargs/helpers");
+
+const argv = yargs(hideBin(process.argv)).option("browsers", {
+  type: "array",
+  default: ["chrome"]
+}).argv;
 
 /**
  * This script produces a build of Alloy from the source, then starts functional
@@ -44,7 +51,7 @@ const effectByEventCode = {
       firstBuildComplete = true;
       const testcafe = await createTestCafe();
       const liveRunner = testcafe.createLiveModeRunner();
-      await liveRunner.browsers(["chrome"]).run();
+      await liveRunner.browsers(argv.browsers).run();
       await testcafe.close();
     }
   },

--- a/test/functional/helpers/createCollectEndpointAsserter.js
+++ b/test/functional/helpers/createCollectEndpointAsserter.js
@@ -1,0 +1,122 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { t } from "testcafe";
+import createNetworkLogger from "./networkLogger";
+import sendBeaconMock from "./sendBeaconMock";
+import isSendBeaconSupported from "./isSendBeaconSupported";
+
+/**
+ * A useful utility when dealing with assertions related to
+ * the collect endpoint. Alloy sends requests to the collect endpoint
+ * using sendBeacon if sendBeacon is supported by the browser. When
+ * sendBeacon is called, the browser doesn't send the request right
+ * away, but instead queues the request to be sent sometime
+ * later, which can make it tricky to correctly assert that requests
+ * have or have not been sent to the endpoint.
+ */
+export default async () => {
+  const networkLogger = createNetworkLogger();
+  await t.addRequestHooks(
+    networkLogger.edgeInteractEndpointLogs,
+    networkLogger.edgeCollectEndpointLogs
+  );
+
+  if (isSendBeaconSupported()) {
+    await sendBeaconMock.mock();
+  }
+
+  const assertCollectCalled = async () => {
+    if (isSendBeaconSupported()) {
+      // When sendBeacon is called, the browser doesn't send
+      // the request right away, but instead queues the request to be sent sometime
+      // later. Therefore, the sendEvent promise resolves before any network
+      // request may have actually been made. By calling the RequestLogger's count
+      // method, TestCafe will retry this assertion until it succeeds or until the
+      // timeout is reached. The parameter to count is a filter function. In this
+      // case we want to count all the requests.
+      await t
+        .expect(networkLogger.edgeCollectEndpointLogs.count(() => true))
+        .eql(1, "No network request to the collect endpoint was detected.");
+      // If sendBeacon is supported by the browser, we should always be using it when
+      // sending requests to the collect endpoint.
+      await t
+        .expect(sendBeaconMock.getCallCount())
+        .eql(1, "No sendBeacon call was detected.");
+    } else {
+      // In IE, sendBeacon isn't supported, which means we fall back to XHR. In the case
+      // of XHR, the network request will be sent before the sendEvent promise resolves, so
+      // we can immediately check the number of network requests.
+      await t
+        .expect(networkLogger.edgeCollectEndpointLogs.requests.length)
+        .eql(1, "No network request to the collect endpoint was detected.");
+    }
+  };
+
+  const assertCollectNotCalled = async () => {
+    if (isSendBeaconSupported()) {
+      // The browser's sendBeacon api returns before the actual request is made. Therefore,
+      // the sendEvent promise resolves before any network request may have actually been made.
+      // In order to check that a request to the collect endpoint is never made, we would
+      // have to wait for an arbitrary period of time before checking that the number of
+      // network requests to the collect endpoint is 0. Instead of waiting for an arbitrary
+      // period of time, which is a fragile and slow solution, we'll make our best attempt
+      // at this assertion by checking that sendBeacon was never called. If supported by the
+      // browser, sendBeacon is solely used to send requests to collect, so it's a fair approximation.
+      await t
+        .expect(sendBeaconMock.getCallCount())
+        .eql(0, "A network request to the collect endpoint was detected.");
+    } else {
+      // In IE, sendBeacon isn't supported, which means we fall back to XHR. In the case
+      // of XHR, the network request will be sent before the sendEvent promise resolves, so
+      // we can immediately check the number of network requests.
+      await t
+        .expect(networkLogger.edgeCollectEndpointLogs.requests.length)
+        .eql(0, "A network request to the collect endpoint was detected.");
+    }
+  };
+
+  const assertInteractCalled = async () => {
+    await t
+      .expect(networkLogger.edgeInteractEndpointLogs.requests.length)
+      .eql(1, "No network request to the interact endpoint was detected.");
+  };
+
+  const assertInteractNotCalled = async () => {
+    await t
+      .expect(networkLogger.edgeInteractEndpointLogs.requests.length)
+      .eql(0, "A network request to the interact endpoint was detected.");
+  };
+
+  return {
+    async assertCollectCalledAndNotInteract() {
+      // The order of these matter because we need to make sure sendBeacon
+      // requests have actually been sent by the browser before checking
+      // that they weren't interact calls.
+      await assertCollectCalled();
+      await assertInteractNotCalled();
+      return networkLogger.edgeCollectEndpointLogs.requests[0];
+    },
+    async assertInteractCalledAndNotCollect() {
+      await assertCollectNotCalled();
+      await assertInteractCalled();
+      return networkLogger.edgeInteractEndpointLogs.requests[0];
+    },
+    async assertNeitherCollectNorInteractCalled() {
+      await assertCollectNotCalled();
+      await assertInteractNotCalled();
+    },
+    async reset() {
+      await networkLogger.clearLogs();
+      await sendBeaconMock.reset();
+    }
+  };
+};

--- a/test/functional/helpers/createFixture/destinationRequestMock.js
+++ b/test/functional/helpers/createFixture/destinationRequestMock.js
@@ -19,5 +19,5 @@ import { RequestMock } from "testcafe";
 // destination to successfully execute, we'll mock the third-party
 // URL destination endpoint.
 export default RequestMock()
-  .onRequestTo("https://cataas.com/cat")
+  .onRequestTo(/^https:\/\/cataas.com\//)
   .respond(null, 200);

--- a/test/functional/helpers/createFixture/destinationRequestMock.js
+++ b/test/functional/helpers/createFixture/destinationRequestMock.js
@@ -1,0 +1,23 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { RequestMock } from "testcafe";
+
+// The main edge configuration we're using for testing
+// has URL destinations enabled and a URL destination handle is sent
+// back as part of the response from each interact endpoint request.
+// So that we're not relying on a third-party server for the URL
+// destination to successfully execute, we'll mock the third-party
+// URL destination endpoint.
+export default RequestMock()
+  .onRequestTo("https://cataas.com/cat")
+  .respond(null, 200);

--- a/test/functional/helpers/createFixture/index.js
+++ b/test/functional/helpers/createFixture/index.js
@@ -1,5 +1,6 @@
 import testPageUrl from "../constants/testPageUrl";
 import { getFixtureClientScripts } from "./clientScripts";
+import destinationRequestMock from "./destinationRequestMock";
 
 export default ({
   title = "",
@@ -16,6 +17,6 @@ export default ({
   });
   return fixture(title)
     .page(url)
-    .requestHooks(...requestHooks)
+    .requestHooks(...requestHooks, destinationRequestMock)
     .clientScripts(clientScripts);
 };

--- a/test/functional/helpers/networkLogger/index.js
+++ b/test/functional/helpers/networkLogger/index.js
@@ -36,6 +36,8 @@ const createNetworkLogger = () => {
 
   return {
     edgeEndpointLogs,
+    // Before using edgeCollectEndpointLogs in a test, check to see if you
+    // should be using the createCollectEndpointAssertion.js module instead.
     edgeCollectEndpointLogs,
     edgeInteractEndpointLogs,
     setConsentEndpointLogs,

--- a/test/functional/helpers/preventLinkNavigation.js
+++ b/test/functional/helpers/preventLinkNavigation.js
@@ -1,0 +1,24 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { ClientFunction } from "testcafe";
+
+/**
+ * Prevents links from navigating the user. This can be particularly
+ * useful in tests that are asserting requests that would typically
+ * occur as a user navigates away from the page.
+ */
+export default ClientFunction(() => {
+  document.addEventListener("click", event => {
+    event.preventDefault();
+  });
+});

--- a/test/functional/specs/Audiences/C31436.js
+++ b/test/functional/specs/Audiences/C31436.js
@@ -1,4 +1,4 @@
-import { RequestLogger, RequestMock, t } from "testcafe";
+import { RequestLogger, t } from "testcafe";
 import createNetworkLogger from "../../helpers/networkLogger";
 import createFixture from "../../helpers/createFixture";
 import { orgMainConfigMain } from "../../helpers/constants/configParts";
@@ -16,17 +16,9 @@ const destinationLogger = RequestLogger(
   networkLoggerConfig
 );
 
-const destinationRequestMock = RequestMock()
-  .onRequestTo("https://cataas.com/cat/cute")
-  .respond(null, 200);
-
 createFixture({
   title: "C31436 Qualify for URL destinations via XDM Data.",
-  requestHooks: [
-    networkLogger.edgeEndpointLogs,
-    destinationLogger,
-    destinationRequestMock
-  ]
+  requestHooks: [networkLogger.edgeEndpointLogs, destinationLogger]
 });
 
 test.meta({

--- a/test/functional/specs/Audiences/C31436.js
+++ b/test/functional/specs/Audiences/C31436.js
@@ -1,4 +1,4 @@
-import { RequestLogger, t } from "testcafe";
+import { RequestLogger, RequestMock, t } from "testcafe";
 import createNetworkLogger from "../../helpers/networkLogger";
 import createFixture from "../../helpers/createFixture";
 import { orgMainConfigMain } from "../../helpers/constants/configParts";
@@ -16,9 +16,17 @@ const destinationLogger = RequestLogger(
   networkLoggerConfig
 );
 
+const destinationRequestMock = RequestMock()
+  .onRequestTo("https://cataas.com/cat/cute")
+  .respond(null, 200);
+
 createFixture({
   title: "C31436 Qualify for URL destinations via XDM Data.",
-  requestHooks: [networkLogger.edgeEndpointLogs, destinationLogger]
+  requestHooks: [
+    networkLogger.edgeEndpointLogs,
+    destinationLogger,
+    destinationRequestMock
+  ]
 });
 
 test.meta({

--- a/test/functional/specs/Data Collector/C455258.js
+++ b/test/functional/specs/Data Collector/C455258.js
@@ -1,20 +1,11 @@
-import { t } from "testcafe";
-import createNetworkLogger from "../../helpers/networkLogger";
 import createFixture from "../../helpers/createFixture";
-import sendBeaconMock from "../../helpers/sendBeaconMock";
 import { orgMainConfigMain } from "../../helpers/constants/configParts";
-import isSendBeaconSupported from "../../helpers/isSendBeaconSupported";
 import createAlloyProxy from "../../helpers/createAlloyProxy";
-
-const networkLogger = createNetworkLogger();
+import createCollectEndpointAsserter from "../../helpers/createCollectEndpointAsserter";
 
 createFixture({
   title:
-    "C455258: sendEvent command sends a request to the collect endpoint using sendBeacon when documentUnloading is set to true but only when identity has established.",
-  requestHooks: [
-    networkLogger.edgeInteractEndpointLogs,
-    networkLogger.edgeCollectEndpointLogs
-  ]
+    "C455258: sendEvent command sends a request to the collect endpoint using sendBeacon when documentUnloading is set to true but only when identity has established."
 });
 
 test.meta({
@@ -24,48 +15,24 @@ test.meta({
 });
 
 test("Test C455258: sendEvent command sends a request to the collect endpoint when identity has been established and documentUnloading is set to true, interact otherwise.", async () => {
-  if (isSendBeaconSupported()) {
-    await sendBeaconMock.mock();
-  }
+  const collectEndpointAsserter = await createCollectEndpointAsserter();
   const alloy = createAlloyProxy();
   await alloy.configure(orgMainConfigMain);
 
   // An identity has not yet been established. This request should go to the
   // interact endpoint.
   await alloy.sendEvent({ documentUnloading: true });
-
-  await t.expect(networkLogger.edgeInteractEndpointLogs.requests.length).eql(1);
-  await t.expect(networkLogger.edgeCollectEndpointLogs.requests.length).eql(0);
-
-  if (isSendBeaconSupported()) {
-    await t.expect(sendBeaconMock.getCallCount()).eql(0);
-  }
+  await collectEndpointAsserter.assertInteractCalledAndNotCollect();
+  await collectEndpointAsserter.reset();
 
   // An identity has been established. This request should go to the
   // collect endpoint.
   await alloy.sendEvent({ documentUnloading: true });
-
-  await t.expect(networkLogger.edgeInteractEndpointLogs.requests.length).eql(1);
-  // The browser's sendBeacon api returns before the actual request is made. Therefore
-  // the sendEvent promise resolves right away so the /collect call may not have gone
-  // out yet. By calling the RequestLogger's count method, TestCafe will retry this
-  // assertion until it succeeds or until the timeout is reached. The parameter to count
-  // is a filter function. In this case we want to count all the requests.
-  await t
-    .expect(networkLogger.edgeCollectEndpointLogs.count(() => true))
-    .eql(1);
-
-  if (isSendBeaconSupported()) {
-    await t.expect(sendBeaconMock.getCallCount()).eql(1);
-  }
+  await collectEndpointAsserter.assertCollectCalledAndNotInteract();
+  await collectEndpointAsserter.reset();
 
   // documentUnloading is not set to true. The request should go to the
   // interact endpoint.
   await alloy.sendEvent();
-
-  await t.expect(networkLogger.edgeInteractEndpointLogs.requests.length).eql(2);
-  await t.expect(networkLogger.edgeCollectEndpointLogs.requests.length).eql(1);
-  if (isSendBeaconSupported()) {
-    await t.expect(sendBeaconMock.getCallCount()).eql(1);
-  }
+  await collectEndpointAsserter.assertInteractCalledAndNotCollect();
 });

--- a/test/functional/specs/Data Collector/C8118.js
+++ b/test/functional/specs/Data Collector/C8118.js
@@ -45,7 +45,8 @@ test("Test C8118: Verify link click sends a request to the collect endpoint when
   await alloy.configure(orgMainConfigMain);
   await addLinkToBody();
   await clickLink();
-  const interactRequest = await collectEndpointAsserter.assertInteractCalledAndNotCollect();
+  await collectEndpointAsserter.assertInteractCalledAndNotCollect();
+  const interactRequest = await collectEndpointAsserter.getInteractRequest();
   await collectEndpointAsserter.reset();
   // If an identity has not been established, we hit the interact endpoint using
   // fetch even though the user may be navigating away from the page. In the
@@ -59,6 +60,7 @@ test("Test C8118: Verify link click sends a request to the collect endpoint when
   // Because an identity has been established, we can safely hit the collect
   // endpoint using sendBeacon.
   await clickLink();
-  const collectRequest = await collectEndpointAsserter.assertCollectCalledAndNotInteract();
+  await collectEndpointAsserter.assertCollectCalledAndNotInteract();
+  const collectRequest = collectEndpointAsserter.getCollectRequest();
   await assertRequestXdm(collectRequest);
 });

--- a/test/functional/specs/Data Collector/C8118.js
+++ b/test/functional/specs/Data Collector/C8118.js
@@ -1,21 +1,13 @@
-import { t, Selector, ClientFunction } from "testcafe";
-import createNetworkLogger from "../../helpers/networkLogger";
+import { t, Selector } from "testcafe";
 import createFixture from "../../helpers/createFixture";
 import addHtmlToBody from "../../helpers/dom/addHtmlToBody";
-import sendBeaconMock from "../../helpers/sendBeaconMock";
 import { orgMainConfigMain } from "../../helpers/constants/configParts";
-import isSendBeaconSupported from "../../helpers/isSendBeaconSupported";
-import testPageUrl from "../../helpers/constants/testPageUrl";
 import createAlloyProxy from "../../helpers/createAlloyProxy";
-
-const networkLogger = createNetworkLogger();
+import preventLinkNavigation from "../../helpers/preventLinkNavigation";
+import createCollectEndpointAsserter from "../../helpers/createCollectEndpointAsserter";
 
 createFixture({
-  title: "C8118: Send event with information about link clicks.",
-  requestHooks: [
-    networkLogger.edgeInteractEndpointLogs,
-    networkLogger.edgeCollectEndpointLogs
-  ]
+  title: "C8118: Send event with information about link clicks."
 });
 
 test.meta({
@@ -23,8 +15,6 @@ test.meta({
   SEVERITY: "P0",
   TEST_RUN: "Regression"
 });
-
-const getLocation = ClientFunction(() => document.location.href.toString());
 
 const addLinkToBody = () => {
   return addHtmlToBody(
@@ -34,10 +24,9 @@ const addLinkToBody = () => {
 
 const clickLink = async () => {
   await t.click(Selector("#alloy-link-test"));
-  await t.expect(getLocation()).contains("blank.html");
 };
 
-const assertRequest = async request => {
+const assertRequestXdm = async request => {
   const requestBody = JSON.parse(request.request.body);
   const eventXdm = requestBody.events[0].xdm;
   await t.expect(eventXdm.eventType).eql("web.webinteraction.linkClicks");
@@ -49,57 +38,27 @@ const assertRequest = async request => {
   });
 };
 
-test.skip("Test C8118: Verify link click sends a request to the collect endpoint when identity has been established, interact endpoint otherwise", async () => {
-  if (isSendBeaconSupported()) {
-    await sendBeaconMock.mock();
-  }
+test("Test C8118: Verify link click sends a request to the collect endpoint when identity has been established, interact endpoint otherwise", async () => {
+  const collectEndpointAsserter = await createCollectEndpointAsserter();
+  await preventLinkNavigation();
   const alloy = createAlloyProxy();
   await alloy.configure(orgMainConfigMain);
   await addLinkToBody();
-
-  // If an identity has not been established, we hit the interact endpoint using
-  // fetch even though the user may be navigating away from the page. We may
-  // or may not get a response back before navigation completes. If we don't,
-  // an identity will not have been established, unfortunately.
   await clickLink();
-
-  // We cannot assert the interact endpoint has been called because Alloy uses
-  // the fetch API in this case and there is no guarantee that the browser will
-  // finish sending the request before navigating the user.
-
-  await t.expect(networkLogger.edgeCollectEndpointLogs.requests.length).eql(0);
-  // await assertRequest(networkLogger.edgeInteractEndpointLogs.requests[0]);
-  if (isSendBeaconSupported()) {
-    await t.expect(sendBeaconMock.getCallCount()).eql(0);
-  }
-
-  // The link click took us to a new page. Let's go back to our test page.
-  await t.navigateTo(testPageUrl);
-  await networkLogger.clearLogs();
-
-  if (isSendBeaconSupported()) {
-    await sendBeaconMock.mock();
-  }
-
-  await alloy.configure(orgMainConfigMain);
-  // Ensure an identity is established by sending an event in the regular manner.
-  await alloy.sendEvent();
-  await t.expect(networkLogger.edgeInteractEndpointLogs.requests.length).eql(1);
-  await t.expect(networkLogger.edgeCollectEndpointLogs.requests.length).eql(0);
-  if (isSendBeaconSupported()) {
-    await t.expect(sendBeaconMock.getCallCount()).eql(0);
-  }
-
-  await networkLogger.clearLogs();
+  const interactRequest = await collectEndpointAsserter.assertInteractCalledAndNotCollect();
+  await collectEndpointAsserter.reset();
+  // If an identity has not been established, we hit the interact endpoint using
+  // fetch even though the user may be navigating away from the page. In the
+  // real world where we're not blocking navigation, Alloy may
+  // or may not get a response back before navigation completes. If Alloy does not
+  // receive a response back, an identity cookie will not have been established, unfortunately,
+  // but that is considered better than using sendBeacon that for sure would not establish
+  // an identity.
+  await assertRequestXdm(interactRequest);
 
   // Because an identity has been established, we can safely hit the collect
   // endpoint using sendBeacon.
-  await addLinkToBody();
   await clickLink();
-  await t.expect(networkLogger.edgeInteractEndpointLogs.requests.length).eql(0);
-  await t.expect(networkLogger.edgeCollectEndpointLogs.requests.length).eql(1);
-  await assertRequest(networkLogger.edgeCollectEndpointLogs.requests[0]);
-  if (isSendBeaconSupported()) {
-    await t.expect(sendBeaconMock.getCallCount()).eql(1);
-  }
+  const collectRequest = await collectEndpointAsserter.assertCollectCalledAndNotInteract();
+  await assertRequestXdm(collectRequest);
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The tests involving the collect endpoint + sendBeacon were skipped before the release because they needed some re-work to ensure they were asserting the things we were expecting and that they weren't intermittently failing. This PR addresses those problem. Hopefully the code comments explain the problem and why we do what we have to do.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/PDCL-4617
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Re-enable tests for better coverage.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
