### PR TITLE
Set the npm release tag to next for prerelease versions

### DIFF
--- a/.github/workflows/deployRelease.yml
+++ b/.github/workflows/deployRelease.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: webfactory/ssh-agent@v0.5.3
         with:
           ssh-private-key: ${{ secrets.ALLOY_BOT_GITHUB_SSH_PRIVATE_KEY }}
-      - run: ./scripts/deploy.sh ${{ github.event.inputs.version }}
+      - run: ./scripts/deploy.sh ${{ github.event.inputs.version }} latest
         env:
           NPM_TOKEN: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
           CDN_PRIVATE_KEY: ${{ secrets.CDN_PRIVATE_KEY }}
@@ -58,7 +58,7 @@ jobs:
       - uses: webfactory/ssh-agent@v0.5.3
         with:
           ssh-private-key: ${{ secrets.ALLOY_BOT_GITHUB_SSH_PRIVATE_KEY }}
-      - run: ./scripts/deploy.sh ${{ github.event.inputs.version }}
+      - run: ./scripts/deploy.sh ${{ github.event.inputs.version }} next
         env:
           NPM_TOKEN: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
       - uses: actions/upload-artifact@v2

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,6 +1,7 @@
 #! /usr/bin/env bash
 
 VERSION=$1
+NPM_TAG=$2
 
 # install dependencies
 npm ci
@@ -19,7 +20,7 @@ git commit -m "[skip ci] ${VERSION}"
 # publish the package to NPM if it hasn't already been published
 if [[ -z "$(npm view @adobe/alloy@${VERSION})" ]]; then
   echo "Publishing to NPM"
-  npm publish --access public
+  npm publish --access public --tag $NPM_TAG
 else
   echo "NPM already has version ${VERSION}"
 fi


### PR DESCRIPTION

## Description

By default npm publish will update the "latest" tag. This changes pre-release versions to use the "next" tag.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

This page gives a good summary of the problem: https://medium.com/@mbostock/prereleases-and-npm-e778fc5e2420

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
