### PR TITLE
PDCL-4714 Include older Alloy versions in pre-edge-deploy and prod workflows

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -45,5 +45,5 @@ jobs:
     - name: Build
       run: npm run test:functional:build:int
     - name: Run Functional Test
-      run: npx testcafe -q -c 5 'saucelabs:Chrome@latest-1:macOS 11.00','saucelabs:IE@latest:Windows 10','saucelabs:Firefox@latest:Windows 10','saucelabs:Safari@latest:macOS 11.00'
+      run: npx testcafe -q -c 5 'saucelabs:Chrome@latest:macOS 11.00','saucelabs:IE@latest:Windows 10','saucelabs:Firefox@latest:Windows 10','saucelabs:Safari@latest:macOS 11.00'
     

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -46,4 +46,4 @@ jobs:
       run: npm run test:functional:build:int
     - name: Run Functional Test
       run: npx testcafe -q -c 5 'saucelabs:Chrome@latest:macOS 11.00','saucelabs:IE@latest:Windows 10','saucelabs:Firefox@latest:Windows 10','saucelabs:Safari@latest:macOS 11.00'
-    
+      

--- a/.github/workflows/pre-deploy.yaml
+++ b/.github/workflows/pre-deploy.yaml
@@ -26,4 +26,4 @@ jobs:
     - name: Build
       run: npm run test:functional:build:int
     - name: Run TestCafe Tests
-      run: npx testcafe -q -c 5 'saucelabs:Chrome@latest-1:macOS 11.00','saucelabs:IE@latest:Windows 10','saucelabs:Firefox@latest:Windows 10','saucelabs:Safari@latest:macOS 11.00'
+      run: npx testcafe -q -c 5 'saucelabs:Chrome@latest:macOS 11.00','saucelabs:IE@latest:Windows 10','saucelabs:Firefox@latest:Windows 10','saucelabs:Safari@latest:macOS 11.00'

--- a/.github/workflows/pre-edge-deploy.yaml
+++ b/.github/workflows/pre-edge-deploy.yaml
@@ -38,6 +38,6 @@ jobs:
       - name: Build
         run: npm run test:functional:build:prod
       - name: Run TestCafe Tests
-        run: npm run test:functional:ci:prod
+        run: npm run test:functional:ci:prod -- 'saucelabs:Chrome@latest-1:macOS 11.00','saucelabs:IE@latest:Windows 10','saucelabs:Firefox@latest:Windows 10','saucelabs:Safari@latest:macOS 11.00'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-edge-deploy.yaml
+++ b/.github/workflows/pre-edge-deploy.yaml
@@ -38,6 +38,6 @@ jobs:
       - name: Build
         run: npm run test:functional:build:prod
       - name: Run TestCafe Tests
-        run: npm run test:functional:ci:prod -- 'saucelabs:Chrome@latest:macOS 11.00','saucelabs:IE@latest:Windows 10','saucelabs:Firefox@latest:Windows 10','saucelabs:Safari@latest:macOS 11.00'
+        run: npm run test:functional:ci:prod
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-edge-deploy.yaml
+++ b/.github/workflows/pre-edge-deploy.yaml
@@ -38,6 +38,6 @@ jobs:
       - name: Build
         run: npm run test:functional:build:prod
       - name: Run TestCafe Tests
-        run: npm run test:functional:ci:prod -- 'saucelabs:Chrome@latest-1:macOS 11.00','saucelabs:IE@latest:Windows 10','saucelabs:Firefox@latest:Windows 10','saucelabs:Safari@latest:macOS 11.00'
+        run: npm run test:functional:ci:prod -- 'saucelabs:Chrome@latest:macOS 11.00','saucelabs:IE@latest:Windows 10','saucelabs:Firefox@latest:Windows 10','saucelabs:Safari@latest:macOS 11.00'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Fetch releases
     runs-on: ubuntu-latest
     outputs:
