### PR TITLE
PDCL-6554 - return empty array when no view decisions for a specific view

### DIFF
--- a/src/components/Personalization/createViewCacheManager.js
+++ b/src/components/Personalization/createViewCacheManager.js
@@ -35,7 +35,7 @@ export default () => {
   };
 
   const getView = viewName => {
-    return viewStorageDeferred.promise.then(() => viewStorage[viewName]);
+    return viewStorageDeferred.promise.then(() => viewStorage[viewName] || []);
   };
 
   const isInitialized = () => {

--- a/src/components/Personalization/createViewChangeHandler.js
+++ b/src/components/Personalization/createViewChangeHandler.js
@@ -22,7 +22,7 @@ export default ({
   return ({ personalizationDetails, onResponse, onRequestFailure }) => {
     const viewName = personalizationDetails.getViewName();
 
-    return viewCache.getView(viewName).then((currentViewDecisions = []) => {
+    return viewCache.getView(viewName).then(currentViewDecisions => {
       if (personalizationDetails.isRenderDecisions()) {
         executeCachedViewDecisions({
           viewName,

--- a/test/unit/specs/components/Personalization/createAutoRenderingHandler.spec.js
+++ b/test/unit/specs/components/Personalization/createAutoRenderingHandler.spec.js
@@ -112,4 +112,45 @@ describe("Personalization::createAutoRenderingHandler", () => {
     expect(executeDecisions).toHaveBeenCalledWith(pageWideScopeDecisions);
     expect(showContainers).toHaveBeenCalled();
   });
+
+  it("it would pass empty array to executeCachedViewDecisions when cache returns empty array ", () => {
+    const viewName = "cart";
+    const promise = {
+      then: callback => callback([])
+    };
+    viewCache.getView.and.returnValue(promise);
+
+    const autorenderingHandler = createAutoRenderingHandler({
+      viewCache,
+      executeDecisions,
+      executeCachedViewDecisions,
+      showContainers,
+      logger
+    });
+
+    const result = autorenderingHandler({
+      viewName,
+      pageWideScopeDecisions,
+      nonAutoRenderableDecisions
+    });
+    expect(viewCache.getView).toHaveBeenCalledWith("cart");
+    expect(executeDecisions).toHaveBeenCalledWith(pageWideScopeDecisions);
+    expect(executeCachedViewDecisions).toHaveBeenCalledWith({
+      viewName,
+      viewDecisions: []
+    });
+    expect(showContainers).toHaveBeenCalled();
+
+    result.decisions.forEach(decision => {
+      expect(decision.renderAttempted).toBeUndefined();
+    });
+
+    result.propositions.forEach(proposition => {
+      if (proposition.scope === "__view__" || proposition.scope === viewName) {
+        expect(proposition.renderAttempted).toEqual(true);
+      } else {
+        expect(proposition.renderAttempted).toEqual(false);
+      }
+    });
+  });
 });

--- a/test/unit/specs/components/Personalization/createViewCacheManager.spec.js
+++ b/test/unit/specs/components/Personalization/createViewCacheManager.spec.js
@@ -16,6 +16,7 @@ import { defer } from "../../../../../src/utils";
 describe("Personalization::createCacheManager", () => {
   const cartView = "cart";
   const homeView = "home";
+  const productsView = "products";
   const viewDecisions = {
     home: [
       {
@@ -55,6 +56,18 @@ describe("Personalization::createCacheManager", () => {
     ]);
   });
 
+  it("gets an empty array if there is no decisions for a specific view", () => {
+    const viewCacheManager = createViewCacheManager();
+    const decisionsDeferred = defer();
+
+    viewCacheManager.storeViews(decisionsDeferred.promise);
+    decisionsDeferred.resolve(viewDecisions);
+
+    return Promise.all([
+      expectAsync(viewCacheManager.getView(productsView)).toBeResolvedTo([])
+    ]);
+  });
+
   it("should be no views when decisions deferred is rejected", () => {
     const viewCacheManager = createViewCacheManager();
     const decisionsDeferred = defer();
@@ -63,7 +76,7 @@ describe("Personalization::createCacheManager", () => {
     decisionsDeferred.reject();
 
     return expectAsync(viewCacheManager.getView("cart"))
-      .toBeResolvedTo(undefined)
+      .toBeResolvedTo([])
       .then(() => {
         expect(viewCacheManager.isInitialized()).toBeTrue();
       });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Because the viewCache promise gets resolved with `undefined`.  `undefined` would've been passed to handlers, in some handlers we would `currentViewDecisions || []`.  I would make `viewCache` return empty array when there are no decisions for a specific view, rather than returning `undefined` and then have to check for `undefined` everywhere we trigger `viewCache.getView`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
