### PR TITLE
PDCL-5928 Decoupling test assertions from server-generated messaging.

### DIFF
--- a/test/functional/specs/Privacy/C14410.js
+++ b/test/functional/specs/Privacy/C14410.js
@@ -52,9 +52,7 @@ test("Test C14410: Setting consent for unknown purposes fails", async t => {
     .expect(errorMessage)
     .contains("The server responded with a status code 400")
     .expect(errorMessage)
-    .contains(
-      "The value supplied for field 'consent.[0].value' does not match your input schema"
-    );
+    .contains("EXEG-0102-400");
 
   // make sure we can call it again with the correct values
   await alloy.setConsent(CONSENT_IN);

--- a/test/functional/specs/Privacy/IAB/C224675.js
+++ b/test/functional/specs/Privacy/IAB/C224675.js
@@ -9,11 +9,7 @@ import {
 } from "../../../helpers/constants/configParts";
 import createAlloyProxy from "../../../helpers/createAlloyProxy";
 
-const config = compose(
-  orgMainConfigMain,
-  consentPending,
-  debugEnabled
-);
+const config = compose(orgMainConfigMain, consentPending, debugEnabled);
 
 const networkLogger = createNetworkLogger();
 
@@ -54,11 +50,7 @@ test("Test C224675: Passing invalid consent options should throw a validation er
     .expect(errorMessageForInvalidStandard)
     .contains("The server responded with a status code 400")
     .expect(errorMessageForInvalidStandard)
-    .contains(
-      "The value supplied for field 'consent[0]' does not match your input schema"
-    );
-
-  await t.expect(errorMessageForInvalidStandard).contains("EXEG-0102-400");
+    .contains("EXEG-0102-400");
 
   const errorMessageForInvalidVersion = await alloy.setConsentErrorMessage({
     consent: [
@@ -78,11 +70,7 @@ test("Test C224675: Passing invalid consent options should throw a validation er
     .expect(errorMessageForInvalidVersion)
     .contains("The server responded with a status code 400")
     .expect(errorMessageForInvalidVersion)
-    .contains(
-      "The value supplied for field 'consent[0]' does not match your input schema"
-    );
-
-  await t.expect(errorMessageForInvalidVersion).contains("EXEG-0102-400");
+    .contains("EXEG-0102-400");
 
   const errorMessageForInvalidValue = await alloy.setConsentErrorMessage({
     consent: [
@@ -101,9 +89,7 @@ test("Test C224675: Passing invalid consent options should throw a validation er
     .expect(errorMessageForInvalidValue)
     .contains("The server responded with a status code 400")
     .expect(errorMessageForInvalidValue)
-    .contains("No value supplied for field 'consent.[0].value'");
-
-  await t.expect(errorMessageForInvalidValue).contains("EXEG-0103-400");
+    .contains("EXEG-0103-400");
 
   const errorMessageForEmptyValue = await alloy.setConsentErrorMessage({
     consent: [
@@ -123,9 +109,5 @@ test("Test C224675: Passing invalid consent options should throw a validation er
     .expect(errorMessageForEmptyValue)
     .contains("The server responded with a status code 422")
     .expect(errorMessageForEmptyValue)
-    .contains(
-      "IAB consent string value must not be empty for standard 'IAB TCF' at index 0"
-    );
-
-  await t.expect(errorMessageForEmptyValue).contains("EXEG-0104-422");
+    .contains("EXEG-0104-422");
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Some test assertions were dependent on server-generated error descriptions. Because Konductor treats changes to server-generated error descriptions as backward-compatible, our tests shouldn't fail when changes to the descriptions change.

This also fixes functional tests in `main`, because Konductor recently made additional changes to their descriptions.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/PDCL-5928
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Changes to error descriptions shouldn't fail Alloy tests, because they are considered backward-compatible changes.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
