### PR TITLE
Additional workflow for konductor 

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -3,12 +3,12 @@ on:
   push:
   workflow_dispatch:
 env:
-        SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-        SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        SAUCE_JOB: "Alloy Dev Workflow"
-        SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
-        EDGE_BASE_PATH: ee-pre-prd
-        ALLOY_ENV: int
+  SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+  SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+  SAUCE_JOB: "Alloy Dev Workflow"
+  SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
+  EDGE_BASE_PATH: ee-pre-prd
+  ALLOY_ENV: int
 
 jobs:
   unit-test:

--- a/.github/workflows/pre-deploy.yaml
+++ b/.github/workflows/pre-deploy.yaml
@@ -1,11 +1,11 @@
 name: Pre-Deploy
 on: workflow_dispatch
 env:
-        SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-        SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        SAUCE_JOB: "Alloy Pre-Deploy Workflow"
-        SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
-        ALLOY_ENV: int 
+  SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+  SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+  SAUCE_JOB: "Alloy Pre-Deploy Workflow"
+  SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
+  ALLOY_ENV: int 
 
 jobs:
   e2e-test:

--- a/.github/workflows/pre-edge-cron.yaml
+++ b/.github/workflows/pre-edge-cron.yaml
@@ -1,18 +1,26 @@
-name: Prod
+#This configuration will be used by the Edge team to test against prod.
+
+name: Pre-Edge-Cron
 on:
   schedule:
     - cron: "0 */24 * * *"
   workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
 env:
   SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
   SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-  SAUCE_JOB: "Alloy Prod Workflow"
+  SAUCE_JOB: "Alloy Pre-Edge Cron Workflow"
   SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
   ALLOY_ENV: prod
+  EDGE_BASE_PATH: ee-pre-prd
 
 jobs:
-  alloy-prod-e2e:
-    name: "Cron: Prod E2E Tests"
+  alloy-preedge-e2e:
+    name: "Pre Edge: Prod E2E Tests"
     runs-on: ubuntu-latest
     steps:
       - name: "Get latest Alloy Release"
@@ -38,8 +46,3 @@ jobs:
         run: npm run test:functional:ci:prod
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: craftech-io/slack-action@v1
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          status: failure
-        if: failure()

--- a/.github/workflows/pre-edge-deploy.yaml
+++ b/.github/workflows/pre-edge-deploy.yaml
@@ -1,12 +1,11 @@
 name: Pre-Edge-Deploy
 on:
-  push:
-    workflow_dispatch:
-    inputs:
-      logLevel:
-        description: 'Log level'
-        required: true
-        default: 'warning'
+  workflow_dispatch:
+  inputs:
+    logLevel:
+      description: 'Log level'
+      required: true
+      default: 'warning'
 env:
   SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
   SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/.github/workflows/pre-edge-deploy.yaml
+++ b/.github/workflows/pre-edge-deploy.yaml
@@ -1,45 +1,36 @@
-#This configuration will be used by the Edge team to test against prod.
-
 name: Pre-Edge-Deploy
 on:
-  workflow_dispatch:
+  push:
+    workflow_dispatch:
     inputs:
       logLevel:
         description: 'Log level'
         required: true
         default: 'warning'
 env:
-        SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-        SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
-        ALLOY_ENV: prod
-        EDGE_BASE_PATH: ee-pre-prd
+  SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+  SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+  SAUCE_JOB: "Alloy Pre-Edge Workflow"
+  SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
+  ALLOY_ENV: int
+  EDGE_BASE_PATH: ee-pre-prd
 
 jobs:
-  alloy-prod-e2e:
-    name: "Pre Edge: Prod E2E Tests"
+  functional-test:
+    name: "Functional Test"
     runs-on: ubuntu-latest
     steps:
-      - name: "Get latest Alloy Release"
-        id: last_release
-        uses: InsonusK/get-latest-release@v1.0.1
-        with:
-          myToken: ${{ github.token }}
-          exclude_types: "draft|prerelease"
-      - uses: actions/checkout@v2.3.3
-        with:
-          ref: ${{ steps.last_release.outputs.tag_name }}
-      - uses: actions/cache@v2
-        id: npm-cache
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
-      - name: Install dependencies
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: npm ci
-      - name: Build
-        run: npm run test:functional:build:prod
-      - name: Run TestCafe Tests
-        run: npm run test:functional:ci:prod
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      id: npm-cache
+      with:
+        path: '**/node_modules'
+        key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
+    - name: Install dependencies
+      if: steps.npm-cache.outputs.cache-hit != 'true'
+      run: npm ci
+    - name: Build
+      run: npm run test:functional:build:int
+    - name: Run Functional Test
+      run: npx testcafe -q -c 5 'saucelabs:Chrome@latest-1:macOS 11.00','saucelabs:IE@latest:Windows 10','saucelabs:Firefox@latest:Windows 10','saucelabs:Safari@latest:macOS 11.00'
+    


### PR DESCRIPTION
Currently the "pre-edge-deploy" workflow checkouts the last production release of Alloy and uses the functional tests within the release. Main currently has fixed functional tests but the "pre-edge-deploy" workflow is failing since the last release still contains broken test cases.  

Changed the current "pre-edge-deploy" to run in a cron job and an additional workflow that checks out main with Alloy int.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
