### PR TITLE
renaming the mboxEdit query string param to the one that is used by the VEC Helper extension

### DIFF
--- a/src/components/Personalization/utils/isAuthoringModeEnabled.js
+++ b/src/components/Personalization/utils/isAuthoringModeEnabled.js
@@ -11,5 +11,5 @@ governing permissions and limitations under the License.
 */
 
 export default (doc = document) => {
-  return doc.location.href.indexOf("mboxEdit") !== -1;
+  return doc.location.href.indexOf("authoringEnabled") !== -1;
 };

--- a/test/unit/specs/components/Personalization/utils/isAuthoringModeEnabled.spec.js
+++ b/test/unit/specs/components/Personalization/utils/isAuthoringModeEnabled.spec.js
@@ -16,7 +16,7 @@ describe("Personalization::isAuthoringModeEnabled", () => {
   it("returns true if authoring mode is enabled", () => {
     const doc = {
       location: {
-        href: "http://foo.com?mboxEdit=1"
+        href: "http://foo.com?authoringEnabled=1"
       }
     };
     expect(isAuthoringModeEnabled(doc)).toEqual(true);


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
