### PR TITLE
PDCL-1352 - Adds lint rules to check for focused tests added by mistake

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
       { name: "fdescribe", message: "don't focus tests" },
       { name: ["it", "only"], message: "don't focus tests" },
       { name: "fit", message: "don't focus tests" },
+      { name: ["fixture", "only"], message: "don't focus tests" },
       { name: ["test", "only"], message: "don't focus tests" },
       { name: "ftest", message: "don't focus tests" }
     ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,8 +5,17 @@ module.exports = {
     node: true,
     jasmine: true
   },
-  plugins: ["prettier", "testcafe"],
+  plugins: ["ban", "prettier", "testcafe"],
   rules: {
+    "ban/ban": [
+      "error",
+      { name: ["describe", "only"], message: "don't focus tests" },
+      { name: "fdescribe", message: "don't focus tests" },
+      { name: ["it", "only"], message: "don't focus tests" },
+      { name: "fit", message: "don't focus tests" },
+      { name: ["test", "only"], message: "don't focus tests" },
+      { name: "ftest", message: "don't focus tests" }
+    ],
     "prettier/prettier": "error",
     "no-param-reassign": ["error", { props: false }],
     "func-style": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "eslint": "^6.5.1",
         "eslint-config-airbnb-base": "^14.0.0",
         "eslint-config-prettier": "^6.4.0",
+        "eslint-plugin-ban": "^1.5.2",
         "eslint-plugin-import": "^2.16.0",
         "eslint-plugin-prettier": "^3.0.1",
         "eslint-plugin-testcafe": "^0.2.1",
@@ -6681,6 +6682,18 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "node_modules/eslint-plugin-ban": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ban/-/eslint-plugin-ban-1.5.2.tgz",
+      "integrity": "sha512-i6yjMbep866kREX8HfCPM32QyTZG4gfhlEFjL7s04P+sJjsM+oa0pejwyLOz/6s/oiW7BQqc6u3Dcr9tKz+svg==",
+      "dev": true,
+      "dependencies": {
+        "requireindex": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/eslint-plugin-import": {
       "version": "2.18.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
@@ -12761,6 +12774,15 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
+    },
+    "node_modules/requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.5"
+      }
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
@@ -23950,6 +23972,15 @@
         }
       }
     },
+    "eslint-plugin-ban": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ban/-/eslint-plugin-ban-1.5.2.tgz",
+      "integrity": "sha512-i6yjMbep866kREX8HfCPM32QyTZG4gfhlEFjL7s04P+sJjsM+oa0pejwyLOz/6s/oiW7BQqc6u3Dcr9tKz+svg==",
+      "dev": true,
+      "requires": {
+        "requireindex": "~1.2.0"
+      }
+    },
     "eslint-plugin-import": {
       "version": "2.18.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
@@ -28820,6 +28851,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
       "dev": true
     },
     "requires-port": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "eslint": "^6.5.1",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^6.4.0",
+    "eslint-plugin-ban": "^1.5.2",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-testcafe": "^0.2.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change implements the eslint plugin "ban" to check for focused unit or functional tests that were added by mistake.

E.g. `fit()` or `fdescribe()`, or `test.only()` or `fixture.only()`

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
