### PR TITLE
PDCL-4711 automatically build release notes

### DIFF
--- a/.github/workflows/deployRelease.yml
+++ b/.github/workflows/deployRelease.yml
@@ -70,3 +70,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ github.event.inputs.version }}
+          referencePrefixes: "PDCL-,CORE-,AN-"
+          referenceTargetUrlPrefix: "https://jira.corp.adobe.com/browse/"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add two parameters to the record-release project-card-release-automation action. These parameters enable the release notes builder to extract JIRA links from the commit and PR messages. Do not merge until https://github.com/adobe/project-card-release-automation/pull/13 is merged and built, otherwise this workflow will fail with "Unknown inputs for action..."

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-4711

## Motivation and Context

This will help us build release notes by showing all the PRs and commits that have been merged since the last release.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
