### PR TITLE
PDCL-4785 Log when an event has been canceled by onBeforeEventSend.

### DIFF
--- a/src/components/Audiences/injectProcessDestinations.js
+++ b/src/components/Audiences/injectProcessDestinations.js
@@ -25,7 +25,7 @@ const processUrls = (fireReferrerHideableImage, logger, destinations) => {
     urlDestinations.map(urlDestination => {
       return fireReferrerHideableImage(urlDestination.spec)
         .then(() => {
-          logger.log(createResultLogMessage(urlDestination, true));
+          logger.info(createResultLogMessage(urlDestination, true));
         })
         .catch(() => {
           // We intentionally do not throw an error if destinations fail. We

--- a/src/components/Identity/injectEnsureSingleIdentity.js
+++ b/src/components/Identity/injectEnsureSingleIdentity.js
@@ -56,7 +56,7 @@ export default ({
       // response. We will hold up this request until the last request
       // requiring identity returns and awaitIdentityCookie confirms the
       // identity was set.
-      logger.log("Delaying request while retrieving ECID from server.");
+      logger.info("Delaying request while retrieving ECID from server.");
       const previousObtainedIdentityPromise = obtainedIdentityPromise;
 
       // This promise resolves when we have an identity cookie. Additional
@@ -70,7 +70,7 @@ export default ({
       return (
         previousObtainedIdentityPromise
           .then(() => {
-            logger.log("Resuming previously delayed request.");
+            logger.info("Resuming previously delayed request.");
             request.setIsIdentityEstablished();
           })
           // If Konductor did not set the identity cookie on the previous

--- a/src/components/Identity/injectProcessIdSyncs.js
+++ b/src/components/Identity/injectProcessIdSyncs.js
@@ -25,7 +25,7 @@ export default ({ fireReferrerHideableImage, logger }) => idSyncs => {
     urlIdSyncs.map(idSync => {
       return fireReferrerHideableImage(idSync.spec)
         .then(() => {
-          logger.log(createResultLogMessage(idSync, true));
+          logger.info(createResultLogMessage(idSync, true));
         })
         .catch(() => {
           // We intentionally do not throw an error if id syncs fail. We

--- a/src/components/Identity/visitorService/awaitVisitorOptIn.js
+++ b/src/components/Identity/visitorService/awaitVisitorOptIn.js
@@ -16,12 +16,12 @@ export default ({ logger }) => {
   return new Promise((resolve, reject) => {
     if (isObject(window.adobe) && isObject(window.adobe.optIn)) {
       const optInOld = window.adobe.optIn;
-      logger.log(
+      logger.info(
         "Delaying request while waiting for legacy opt-in to let Visitor retrieve ECID from server."
       );
       optInOld.fetchPermissions(() => {
         if (optInOld.isApproved([optInOld.Categories.ECID])) {
-          logger.log(
+          logger.info(
             "Received legacy opt-in approval to let Visitor retrieve ECID from server."
           );
           resolve();

--- a/src/components/Identity/visitorService/injectGetEcidFromVisitor.js
+++ b/src/components/Identity/visitorService/injectGetEcidFromVisitor.js
@@ -20,14 +20,14 @@ export default ({ logger, orgId, awaitVisitorOptIn }) => {
       // with invalid values prior to optIn being approved
       return awaitVisitorOptIn({ logger })
         .then(() => {
-          logger.log(
+          logger.info(
             "Delaying request while using Visitor to retrieve ECID from server."
           );
 
           return new Promise(resolve => {
             const visitor = Visitor.getInstance(orgId, {});
             visitor.getMarketingCloudVisitorID(ecid => {
-              logger.log(
+              logger.info(
                 "Resuming previously delayed request that was waiting for ECID from Visitor."
               );
               resolve(ecid);
@@ -39,11 +39,11 @@ export default ({ logger, orgId, awaitVisitorOptIn }) => {
           // consent should operate independently, but during id migration AEP Web SDK needs
           // to wait for optIn object consent resolution so that only one ECID is generated.
           if (error) {
-            logger.log(
+            logger.info(
               `${error.message}, retrieving ECID from experience edge`
             );
           } else {
-            logger.log(
+            logger.info(
               "An error occurred while obtaining the ECID from Visitor."
             );
           }

--- a/src/components/Personalization/dom-actions/executeActions.js
+++ b/src/components/Personalization/dom-actions/executeActions.js
@@ -26,7 +26,7 @@ const logActionCompleted = (logger, action) => {
   if (logger.enabled) {
     const details = JSON.stringify(action);
 
-    logger.log(`Action ${details} executed.`);
+    logger.info(`Action ${details} executed.`);
   }
 };
 

--- a/src/core/createEvent.js
+++ b/src/core/createEvent.js
@@ -78,7 +78,8 @@ export default () => {
         // assume that the onBeforeEventSend callback will fail (in-case of an error)
         shouldSendEvent = false;
 
-        // this allows the user to replace the object passed into the callback
+        // this allows the user to replace the xdm and data properties
+        // on the object passed to the callback
         const tempContent = {
           xdm: content.xdm || {},
           data: content.data || {}

--- a/src/core/createEventManager.js
+++ b/src/core/createEventManager.js
@@ -12,8 +12,12 @@ governing permissions and limitations under the License.
 
 import { createCallbackAggregator } from "../utils";
 
+const EVENT_CANCELLATION_MESSAGE =
+  "Event was canceled because the onBeforeEventSend callback returned false.";
+
 export default ({
   config,
+  logger,
   lifecycle,
   consent,
   createEvent,
@@ -74,7 +78,8 @@ export default ({
           // if the callback returns false, the event should not be sent
           if (!event.shouldSend()) {
             onRequestFailureCallbackAggregator.add(lifecycle.onRequestFailure);
-            const error = new Error("Event was cancelled.");
+            logger.info(EVENT_CANCELLATION_MESSAGE);
+            const error = new Error(EVENT_CANCELLATION_MESSAGE);
             return onRequestFailureCallbackAggregator
               .call({ error })
               .then(() => {

--- a/src/core/createLogger.js
+++ b/src/core/createLogger.js
@@ -92,11 +92,6 @@ export default ({ getDebugEnabled, console, getMonitors, context }) => {
       );
     },
     /**
-     * Outputs a message to the web console.
-     * @param {...*} arg Any argument to be logged.
-     */
-    log: log.bind(null, "log"),
-    /**
      * Outputs informational message to the web console. In some
      * browsers a small "i" icon is displayed next to these items
      * in the web console's log.

--- a/src/core/network/requestMethods/injectSendBeaconRequest.js
+++ b/src/core/network/requestMethods/injectSendBeaconRequest.js
@@ -14,7 +14,7 @@ export default ({ sendBeacon, sendFetchRequest, logger }) => {
   return (url, body) => {
     const blob = new Blob([body], { type: "text/plain; charset=UTF-8" });
     if (!sendBeacon(url, blob)) {
-      logger.log("Unable to use `sendBeacon`; falling back to `fetch`.");
+      logger.info("Unable to use `sendBeacon`; falling back to `fetch`.");
       return sendFetchRequest(url, body);
     }
 

--- a/test/functional/specs/Data Collector/C1715149.js
+++ b/test/functional/specs/Data Collector/C1715149.js
@@ -1,8 +1,12 @@
 import { t, ClientFunction } from "testcafe";
 import createNetworkLogger from "../../helpers/networkLogger";
 import createFixture from "../../helpers/createFixture";
-import { orgMainConfigMain } from "../../helpers/constants/configParts";
+import {
+  debugEnabled,
+  orgMainConfigMain
+} from "../../helpers/constants/configParts";
 import createAlloyProxy from "../../helpers/createAlloyProxy";
+import createConsoleLogger from "../../helpers/consoleLogger";
 
 const networkLogger = createNetworkLogger();
 
@@ -66,9 +70,11 @@ test("C1715149 Events should call onBeforeEventSend callback, fail, and not send
 });
 
 test("C1715149 Events should call onBeforeEventSend callback, return false, and not send event", async () => {
+  const logger = await createConsoleLogger();
   const alloy = createAlloyProxy();
   await alloy.configure({
     ...orgMainConfigMain,
+    ...debugEnabled,
     onBeforeEventSend: onBeforeEventSendFalse
   });
 
@@ -79,4 +85,5 @@ test("C1715149 Events should call onBeforeEventSend callback, return false, and 
   // if event is cancelled, the promise should resolve with an empty object
   await t.expect(result).eql({});
   await t.expect(networkLogger.edgeInteractEndpointLogs.requests.length).eql(0);
+  await logger.info.expectMessageMatching(/Event was canceled/);
 });

--- a/test/unit/specs/components/Audiences/injectProcessDestinations.spec.js
+++ b/test/unit/specs/components/Audiences/injectProcessDestinations.spec.js
@@ -10,7 +10,7 @@ describe("Audiences::injectProcessDestinations", () => {
     fireReferrerHideableImage = jasmine
       .createSpy()
       .and.returnValue(Promise.resolve());
-    logger = jasmine.createSpyObj("logger", ["log", "error"]);
+    logger = jasmine.createSpyObj("logger", ["info", "error"]);
     processDestinations = injectProcessDestinations({
       fireReferrerHideableImage,
       logger
@@ -94,7 +94,7 @@ describe("Audiences::injectProcessDestinations", () => {
         url: "http://test.zyx",
         hideReferrer: false
       });
-      expect(logger.log).toHaveBeenCalledWith(
+      expect(logger.info).toHaveBeenCalledWith(
         "URL destination succeeded: http://test.zyx"
       );
       expect(logger.error).toHaveBeenCalledWith(

--- a/test/unit/specs/components/DataCollector/index.spec.js
+++ b/test/unit/specs/components/DataCollector/index.spec.js
@@ -25,9 +25,7 @@ describe("Event Command", () => {
       "mergeXdm",
       "mergeMeta"
     ]);
-    logger = jasmine.createSpyObj("logger", {
-      warn: undefined
-    });
+    logger = jasmine.createSpyObj("logger", ["warn"]);
 
     eventManager = {
       createEvent() {

--- a/test/unit/specs/components/Identity/injectEnsureSingleIdentity.spec.js
+++ b/test/unit/specs/components/Identity/injectEnsureSingleIdentity.spec.js
@@ -32,7 +32,7 @@ describe("Identity::injectEnsureSingleIdentity", () => {
   let doesIdentityCookieExistBoolean;
 
   beforeEach(() => {
-    logger = jasmine.createSpyObj("logger", ["log"]);
+    logger = jasmine.createSpyObj("logger", ["info"]);
 
     sentIndex = 0;
     receivedIndex = 0;
@@ -173,19 +173,19 @@ describe("Identity::injectEnsureSingleIdentity", () => {
         return flushPromiseChains();
       })
       .then(() => {
-        expect(logger.log).not.toHaveBeenCalled();
+        expect(logger.info).not.toHaveBeenCalled();
         sendRequest();
         return flushPromiseChains();
       })
       .then(() => {
-        expect(logger.log).toHaveBeenCalledWith(
+        expect(logger.info).toHaveBeenCalledWith(
           "Delaying request while retrieving ECID from server."
         );
         simulateResponseWithIdentity();
         return flushPromiseChains();
       })
       .then(() => {
-        expect(logger.log).toHaveBeenCalledWith(
+        expect(logger.info).toHaveBeenCalledWith(
           "Resuming previously delayed request."
         );
       });

--- a/test/unit/specs/components/Identity/injectProcessIdSyncs.spec.js
+++ b/test/unit/specs/components/Identity/injectProcessIdSyncs.spec.js
@@ -9,7 +9,7 @@ describe("Identity::injectProcessIdSyncs", () => {
     fireReferrerHideableImage = jasmine
       .createSpy()
       .and.returnValue(Promise.resolve());
-    logger = jasmine.createSpyObj("logger", ["log", "error"]);
+    logger = jasmine.createSpyObj("logger", ["info", "error"]);
     processIdSyncs = injectProcessIdSyncs({
       fireReferrerHideableImage,
       logger
@@ -64,7 +64,7 @@ describe("Identity::injectProcessIdSyncs", () => {
         url: "http://test.zyx",
         hideReferrer: false
       });
-      expect(logger.log).toHaveBeenCalledWith(
+      expect(logger.info).toHaveBeenCalledWith(
         "ID sync succeeded: http://test.zyx"
       );
       expect(logger.error).toHaveBeenCalledWith(

--- a/test/unit/specs/components/Identity/visitorService/awaitVisitorOptIn.spec.js
+++ b/test/unit/specs/components/Identity/visitorService/awaitVisitorOptIn.spec.js
@@ -12,9 +12,7 @@ governing permissions and limitations under the License.
 
 import awaitVisitorOptIn from "../../../../../../src/components/Identity/visitorService/awaitVisitorOptIn";
 
-const logger = {
-  log() {}
-};
+const logger = jasmine.createSpyObj(["info"]);
 
 describe("awaitVisitorOptIn", () => {
   beforeEach(() => {

--- a/test/unit/specs/components/Identity/visitorService/injectGetEcidFromVisitor.spec.js
+++ b/test/unit/specs/components/Identity/visitorService/injectGetEcidFromVisitor.spec.js
@@ -12,9 +12,7 @@ governing permissions and limitations under the License.
 
 import injectGetEcidFromVisitor from "../../../../../../src/components/Identity/visitorService/injectGetEcidFromVisitor";
 
-const logger = {
-  log() {}
-};
+const logger = jasmine.createSpyObj(["info"]);
 
 const Visitor = () => {};
 Visitor.getInstance = () => {

--- a/test/unit/specs/components/Personalization/createExecuteDecisions.spec.js
+++ b/test/unit/specs/components/Personalization/createExecuteDecisions.spec.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 import createExecuteDecisions from "../../../../../src/components/Personalization/createExecuteDecisions";
 
 describe("Personalization::createExecuteDecisions", () => {
-  const logger = jasmine.createSpyObj("logger", ["log", "warn", "error"]);
+  const logger = jasmine.createSpyObj("logger", ["info", "warn", "error"]);
   let executeActions;
   let collect;
 

--- a/test/unit/specs/components/Personalization/dom-actions/executeActions.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/executeActions.spec.js
@@ -15,7 +15,7 @@ import executeActions from "../../../../../../src/components/Personalization/dom
 describe("Personalization::executeActions", () => {
   it("should execute actions", () => {
     const actionSpy = jasmine.createSpy().and.returnValue(Promise.resolve(1));
-    const logger = jasmine.createSpyObj("logger", ["error", "log"]);
+    const logger = jasmine.createSpyObj("logger", ["error", "info"]);
     logger.enabled = true;
     const actions = [{ type: "foo" }];
     const modules = {
@@ -25,14 +25,14 @@ describe("Personalization::executeActions", () => {
     return executeActions(actions, modules, logger).then(result => {
       expect(result).toEqual([1]);
       expect(actionSpy).toHaveBeenCalled();
-      expect(logger.log.calls.count()).toEqual(1);
+      expect(logger.info.calls.count()).toEqual(1);
       expect(logger.error).not.toHaveBeenCalled();
     });
   });
 
-  it("should not invoke logger.log when logger is not enabled", () => {
+  it("should not invoke logger.info when logger is not enabled", () => {
     const actionSpy = jasmine.createSpy().and.returnValue(Promise.resolve(1));
-    const logger = jasmine.createSpyObj("logger", ["error", "log"]);
+    const logger = jasmine.createSpyObj("logger", ["error", "info"]);
     logger.enabled = false;
     const actions = [{ type: "foo" }];
     const modules = {
@@ -41,13 +41,13 @@ describe("Personalization::executeActions", () => {
     return executeActions(actions, modules, logger).then(result => {
       expect(result).toEqual([1]);
       expect(actionSpy).toHaveBeenCalled();
-      expect(logger.log.calls.count()).toEqual(0);
+      expect(logger.info.calls.count()).toEqual(0);
       expect(logger.error).not.toHaveBeenCalled();
     });
   });
 
   it("should throw error when execute actions fails", () => {
-    const logger = jasmine.createSpyObj("logger", ["error", "log"]);
+    const logger = jasmine.createSpyObj("logger", ["error", "info"]);
     logger.enabled = true;
     const actions = [{ type: "foo" }];
     const modules = {
@@ -58,19 +58,19 @@ describe("Personalization::executeActions", () => {
   });
 
   it("should log nothing when there are no actions", () => {
-    const logger = jasmine.createSpyObj("logger", ["error", "log"]);
+    const logger = jasmine.createSpyObj("logger", ["error", "info"]);
     const actions = [];
     const modules = {};
 
     return executeActions(actions, modules, logger).then(result => {
       expect(result).toEqual([]);
-      expect(logger.log).not.toHaveBeenCalled();
+      expect(logger.info).not.toHaveBeenCalled();
       expect(logger.error).not.toHaveBeenCalled();
     });
   });
 
   it("should throw error when there are no actions types", () => {
-    const logger = jasmine.createSpyObj("logger", ["error", "log"]);
+    const logger = jasmine.createSpyObj("logger", ["error", "info"]);
     logger.enabled = true;
     const actions = [{ type: "foo1" }];
     const modules = {

--- a/test/unit/specs/core/buildAndValidateConfig.spec.js
+++ b/test/unit/specs/core/buildAndValidateConfig.spec.js
@@ -34,7 +34,7 @@ describe("buildAndValidateConfig", () => {
     };
     logger = {
       enabled: false,
-      log: jasmine.createSpy(),
+      info: jasmine.createSpy(),
       logOnBeforeCommand: jasmine.createSpy(),
       logOnInstanceConfigured: jasmine.createSpy()
     };

--- a/test/unit/specs/core/createEventManager.spec.js
+++ b/test/unit/specs/core/createEventManager.spec.js
@@ -15,6 +15,8 @@ import createConfig from "../../../../src/core/config/createConfig";
 import { defer } from "../../../../src/utils";
 import flushPromiseChains from "../../helpers/flushPromiseChains";
 
+const CANCELLATION_MESSAGE_REGEX = /Event was canceled/;
+
 describe("createEventManager", () => {
   let config;
   let logger;
@@ -33,7 +35,7 @@ describe("createEventManager", () => {
       onBeforeEventSend: jasmine.createSpy(),
       debugEnabled: true
     });
-    logger = jasmine.createSpyObj("logger", ["error", "warn"]);
+    logger = jasmine.createSpyObj("logger", ["info"]);
     lifecycle = jasmine.createSpyObj("lifecycle", {
       onBeforeEvent: Promise.resolve(),
       onBeforeDataCollectionRequest: Promise.resolve(),
@@ -136,7 +138,10 @@ describe("createEventManager", () => {
         expect(
           onRequestFailureForOnBeforeEvent.calls.mostRecent().args[0].error
             .message
-        ).toBe("Event was cancelled.");
+        ).toMatch(CANCELLATION_MESSAGE_REGEX);
+        expect(logger.info).toHaveBeenCalledWith(
+          jasmine.stringMatching(CANCELLATION_MESSAGE_REGEX)
+        );
         expect(sendEdgeNetworkRequest).not.toHaveBeenCalled();
       });
     });

--- a/test/unit/specs/core/createLogger.spec.js
+++ b/test/unit/specs/core/createLogger.spec.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 import createLogger from "../../../../src/core/createLogger";
 
-const logMethods = ["log", "info", "warn", "error"];
+const logMethods = ["info", "warn", "error"];
 const monitorMethods = [
   "onInstanceCreated",
   "onInstanceConfigured",

--- a/test/unit/specs/core/edgeNetwork/injectSendEdgeNetworkRequest.spec.js
+++ b/test/unit/specs/core/edgeNetwork/injectSendEdgeNetworkRequest.spec.js
@@ -112,7 +112,7 @@ describe("injectSendEdgeNetworkRequest", () => {
       getUseIdThirdPartyDomain: false,
       getUseSendBeacon: false
     });
-    logger = jasmine.createSpyObj("logger", ["log"]);
+    logger = jasmine.createSpyObj("logger", ["info"]);
     lifecycle = jasmine.createSpyObj("lifecycle", {
       onBeforeRequest: Promise.resolve(),
       onRequestFailure: Promise.resolve(),

--- a/test/unit/specs/core/injectExecuteCommand.spec.js
+++ b/test/unit/specs/core/injectExecuteCommand.spec.js
@@ -19,7 +19,6 @@ describe("injectExecuteCommand", () => {
 
   beforeEach(() => {
     logger = jasmine.createSpyObj("logger", [
-      "log",
       "info",
       "warn",
       "error",

--- a/test/unit/specs/core/network/requestMethods/injectSendBeaconRequest.spec.js
+++ b/test/unit/specs/core/network/requestMethods/injectSendBeaconRequest.spec.js
@@ -33,9 +33,7 @@ describe("injectSendBeaconRequest", () => {
       const sendFetchRequest = jasmine
         .createSpy()
         .and.returnValue(sendFetchRequestPromise);
-      const logger = {
-        log: jasmine.createSpy()
-      };
+      const logger = jasmine.createSpyObj(["info"]);
       const sendBeaconRequest = injectSendBeaconRequest({
         sendBeacon,
         sendFetchRequest,
@@ -51,7 +49,7 @@ describe("injectSendBeaconRequest", () => {
         "https://example.com/endpoint",
         body
       );
-      expect(logger.log).toHaveBeenCalledWith(
+      expect(logger.info).toHaveBeenCalledWith(
         jasmine.stringMatching("falling back to")
       );
       expect(result).toBe(sendFetchRequestPromise);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Closes #700. When an event is canceled by an `onBeforeEventSend` callback returning `false`, the customer would like to know that the event has been canceled by seeing a log message in the console.

While working on this, I noticed we were using `logger.log` sometimes and `logger.info` other times, without any real pattern as to when/why we were using the separate APIs. I've removed the `logger.log` API entirely and converted all usages to `logger.info`.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/PDCL-4785
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Improved transparency into what's happening with events.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
