### PR TITLE
PDCL-6554: guard against spreading non iterable values

### DIFF
--- a/src/components/Personalization/createAutoRenderingHandler.js
+++ b/src/components/Personalization/createAutoRenderingHandler.js
@@ -38,7 +38,10 @@ export default ({
           },
           propositions: [
             ...addRenderAttemptedToDecisions({
-              decisions: [...pageWideScopeDecisions, ...currentViewDecisions],
+              decisions: [
+                ...pageWideScopeDecisions,
+                ...(currentViewDecisions || [])
+              ],
               renderAttempted: true
             }),
             ...addRenderAttemptedToDecisions({


### PR DESCRIPTION
## Description

If `currentViewDecisions` is undefined, trying to spread it will throw an exception.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
