### PR TITLE
C205529 - fix the functional test

### DIFF
--- a/test/functional/specs/Personalization/C205529.js
+++ b/test/functional/specs/Personalization/C205529.js
@@ -33,7 +33,7 @@ test("Test C205529: Receive offer based on device", async () => {
   const result = await alloy.sendEvent({
     xdm: {
       device: {
-        screenWidth: 9999
+        customDeviceField: 9999
       }
     }
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Because @ciocanu have fixed an issue of xdm.device parameters being duplicated this have broken the functional test.
`device.screenWidth` or `device.screenHeight` was available in VEC by mistake.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
