### PR TITLE
PDCL-4489 Fixed an issue where user-provided XDM was being leaked acr…

### DIFF
--- a/scripts/watchFunctionalTests.js
+++ b/scripts/watchFunctionalTests.js
@@ -64,7 +64,7 @@ const effectByEventCode = {
   // Ideally we would pass these environment variables as part
   // of the loadConfigFile function, but that doesn't work.
   // See https://github.com/rollup/rollup/issues/4003
-  process.env.SANDBOX = "true";
+  process.env.STANDALONE = "true";
   process.env.NPM_PACKAGE_LOCAL = "true";
   process.env.BASE_CODE_MIN = "true";
   const { options, warnings } = await loadConfigFile(

--- a/src/components/Context/implementationDetails.js
+++ b/src/components/Context/implementationDetails.js
@@ -10,9 +10,14 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import { deepAssign } from "../../utils";
+import libraryName from "../../constants/libraryName";
+import libraryVersion from "../../constants/libraryVersion";
 
-export default implementationDetails => {
-  return xdm => {
-    deepAssign(xdm, { implementationDetails });
+export default xdm => {
+  const implementationDetails = {
+    name: libraryName,
+    version: libraryVersion,
+    environment: "browser"
   };
+  deepAssign(xdm, { implementationDetails });
 };

--- a/src/components/Context/index.js
+++ b/src/components/Context/index.js
@@ -15,9 +15,7 @@ import injectDevice from "./injectDevice";
 import injectEnvironment from "./injectEnvironment";
 import injectPlaceContext from "./injectPlaceContext";
 import injectTimestamp from "./injectTimestamp";
-import injectImplementationDetails from "./injectImplementationDetails";
-import libraryVersion from "../../constants/libraryVersion";
-import libraryName from "../../constants/libraryName";
+import implementationDetails from "./implementationDetails";
 import createComponent from "./createComponent";
 import { arrayOf, string } from "../../utils/validation";
 
@@ -26,11 +24,6 @@ const device = injectDevice(window);
 const environment = injectEnvironment(window);
 const placeContext = injectPlaceContext(() => new Date());
 const timestamp = injectTimestamp(() => new Date());
-const implementationDetails = injectImplementationDetails({
-  name: libraryName,
-  version: libraryVersion,
-  environment: "browser"
-});
 
 const optionalContexts = {
   web,

--- a/test/functional/specs/Context/C1911390.js
+++ b/test/functional/specs/Context/C1911390.js
@@ -1,0 +1,93 @@
+import { t } from "testcafe";
+import createNetworkLogger from "../../helpers/networkLogger";
+import createFixture from "../../helpers/createFixture";
+import createAlloyProxy from "../../helpers/createAlloyProxy";
+import { orgMainConfigMain } from "../../helpers/constants/configParts";
+
+const networkLogger = createNetworkLogger();
+
+const DESCRIPTION =
+  "C1911390 - Adds only device context data when only device is specified in configuration.";
+
+createFixture({
+  title: DESCRIPTION,
+  requestHooks: [networkLogger.edgeEndpointLogs]
+});
+
+test.meta({
+  ID: "C1911390",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+
+test(DESCRIPTION, async () => {
+  const alloy = createAlloyProxy();
+  await alloy.configure(orgMainConfigMain);
+  await alloy.sendEvent({
+    xdm: {
+      device: {
+        customDeviceField: "foo"
+      },
+      environment: {
+        customEnvironmentField: "foo"
+      },
+      implementationDetails: {
+        customImplementationDetailsField: "foo"
+      },
+      placeContext: {
+        customPlaceContextField: "foo"
+      },
+      web: {
+        customWebField: "foo"
+      }
+    }
+  });
+
+  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
+
+  let parsedBody = JSON.parse(
+    networkLogger.edgeEndpointLogs.requests[0].request.body
+  );
+  let sentXdm = parsedBody.events[0].xdm;
+
+  await t
+    .expect(sentXdm.device.customDeviceField)
+    .eql("foo", "custom device field incorrectly populated");
+  await t
+    .expect(sentXdm.environment.customEnvironmentField)
+    .eql("foo", "custom environment field incorrectly populated");
+  await t
+    .expect(sentXdm.implementationDetails.customImplementationDetailsField)
+    .eql("foo", "custom implementation details field incorrectly populated");
+  await t
+    .expect(sentXdm.placeContext.customPlaceContextField)
+    .eql("foo", "custom place context field incorrectly populated");
+  await t
+    .expect(sentXdm.web.customWebField)
+    .eql("foo", "custom web field incorrectly populated");
+
+  await alloy.sendEvent({});
+
+  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(2);
+
+  parsedBody = JSON.parse(
+    networkLogger.edgeEndpointLogs.requests[1].request.body
+  );
+  sentXdm = parsedBody.events[0].xdm;
+
+  await t
+    .expect(sentXdm.device.customDeviceField)
+    .notOk("custom device field should be undefined");
+  await t
+    .expect(sentXdm.environment.customEnvironmentField)
+    .notOk("custom environment field should be undefined");
+  await t
+    .expect(sentXdm.implementationDetails.customImplementationDetailsField)
+    .notOk("custom implementation details field should be undefined");
+  await t
+    .expect(sentXdm.placeContext.customPlaceContextField)
+    .notOk("custom place context field should be undefined");
+  await t
+    .expect(sentXdm.web.customWebField)
+    .notOk("custom web field should be undefined");
+});

--- a/test/functional/specs/Context/C2597.js
+++ b/test/functional/specs/Context/C2597.js
@@ -3,17 +3,8 @@ import createNetworkLogger from "../../helpers/networkLogger";
 import { responseStatus } from "../../helpers/assertions/index";
 import createFixture from "../../helpers/createFixture";
 
-import {
-  compose,
-  orgMainConfigMain,
-  debugEnabled
-} from "../../helpers/constants/configParts";
+import { orgMainConfigMain } from "../../helpers/constants/configParts";
 import createAlloyProxy from "../../helpers/createAlloyProxy";
-
-const debugEnabledConfig = compose(
-  orgMainConfigMain,
-  debugEnabled
-);
 
 const networkLogger = createNetworkLogger();
 
@@ -30,17 +21,18 @@ test.meta({
 
 test("Test C2597 - Adds all context data to requests by default.", async () => {
   const alloy = createAlloyProxy();
-  await alloy.configure(debugEnabledConfig);
+  await alloy.configure(orgMainConfigMain);
   await alloy.sendEvent();
 
   await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
 
-  const request = networkLogger.edgeEndpointLogs.requests[0].request.body;
-  const stringifyRequest = JSON.parse(request);
+  const parsedBody = JSON.parse(
+    networkLogger.edgeEndpointLogs.requests[0].request.body
+  );
 
-  await t.expect(stringifyRequest.events[0].xdm.device).ok();
-  await t.expect(stringifyRequest.events[0].xdm.placeContext).ok();
-  await t.expect(stringifyRequest.events[0].xdm.environment.type).ok();
-  await t.expect(stringifyRequest.events[0].xdm.web.webPageDetails).ok();
+  await t.expect(parsedBody.events[0].xdm.device).ok();
+  await t.expect(parsedBody.events[0].xdm.placeContext).ok();
+  await t.expect(parsedBody.events[0].xdm.environment.type).ok();
+  await t.expect(parsedBody.events[0].xdm.web.webPageDetails).ok();
 });

--- a/test/functional/specs/Context/C2598.js
+++ b/test/functional/specs/Context/C2598.js
@@ -34,20 +34,21 @@ test("Test C2598 - Adds only web context data when only web is specified in conf
   await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
 
-  const request = networkLogger.edgeEndpointLogs.requests[0].request.body;
-  const stringifyRequest = JSON.parse(request);
+  const parsedBody = JSON.parse(
+    networkLogger.edgeEndpointLogs.requests[0].request.body
+  );
 
-  await t.expect(stringifyRequest.events[0].xdm.web).ok();
-  await t.expect(stringifyRequest.events[0].xdm.web.webPageDetails).ok();
+  await t.expect(parsedBody.events[0].xdm.web).ok();
+  await t.expect(parsedBody.events[0].xdm.web.webPageDetails).ok();
   await t
-    .expect(stringifyRequest.events[0].xdm.web.webPageDetails.URL)
+    .expect(parsedBody.events[0].xdm.web.webPageDetails.URL)
     .eql(TEST_PAGE_URL);
-  await t.expect(stringifyRequest.events[0].xdm.web.webReferrer).ok();
+  await t.expect(parsedBody.events[0].xdm.web.webReferrer).ok();
   await t
-    .expect(stringifyRequest.events[0].xdm.web.webReferrer.URL)
+    .expect(parsedBody.events[0].xdm.web.webReferrer.URL)
     .eql(TEST_PAGE_URL);
 
-  await t.expect(stringifyRequest.events[0].xdm.device).notOk();
-  await t.expect(stringifyRequest.events[0].xdm.placeContext).notOk();
-  await t.expect(stringifyRequest.events[0].xdm.environment).notOk();
+  await t.expect(parsedBody.events[0].xdm.device).notOk();
+  await t.expect(parsedBody.events[0].xdm.placeContext).notOk();
+  await t.expect(parsedBody.events[0].xdm.environment).notOk();
 });

--- a/test/functional/specs/Context/C2599.js
+++ b/test/functional/specs/Context/C2599.js
@@ -38,12 +38,13 @@ test("C2599 - Adds only device context data when only device is specified in con
   await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
 
-  const request = networkLogger.edgeEndpointLogs.requests[0].request.body;
-  const stringifyRequest = JSON.parse(request);
+  const parsedBody = JSON.parse(
+    networkLogger.edgeEndpointLogs.requests[0].request.body
+  );
 
-  await t.expect(stringifyRequest.events[0].xdm.device).ok();
-  await t.expect(stringifyRequest.events[0].xdm.web.webPageDetails).ok();
+  await t.expect(parsedBody.events[0].xdm.device).ok();
+  await t.expect(parsedBody.events[0].xdm.web.webPageDetails).ok();
 
-  await t.expect(stringifyRequest.events[0].xdm.placeContext).notOk();
-  await t.expect(stringifyRequest.events[0].xdm.environment).notOk();
+  await t.expect(parsedBody.events[0].xdm.placeContext).notOk();
+  await t.expect(parsedBody.events[0].xdm.environment).notOk();
 });

--- a/test/functional/specs/Context/C2600.js
+++ b/test/functional/specs/Context/C2600.js
@@ -38,12 +38,13 @@ test("C2600 - Adds only environment context data when only device is specified i
   await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
 
-  const request = networkLogger.edgeEndpointLogs.requests[0].request.body;
-  const stringifyRequest = JSON.parse(request);
+  const parsedBody = JSON.parse(
+    networkLogger.edgeEndpointLogs.requests[0].request.body
+  );
 
-  await t.expect(stringifyRequest.events[0].xdm.environment).ok();
-  await t.expect(stringifyRequest.events[0].xdm.web.webPageDetails).ok();
+  await t.expect(parsedBody.events[0].xdm.environment).ok();
+  await t.expect(parsedBody.events[0].xdm.web.webPageDetails).ok();
 
-  await t.expect(stringifyRequest.events[0].xdm.device).notOk();
-  await t.expect(stringifyRequest.events[0].xdm.placeContext).notOk();
+  await t.expect(parsedBody.events[0].xdm.device).notOk();
+  await t.expect(parsedBody.events[0].xdm.placeContext).notOk();
 });

--- a/test/functional/specs/Context/C2601.js
+++ b/test/functional/specs/Context/C2601.js
@@ -38,12 +38,13 @@ test("C2601 - Adds only placeContext context data when only device is specified 
   await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
 
-  const request = networkLogger.edgeEndpointLogs.requests[0].request.body;
-  const stringifyRequest = JSON.parse(request);
+  const parsedBody = JSON.parse(
+    networkLogger.edgeEndpointLogs.requests[0].request.body
+  );
 
-  await t.expect(stringifyRequest.events[0].xdm.placeContext).ok();
-  await t.expect(stringifyRequest.events[0].xdm.web.webPageDetails).ok();
+  await t.expect(parsedBody.events[0].xdm.placeContext).ok();
+  await t.expect(parsedBody.events[0].xdm.web.webPageDetails).ok();
 
-  await t.expect(stringifyRequest.events[0].xdm.environment).notOk();
-  await t.expect(stringifyRequest.events[0].xdm.device).notOk();
+  await t.expect(parsedBody.events[0].xdm.environment).notOk();
+  await t.expect(parsedBody.events[0].xdm.device).notOk();
 });

--- a/test/unit/specs/components/Context/implementationDetails.spec.js
+++ b/test/unit/specs/components/Context/implementationDetails.spec.js
@@ -10,23 +10,17 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import injectImplementationDetails from "../../../../../src/components/Context/injectImplementationDetails";
+import implementationDetails from "../../../../../src/components/Context/implementationDetails";
 
 describe("Context::implementationDetails", () => {
-  const details = {
-    name: "myname",
-    version: "myversion",
-    environment: "myenvironment"
-  };
-
   it("works", () => {
     const xdm = {};
-    injectImplementationDetails(details)(xdm);
+    implementationDetails(xdm);
     expect(xdm).toEqual({
       implementationDetails: {
-        name: "myname",
-        version: "myversion",
-        environment: "myenvironment"
+        name: "https://ns.adobe.com/experience/alloy",
+        version: "__VERSION__",
+        environment: "browser"
       }
     });
   });


### PR DESCRIPTION
…oss events/requests.

<!--- Provide a general summary of your changes in the Title above -->

## Description
We were creating a single `implementationDetails` object (the object that contains `name`, `version`, and `environment`) to be used across all events. When a user provided XDM containing a custom field under `implementationDetails`, their field was being merged onto the single `implementationDetails` object we initially created. Since that `implementationDetails` object is used for subsequent requests, the user's custom field would also show up in the XDM sent on subsequent requests, when it shouldn't.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/PDCL-4489
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
User-provided XDM for one event should not show up on any other event unless explicitly provided for that event.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