-      matrix-input: ${{ steps.list-tags.outputs.matrix-input }}
+      matrixInput: ${{ steps.list-tags.outputs.matrixInput }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -30,14 +30,14 @@ jobs:
           script: |
             const getTestingTags = require('./scripts/getTestingTags.js');
             const tagsToTest = await getTestingTags();
-            const matrix-input = { include: tagsToTest.map(tag => ({tag})) }
-            core.setOutput("matrix-input", JSON.stringify(matrix-input));
-            console.log("matrix-input: ", matrix-input);
+            const matrixInput = { include: tagsToTest.map(tag => ({tag})) }
+            core.setOutput("matrixInput", JSON.stringify(matrixInput));
+            console.log("matrixInput: ", matrixInput);
 
   start_workflow:
     name: Trigger Test Matrix
     strategy:
-      matrix: ${{ fromJSON(needs.get-testing-tags.outputs.matrix-input) }}
+      matrix: ${{ fromJSON(needs.get-testing-tags.outputs.matrixInput) }}
     needs: get-testing-tags
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -11,18 +11,18 @@ env:
   ALLOY_ENV: prod
 
 jobs:
-  get_testing_tags:
+  get-testing-tags:
     name: Fetch releases
     runs-on: ubuntu-latest
     outputs:
-      matrixInput: ${{ steps.list_tags_working.outputs.matrixInput }}
+      matrix-input: ${{ steps.list-tags.outputs.matrix-input }}
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - run: npm install @octokit/rest semver
       - name: Retrieve tags
-        id: list_tags_working
+        id: list-tags
         uses: actions/github-script@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -30,15 +30,15 @@ jobs:
           script: |
             const getTestingTags = require('./scripts/getTestingTags.js');
             const tagsToTest = await getTestingTags();
-            const matrixInput = { include: tagsToTest.map(tag => ({tag})) }
-            core.setOutput("matrixInput", JSON.stringify(matrixInput));
-            console.log("matrixInput: ", matrixInput);
+            const matrix-input = { include: tagsToTest.map(tag => ({tag})) }
+            core.setOutput("matrix-input", JSON.stringify(matrix-input));
+            console.log("matrix-input: ", matrix-input);
 
   start_workflow:
     name: Trigger Test Matrix
     strategy:
-      matrix: ${{ fromJSON(needs.get_testing_tags.outputs.matrixInput) }}
-    needs: get_testing_tags
+      matrix: ${{ fromJSON(needs.get-testing-tags.outputs.matrix-input) }}
+    needs: get-testing-tags
     runs-on: ubuntu-latest
     steps:
       - name: Create a workflow dispatch event with ${{ matrix.tag }}

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -4,26 +4,47 @@ on:
     - cron: "0 */24 * * *"
   workflow_dispatch:
 env:
-        SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-        SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        SAUCE_JOB: "Alloy Prod Workflow"
-        SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
-        ALLOY_ENV: prod
+  SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+  SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+  SAUCE_JOB: "Alloy Prod Workflow"
+  SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
+  ALLOY_ENV: prod
 
 jobs:
-  alloy-prod-e2e:
-    name: "Cron: Prod E2E Tests"
+  get_testing_tags:
+    name: Fetch releases
+    runs-on: ubuntu-latest
+    outputs:
+      matrixInput: ${{ steps.list_tags_working.outputs.matrixInput }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: npm install @octokit/rest semver
+      - name: Retrieve tags
+        id: list_tags_working
+        uses: actions/github-script@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            const getTestingTags = require('./scripts/getTestingTags.js');
+            const tagsToTest = await getTestingTags();
+            const matrixInput = { include: tagsToTest.map(tag => ({tag})) }
+            core.setOutput("matrixInput", JSON.stringify(matrixInput));
+            console.log("matrixInput: ", matrixInput);
+
+  start_workflow:
+    name: Trigger Test Matrix
+    strategy:
+      matrix: ${{ fromJSON(needs.get_testing_tags.outputs.matrixInput) }}
+    needs: get_testing_tags
     runs-on: ubuntu-latest
     steps:
-      - name: "Get latest Alloy Release"
-        id: last_release
-        uses: InsonusK/get-latest-release@v1.0.1
+      - name: Create a workflow dispatch event with ${{ matrix.tag }}
+        uses: actions/checkout@v2.3.3
         with:
-          myToken: ${{ github.token }}
-          exclude_types: "draft|prerelease"
-      - uses: actions/checkout@v2.3.3
-        with:
-          ref: ${{ steps.last_release.outputs.tag_name }}
+          ref: ${{ matrix.tag }}
       - uses: actions/cache@v2
         id: npm-cache
         with:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:unit:saucelabs:local": "karma start karma.saucelabs.conf.js --single-run",
     "test:unit:coverage": "karma start --single-run --reporters spec,coverage",
     "test:functional": "EDGE_BASE_PATH=\"ee-pre-prd\" ALLOY_ENV=\"int\" testcafe chrome",
-    "test:functional:ci:prod": "SAUCE_CAPABILITIES_OVERRIDES_PATH=\"sauceLabsCapabilities.json\" ALLOY_PROD_VERSION=`scripts/getProdVersion.js` testcafe -q -c 5 'saucelabs:Chrome@latest-1:macOS 11.00','saucelabs:IE@latest:Windows 10','saucelabs:Firefox@latest:Windows 10','saucelabs:Safari@latest:macOS 11.00'",
+    "test:functional:ci:prod": "SAUCE_CAPABILITIES_OVERRIDES_PATH=\"sauceLabsCapabilities.json\" ALLOY_PROD_VERSION=`scripts/getProdVersion.js` testcafe -q -c 5",
     "test:functional:watch": "EDGE_BASE_PATH=\"ee-pre-prd\" ALLOY_ENV=\"int\" ./scripts/watchFunctionalTests.js --browsers chrome",
     "test:functional:build:int": "rollup -c --environment BASE_CODE_MIN,STANDALONE,NPM_PACKAGE_LOCAL",
     "test:functional:build:prod": "rollup -c --environment BASE_CODE_MIN,NPM_PACKAGE_PROD",

--- a/scripts/getTestingTags.js
+++ b/scripts/getTestingTags.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { Octokit } = require("@octokit/rest");
+const semver = require("semver");
+
+// Outputs the production version of Alloy. This is calculated
+// by looking up the latest release in Github that is neither
+// a draft nor pre-release, then retrieving the package.json
+// from the release's associated tag, then logging the value
+// of the version field found in package.json.
+const octokit = new Octokit({
+  // These APIs have a rate limit of 60/hour total (across all
+  // APIs, per IP address) when unauthenticated, but a rate limit
+  // of 1000/hr when using the Github token for authentication
+  // (15000/hr if we upgrade to a GitHub Enterprise Cloud account).
+  // We'll use the Github token when it's available (when this script
+  // is running as part of a Github workflow).
+  auth: process.env.GITHUB_TOKEN
+});
+
+module.exports = () => {
+  return octokit.paginate(
+    octokit.repos.listReleases,
+    {
+      owner: "adobe",
+      repo: "alloy",
+    },
+    ({ data: releases }, done) => {
+      const prodReleases = releases
+        .filter(release => !release.draft && !release.prerelease)
+        .map(release => release.tag_name);
+      const prodReleasesToTest = prodReleases
+        .filter(tag => semver.lte("2.4.0", semver.clean(tag)));
+      if (prodReleasesToTest.length < prodReleases.length) {
+        done();
+      }
+      return prodReleasesToTest;
+    }
+  )
+}


### PR DESCRIPTION
In the prod workflow, I have two potential way of approaching the Prod workflow supporting older versions. I commented in the workflow file and need help configuring the workflow. 

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
