### PR TITLE
[Redirect offer support] - Adding scope details to the decision

### DIFF
--- a/sandbox/src/RedirectOffers.js
+++ b/sandbox/src/RedirectOffers.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import ContentSecurityPolicy from "./ContentSecurityPolicy";
+import ContentSecurityPolicy from "./components/ContentSecurityPolicy";
 
 export default function RedirectOffers() {
   useEffect(() => {

--- a/sandbox/src/RedirectedNewPage.js
+++ b/sandbox/src/RedirectedNewPage.js
@@ -1,7 +1,16 @@
-import React from "react";
-import ContentSecurityPolicy from "./ContentSecurityPolicy";
+import React, { useEffect } from "react";
+import ContentSecurityPolicy from "./components/ContentSecurityPolicy";
 
 export default function RedirectedNewPage() {
+  useEffect(() => {
+    window
+      .alloy("sendEvent", {
+        renderDecisions: true
+      })
+      .then(({ decisions = [] }) => {
+        console.log("personalized decisions", decisions);
+      });
+  }, []);
   return (
     <div className="personalization-container">
       <ContentSecurityPolicy />

--- a/src/components/Personalization/createClickStorage.js
+++ b/src/components/Personalization/createClickStorage.js
@@ -14,7 +14,8 @@ const metasToArray = metas => {
   return Object.keys(metas).map(key => {
     return {
       id: key,
-      scope: metas[key]
+      scope: metas[key].scope,
+      scopeDetails: metas[key].scopeDetails
     };
   });
 };
@@ -26,7 +27,10 @@ export default () => {
     if (!clickStorage[value.selector]) {
       clickStorage[value.selector] = {};
     }
-    clickStorage[value.selector][value.meta.id] = value.meta.scope;
+    clickStorage[value.selector][value.meta.id] = {
+      scope: value.meta.scope,
+      scopeDetails: value.meta.scopeDetails
+    };
   };
 
   const getClickSelectors = () => {

--- a/src/components/Personalization/createCollect.js
+++ b/src/components/Personalization/createCollect.js
@@ -12,14 +12,14 @@ governing permissions and limitations under the License.
 
 export default ({ eventManager, mergeDecisionsMeta }) => {
   // Called when a decision is auto-rendered for the __view__ scope (non-SPA view).
-  return ({ decisionsMeta, documentMayUnload = false }) => {
+  return ({ decisionsMeta, isRedirectNotification = false }) => {
     const event = eventManager.createEvent();
-    event.mergeXdm({ eventType: "display" });
-    mergeDecisionsMeta(event, decisionsMeta);
-
-    if (documentMayUnload) {
-      event.documentMayUnload();
+    if (isRedirectNotification) {
+      event.mergeXdm({ eventType: "redirect" });
+    } else {
+      event.mergeXdm({ eventType: "display" });
     }
+    mergeDecisionsMeta(event, decisionsMeta);
 
     return eventManager.sendEvent(event);
   };

--- a/src/components/Personalization/createExecuteDecisions.js
+++ b/src/components/Personalization/createExecuteDecisions.js
@@ -26,7 +26,7 @@ const buildActions = decision => {
 
 const processMetas = (collect, logger, actionResults) => {
   const results = flatMap(actionResults, identity);
-  const finalMetas = [];
+  const decisionsMeta = [];
   const set = new Set();
 
   results.forEach(item => {
@@ -46,12 +46,12 @@ const processMetas = (collect, logger, actionResults) => {
     }
 
     set.add(meta.id);
-    finalMetas.push(meta);
+    decisionsMeta.push(meta);
   });
 
-  if (isNonEmptyArray(finalMetas)) {
+  if (isNonEmptyArray(decisionsMeta)) {
     // collect here can either be the function from createCollect or createViewCollect.
-    collect({ decisionsMeta: finalMetas });
+    collect({ decisionsMeta });
   }
 };
 

--- a/src/components/Personalization/createExecuteDecisions.js
+++ b/src/components/Personalization/createExecuteDecisions.js
@@ -15,7 +15,11 @@ import { assign, flatMap, isNonEmptyArray } from "../../utils";
 const identity = item => item;
 
 const buildActions = decision => {
-  const meta = { id: decision.id, scope: decision.scope };
+  const meta = {
+    id: decision.id,
+    scope: decision.scope,
+    scopeDetails: decision.scopeDetails
+  };
 
   return decision.items.map(item => assign({}, item.data, { meta }));
 };

--- a/src/components/Personalization/createRedirectHandler.js
+++ b/src/components/Personalization/createRedirectHandler.js
@@ -12,18 +12,18 @@ governing permissions and limitations under the License.
 
 const getRedirectDetails = redirectDecisions => {
   const decision = redirectDecisions[0];
-  const { items, id, scope } = decision;
+  const { items, id, scope, scopeDetails } = decision;
   const { content } = items[0].data;
 
-  return { content, decisions: [{ id, scope }] };
+  return { content, decisionsMeta: [{ id, scope, scopeDetails }] };
 };
 
 export default ({ collect, window, logger, showContainers }) => {
   return redirectDecisions => {
-    const { content, decisions } = getRedirectDetails(redirectDecisions);
-    const documentMayUnload = true;
+    const { content, decisionsMeta } = getRedirectDetails(redirectDecisions);
+    const isRedirectNotification = true;
 
-    return collect({ meta: { decisions }, documentMayUnload })
+    return collect({ decisionsMeta, isRedirectNotification })
       .then(() => {
         window.location.replace(content);
       })

--- a/src/components/Personalization/decisionsExtractor.js
+++ b/src/components/Personalization/decisionsExtractor.js
@@ -28,7 +28,12 @@ const splitItems = (items, schema) => {
 };
 
 const createDecision = (decision, items) => {
-  return { id: decision.id, scope: decision.scope, items };
+  return {
+    id: decision.id,
+    scope: decision.scope,
+    scopeDetails: decision.scopeDetails,
+    items
+  };
 };
 
 const splitDecisions = (decisions, schema) => {

--- a/test/functional/specs/Personalization/C205528.js
+++ b/test/functional/specs/Personalization/C205528.js
@@ -1,24 +1,19 @@
-import { t, ClientFunction, RequestLogger } from "testcafe";
+import { t, RequestLogger } from "testcafe";
 import createNetworkLogger from "../../helpers/networkLogger";
 import createFixture from "../../helpers/createFixture";
-import configureAlloyInstance from "../../helpers/configureAlloyInstance";
-import {
-  compose,
-  orgMainConfigMain,
-  debugEnabled
-} from "../../helpers/constants/configParts";
+import { orgMainConfigMain } from "../../helpers/constants/configParts";
 import { TEST_PAGE as TEST_PAGE_URL } from "../../helpers/constants/url";
+import { responseStatus } from "../../helpers/assertions";
+import createAlloyProxy from "../../helpers/createAlloyProxy";
+import getResponseBody from "../../helpers/networkLogger/getResponseBody";
+import createResponse from "../../helpers/createResponse";
 
 const networkLogger = createNetworkLogger();
 
 const redirectLogger = RequestLogger(
-  "https://alloyio.com/functional-test/alloyTestPage.html?redirectedTest=true"
+  "https://alloyio.com/functional-test/alloyTestPage.html?redirectedTest=true&test=C205528"
 );
 
-const config = compose(
-  orgMainConfigMain,
-  debugEnabled
-);
 createFixture({
   title:
     "C205528 A redirect offer should redirect the page to the URL in the redirect decision",
@@ -31,20 +26,44 @@ test.meta({
   SEVERITY: "P0",
   TEST_RUN: "Regression"
 });
+const assertRedirectNotificationType = async notificationEvents => {
+  await t.expect(notificationEvents[0].xdm.eventType).eql("redirect");
+};
 
-const triggerAlloyEvent = ClientFunction(() => {
-  return window.alloy("sendEvent", {
-    renderDecisions: true
-  });
-});
+const assertScopeDetails = async (decision, notificationEvents) => {
+  // eslint-disable-next-line no-underscore-dangle
+  const meta = notificationEvents[0].xdm._experience.decisioning.propositions;
+  await t.expect(meta[0].scopeDetails).eql(decision.scopeDetails);
+};
+
+const getDecisions = () => {
+  const response = JSON.parse(
+    getResponseBody(networkLogger.edgeEndpointLogs.requests[0])
+  );
+  return createResponse({
+    content: response
+  }).getPayloadsByType("personalization:decisions");
+};
 
 test("Test C205528: A redirect offer should redirect the page to the URL in the redirect decision", async () => {
-  await configureAlloyInstance("alloy", config);
-  try {
-    await triggerAlloyEvent();
-  } catch (e) {
-    // we'll get the ClientFunction exception here because within it we will do a redirect.
-  } finally {
-    await t.expect(redirectLogger.requests.length).eql(1);
-  }
+  const alloy = createAlloyProxy();
+  await alloy.configure(orgMainConfigMain);
+
+  await alloy.sendEvent({ renderDecisions: true });
+  await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
+
+  const decisions = getDecisions(networkLogger);
+  const redirectNotification = networkLogger.edgeEndpointLogs.requests[1];
+
+  const redirectNotificationBody = JSON.parse(
+    redirectNotification.request.body
+  );
+  const notificationEvents = redirectNotificationBody.events;
+
+  // expect the redirect notification is sent
+  await assertRedirectNotificationType(notificationEvents);
+  await assertScopeDetails(decisions[0], notificationEvents);
+
+  // expect the redirect was executed
+  await t.expect(redirectLogger.requests.length).eql(1);
 });

--- a/test/unit/specs/components/Personalization/createExecuteDecisions.spec.js
+++ b/test/unit/specs/components/Personalization/createExecuteDecisions.spec.js
@@ -21,6 +21,10 @@ describe("Personalization::createExecuteDecisions", () => {
     {
       id: 1,
       scope: "foo",
+      scopeDetails: {
+        experienceId: 123,
+        branchId: 234
+      },
       items: [
         {
           schema: "https://ns.adobe.com/personalization/dom-action",
@@ -35,6 +39,10 @@ describe("Personalization::createExecuteDecisions", () => {
     {
       id: 5,
       scope: "__view__",
+      scopeDetails: {
+        experienceId: 456,
+        branchId: 654
+      },
       items: [
         {
           schema: "https://ns.adobe.com/personalization/dom-action",
@@ -54,18 +62,21 @@ describe("Personalization::createExecuteDecisions", () => {
       content: "<div>Hola Mundo</div>",
       meta: {
         id: decisions[0].id,
-        scope: "foo"
+        scope: "foo",
+        scopeDetails: decisions[0].scopeDetails
       }
     }
   ];
   const metas = [
     {
       id: decisions[0].id,
-      scope: decisions[0].scope
+      scope: decisions[0].scope,
+      scopeDetails: decisions[0].scopeDetails
     },
     {
       id: decisions[1].id,
-      scope: decisions[1].scope
+      scope: decisions[1].scope,
+      scopeDetails: decisions[1].scopeDetails
     }
   ];
   const modules = {

--- a/test/unit/specs/components/Personalization/createRedirectHandler.spec.js
+++ b/test/unit/specs/components/Personalization/createRedirectHandler.spec.js
@@ -18,16 +18,15 @@ describe("Personalization::createRedirectDecisionHandler", () => {
   let showContainers;
   let logger;
 
-  const documentMayUnload = true;
+  const isRedirectNotification = true;
   const decisions = REDIRECT_PAGE_WIDE_SCOPE_DECISION;
-  const meta = {
-    decisions: [
-      {
-        id: decisions[0].id,
-        scope: decisions[0].scope
-      }
-    ]
-  };
+  const decisionsMeta = [
+    {
+      id: decisions[0].id,
+      scope: decisions[0].scope,
+      scopeDetails: decisions[0].scopeDetails
+    }
+  ];
   const replace = jasmine.createSpy();
 
   const window = {
@@ -48,7 +47,10 @@ describe("Personalization::createRedirectDecisionHandler", () => {
       showContainers
     });
     return handleRedirectDecisions(decisions).then(() => {
-      expect(collect).toHaveBeenCalledWith({ meta, documentMayUnload });
+      expect(collect).toHaveBeenCalledWith({
+        decisionsMeta,
+        isRedirectNotification
+      });
       expect(replace).toHaveBeenCalledWith(decisions[0].items[0].data.content);
     });
   });

--- a/test/unit/specs/components/Personalization/responsesMock/eventResponses.js
+++ b/test/unit/specs/components/Personalization/responsesMock/eventResponses.js
@@ -48,6 +48,8 @@ export const PAGE_WIDE_SCOPE_DECISIONS = [
   {
     id: "TNT:activity1:experience1",
     scope: "__view__",
+    scopeDetails:
+      "this is a field that we don't process so will be using just a string",
     items: [
       {
         schema: "https://ns.adobe.com/personalization/dom-action",
@@ -86,6 +88,8 @@ export const PAGE_WIDE_SCOPE_DECISIONS_WITHOUT_DOM_ACTION_SCHEMA_ITEMS = [
   {
     id: "TNT:activity1:experience1",
     scope: "__view__",
+    scopeDetails:
+      "this is a field that we don't process so will be using just a string",
     items: [
       {
         schema: "https://ns.adove.com/experience/item",
@@ -108,6 +112,8 @@ export const PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS = [
   {
     id: "TNT:activity1:experience1",
     scope: "__view__",
+    scopeDetails:
+      "this is a field that we don't process so will be using just a string",
     items: [
       {
         schema: "https://ns.adobe.com/personalization/dom-action",
@@ -181,6 +187,8 @@ export const REDIRECT_PAGE_WIDE_SCOPE_DECISION = [
   {
     id: "TNT:activity15:experience1",
     scope: "__view__",
+    scopeDetails:
+      "here should be an object but we don't process it so will be using a string",
     items: [
       {
         schema: "https://ns.adobe.com/personalization/redirect-item",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
In case of a redirect from PAGE_A to PAGE_B we will have to notify Analytics that we are on PAGE_B because of a Target Redirect Offer.
In this case, we will have along `scope, id and items` another field called `scopeDetails` where we will store data like: `activity, experience, strategies and blob`.
`blob` will contain analytics related data, like: `tnta, state and eventToken`. 
The `scopeDetails` object will not be processed by alloy, it will be just cached and forwarded back to konductor.

We will use a special `eventType: "redirect"` to differentiate a notification call for a redirect offer being executed. 
When a notification for a redirect will be fired, on the Konductor side we will extract the `tnta` value and return it to alloy in the `state:store` payload, so that alloy could create a cookie. It is similar to how we process `target session ID`. This is why we will need to wait till the response is back and then we can do the magic with `window.location.replace` to the new URL. 

The next interact call from the PAGE_B will read the cookie, do the Analytics data exchange and then remove the cookie.

PS: this scenario will work in case customer decides to execute the redirect offer by themselves and send the `redirect` notification (granted they will provide the same `scopeDetails` )
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
