### PR TITLE
Fix automation push permission issue

### DIFF
--- a/.github/workflows/deployRelease.yml
+++ b/.github/workflows/deployRelease.yml
@@ -31,6 +31,9 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 15.x
+      - uses: webfactory/ssh-agent@v0.5.3
+        with:
+          ssh-private-key: ${{ secrets.ALLOY_BOT_GITHUB_SSH_PRIVATE_KEY }}
       - run: ./scripts/deploy.sh ${{ github.event.inputs.version }}
         env:
           NPM_TOKEN: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
@@ -52,6 +55,9 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 15.x
+      - uses: webfactory/ssh-agent@v0.5.3
+        with:
+          ssh-private-key: ${{ secrets.ALLOY_BOT_GITHUB_SSH_PRIVATE_KEY }}
       - run: ./scripts/deploy.sh ${{ github.event.inputs.version }}
         env:
           NPM_TOKEN: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -8,7 +8,7 @@ npm ci
 # setup configuration
 git config user.name $GITHUB_ACTOR
 git config user.email gh-actions-${GITHUB_ACTOR}@github.com
-git remote add gh-origin https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git/
+git remote add gh-origin git@github.com:${GITHUB_REPOSITORY}.git
 npm config set //registry.npmjs.org/:_authToken=${NPM_TOKEN}
 
 # update version in package.json and package-lock.json


### PR DESCRIPTION


## Description

Use an SSH private key to push version updates as part of the automated release process.

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-6268

## Motivation and Context

We have a policy on the main branch that everything pushed there needs to go through a pull request with 2 reviews. The Alloy bot user has admin permission so is able to get around this restriction, but only when using an SSH private key.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
