### PR TITLE
Remove package.json script dependencies from workflow files  

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -3,12 +3,12 @@ on:
   push:
   workflow_dispatch:
 env:
-        SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-        SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        SAUCE_JOB: "Alloy Dev Workflow"
-        SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
-        EDGE_BASE_PATH: ee-pre-prd
-        ALLOY_ENV: int
+  SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+  SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+  SAUCE_JOB: "Alloy Dev Workflow"
+  SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
+  EDGE_BASE_PATH: ee-pre-prd
+  ALLOY_ENV: int
 
 jobs:
   unit-test:

--- a/.github/workflows/pre-deploy.yaml
+++ b/.github/workflows/pre-deploy.yaml
@@ -1,11 +1,11 @@
 name: Pre-Deploy
 on: workflow_dispatch
 env:
-        SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-        SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        SAUCE_JOB: "Alloy Pre-Deploy Workflow"
-        SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
-        ALLOY_ENV: int 
+  SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+  SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+  SAUCE_JOB: "Alloy Pre-Deploy Workflow"
+  SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
+  ALLOY_ENV: int 
 
 jobs:
   e2e-test:

--- a/.github/workflows/pre-edge-deploy.yaml
+++ b/.github/workflows/pre-edge-deploy.yaml
@@ -7,11 +7,11 @@ on:
         required: true
         default: 'warning'
 env:
-        SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-        SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
-        ALLOY_ENV: prod
-        EDGE_BASE_PATH: ee-pre-prd
+  SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+  SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+  SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
+  ALLOY_ENV: prod
+  EDGE_BASE_PATH: ee-pre-prd
 jobs:
   alloy-prod-e2e:
     name: "Pre Edge: Prod E2E Tests"

--- a/.github/workflows/pre-edge-deploy.yaml
+++ b/.github/workflows/pre-edge-deploy.yaml
@@ -12,7 +12,6 @@ env:
         SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
         ALLOY_ENV: prod
         EDGE_BASE_PATH: ee-pre-prd
-
 jobs:
   alloy-prod-e2e:
     name: "Pre Edge: Prod E2E Tests"
@@ -27,6 +26,9 @@ jobs:
       - uses: actions/checkout@v2.3.3
         with:
           ref: ${{ steps.last_release.outputs.tag_name }}
+      - name: Get version from package
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@master
       - uses: actions/cache@v2
         id: npm-cache
         with:
@@ -38,6 +40,6 @@ jobs:
       - name: Build
         run: npm run test:functional:build:prod
       - name: Run TestCafe Tests
-        run: npm run test:functional:ci:prod
+        run: npx testcafe -q -c 5 'saucelabs:Chrome@latest:macOS 11.00','saucelabs:IE@latest:Windows 10','saucelabs:Firefox@latest:Windows 10','saucelabs:Safari@latest:macOS 11.00'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ALLOY_PROD_VERSION: ${{ steps.package-version.outputs.current-version }}    

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -32,7 +32,6 @@ jobs:
     name: Trigger Test Matrix
     strategy:
       matrix: ${{ fromJSON(needs.get-testing-tags.outputs.matrixInput) }}
-      fail-fast: false
     needs: get-testing-tags
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -39,6 +39,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
       SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+      SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
       SAUCE_JOB: "Alloy Prod Workflow"
       ALLOY_ENV: prod
     steps:

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -3,12 +3,6 @@ on:
   schedule:
     - cron: "0 */24 * * *"
   workflow_dispatch:
-env:
-  SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-  SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-  SAUCE_JOB: "Alloy Prod Workflow"
-  SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
-  ALLOY_ENV: prod
 
 jobs:
   get-testing-tags:
@@ -38,8 +32,15 @@ jobs:
     name: Trigger Test Matrix
     strategy:
       matrix: ${{ fromJSON(needs.get-testing-tags.outputs.matrixInput) }}
+      fail-fast: false
     needs: get-testing-tags
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+      SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+      SAUCE_JOB: "Alloy Prod Workflow"
+      ALLOY_ENV: prod
     steps:
       - name: Create a workflow dispatch event with ${{ matrix.tag }}
         uses: actions/checkout@v2.3.3
@@ -50,16 +51,18 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
+      - name: Get version from package
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@master
       - name: Install dependencies
         if: steps.npm-cache.outputs.cache-hit != 'true'
         run: npm ci
       - name: Build
         run: npm run test:functional:build:prod
       - name: Run TestCafe Tests
-        run: npm run test:functional:ci:prod -- -q -c 5 'saucelabs:Chrome@latest:macOS 11.00','saucelabs:IE@latest:Windows 10','saucelabs:Firefox@latest:Windows 10','saucelabs:Safari@latest:macOS 11.00'
+        run: npx testcafe -q -c 5 'saucelabs:Chrome@latest:macOS 11.00','saucelabs:IE@latest:Windows 10','saucelabs:Firefox@latest:Windows 10','saucelabs:Safari@latest:macOS 11.00'
         env:
-          ALLOY_PROD_VERSION: ${{ matrix.tag }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ALLOY_PROD_VERSION: ${{ steps.package-version.outputs.current-version }}    
       - uses: craftech-io/slack-action@v1
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -1,8 +1,8 @@
 name: Publish To NPM
 on: workflow_dispatch
 env:
-        SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-        SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+  SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+  SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
 
 jobs:
   publish-to-npm:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "test:unit:saucelabs:local": "karma start karma.saucelabs.conf.js --single-run",
     "test:unit:coverage": "karma start --single-run --reporters spec,coverage",
     "test:functional": "EDGE_BASE_PATH=\"ee-pre-prd\" ALLOY_ENV=\"int\" testcafe chrome",
-    "test:functional:ci:prod": "SAUCE_CAPABILITIES_OVERRIDES_PATH=\"sauceLabsCapabilities.json\" testcafe",
     "test:functional:watch": "EDGE_BASE_PATH=\"ee-pre-prd\" ALLOY_ENV=\"int\" ./scripts/watchFunctionalTests.js --browsers chrome",
     "test:functional:build:int": "rollup -c --environment BASE_CODE_MIN,STANDALONE,NPM_PACKAGE_LOCAL",
     "test:functional:build:prod": "rollup -c --environment BASE_CODE_MIN,NPM_PACKAGE_PROD",


### PR DESCRIPTION
Depending on the npm script within the release builds limited our ability to configure the production ("prod.yaml" ) and konductor pre-edge ("pre-edge-deploy.yaml" ) functional test configurations.

1. Removed "test:functional:ci:prod" from package.json.
2. Pass saucelabs configuration env "SAUCE_CAPABILITIES_OVERRIDES_PATH" and "ALLOY_PROD_VERSION" from the workflow.
3. Removed "getVersion.js" script decency to retrieve version (already committed).  Replaced it with "martinbeentjes/npm-get-version-action@master" to retrieve running version from the package.json.
4. Formatted tabs space from workflow files.
5. Disabled "C205529" in v2.4.0, breaking test runs, fixed in v2.5.0.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
