### PR TITLE
PDCL-4650 Stabilizing legacy identity unit tests (specifically on Safari).

### DIFF
--- a/test/unit/specs/components/Identity/createLegacyIdentity.spec.js
+++ b/test/unit/specs/components/Identity/createLegacyIdentity.spec.js
@@ -34,6 +34,7 @@ describe("Identity::createLegacyIdentity", () => {
 
   beforeEach(() => {
     idMigrationEnabled = true;
+    removeAllCookies();
   });
 
   afterEach(removeAllCookies);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Unit tests related to legacy identity were failing on Safari due to cookies not having been cleared before the unit test started. I didn't take the time to dig into why this was a problem in Safari and not other browsers.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/PDCL-4650
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Stable tests!
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
