### PR TITLE
Add skip ci to avoid infinite deploy loops

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -14,7 +14,7 @@ npm config set //registry.npmjs.org/:_authToken=${NPM_TOKEN}
 # update version in package.json and package-lock.json
 npm version ${VERSION} --git-tag-version=false
 git add package.json package-lock.json
-git commit -m "${VERSION}"
+git commit -m "[skip ci] ${VERSION}"
 
 # publish the package to NPM if it hasn't already been published
 if [[ -z "$(npm view @adobe/alloy@${VERSION})" ]]; then
@@ -29,7 +29,9 @@ npm install @adobe/alloy@${VERSION} --save-dev
 git add package.json package-lock.json
 
 # tag and push the release
-git commit -m "update self devDependency to ${VERSION}"
+# [skip ci] disables the triggering of github workflows on this push
+# https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
+git commit -m "[skip ci] update self devDependency to ${VERSION}"
 git tag -a "v${VERSION}" -m "${VERSION}"
 git push gh-origin HEAD:${GITHUB_REF} --follow-tags
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Because I changed the continuous integration workflow to push to using a private ssh key, a push in the workflow could trigger another build. Pushes using personal access tokens cannot trigger new workflows.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
