### PR TITLE
Check only the error detail in IAB tests

### DIFF
--- a/test/functional/specs/Privacy/C14410.js
+++ b/test/functional/specs/Privacy/C14410.js
@@ -53,7 +53,7 @@ test("Test C14410: Setting consent for unknown purposes fails", async t => {
     .contains("The server responded with a status code 400")
     .expect(errorMessage)
     .contains(
-      "Invalid request. The value supplied for field 'consent.[0].value' does not match your input schema"
+      "The value supplied for field 'consent.[0].value' does not match your input schema"
     );
 
   // make sure we can call it again with the correct values

--- a/test/functional/specs/Privacy/IAB/C224675.js
+++ b/test/functional/specs/Privacy/IAB/C224675.js
@@ -101,9 +101,7 @@ test("Test C224675: Passing invalid consent options should throw a validation er
     .expect(errorMessageForInvalidValue)
     .contains("The server responded with a status code 400")
     .expect(errorMessageForInvalidValue)
-    .contains(
-      "Invalid request. No value supplied for field 'consent.[0].value'"
-    );
+    .contains("No value supplied for field 'consent.[0].value'");
 
   await t.expect(errorMessageForInvalidValue).contains("EXEG-0103-400");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The errors are now updated to contain a short `title` and then a `detail` field. One example:

```javascript
//before
{
  "type": "https://ns.adobe.com/aep/errors/EXEG-0103-400",
  "status": 400,
  "title": "Invalid request. No value supplied for required field consent.[0].value'.",
  "report": {
    "requestId": "0837dd9a-c070-4cdc-99ae-725b1671c3f0",
    "configId": "bc1a10e0-aee4-4e0e-ac5b-cdbb9abbec83:prod",
    "orgId": "5BFE274A5F6980A50A495C08@AdobeOrg"
  }
}
```
Is now changed to:

```javascript
//after
{
  "type": "https://ns.adobe.com/aep/errors/EXEG-0103-400",
  "status": 400,
  "title": "Invalid request",
  "detail": "No value supplied for required field consent.[0].value'.",
  "report": {
    "requestId": "0837dd9a-c070-4cdc-99ae-725b1671c3f0",
    "configId": "bc1a10e0-aee4-4e0e-ac5b-cdbb9abbec83:prod",
    "orgId": "5BFE274A5F6980A50A495C08@AdobeOrg"
  }
}
```


<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
