### PR TITLE
Fixing watchFunctionalTests.js.

### DIFF
--- a/scripts/watchFunctionalTests.js
+++ b/scripts/watchFunctionalTests.js
@@ -39,10 +39,12 @@ let firstBuildComplete = false;
 
 const effectByEventCode = {
   BUNDLE_START(event) {
-    console.log(`Bundling ${event.input} to ${event.output}`);
+    console.log(`Started bundling ${event.input} to ${event.output}`);
   },
   async BUNDLE_END(event) {
-    console.log(`Bundled ${event.input} to ${event.output}`);
+    console.log(`Finished bundling ${event.input} to ${event.output}`);
+  },
+  async END() {
     if (firstBuildComplete) {
       console.log(
         `Press Ctrl+R to restart the test run against the new build.`
@@ -64,7 +66,7 @@ const effectByEventCode = {
   // Ideally we would pass these environment variables as part
   // of the loadConfigFile function, but that doesn't work.
   // See https://github.com/rollup/rollup/issues/4003
-  process.env.SANDBOX = "true";
+  process.env.STANDALONE = "true";
   process.env.NPM_PACKAGE_LOCAL = "true";
   process.env.BASE_CODE_MIN = "true";
   const { options, warnings } = await loadConfigFile(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
watchFunctionalTests.js was outputting Alloy to `sandbox/public` when testcafe was loading Alloy from `dist`, so TestCafe wasn't picking up any new changes. Also, we weren't waiting for all the bundles to finish building before running the tests, leading to errors.
<!--- Describe your changes in detail -->

## Related Issue
None
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
