### PR TITLE
PDCL-6567 Removed deprecation warning for result.decisions.

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -52,7 +52,7 @@
           });
           tag.nonce = "%REACT_APP_NONCE%";
           tag.src = src;
-          document.head.append(tag);
+          document.head.appendChild(tag);
         });
       }
 

--- a/src/components/Personalization/constants/loggerMessage.js
+++ b/src/components/Personalization/constants/loggerMessage.js
@@ -1,5 +1,3 @@
-export const DECISIONS_DEPRECATED_WARNING =
-  "The decisions property is deprecated. Please use the propositions property instead.";
 export const AUTHORING_ENABLED = "Rendering is disabled for authoring mode.";
 export const REDIRECT_EXECUTION_ERROR =
   "An error occurred while executing the redirect offer.";

--- a/src/components/Personalization/createAutoRenderingHandler.js
+++ b/src/components/Personalization/createAutoRenderingHandler.js
@@ -11,14 +11,12 @@ governing permissions and limitations under the License.
 */
 
 import addRenderAttemptedToDecisions from "./utils/addRenderAttemptedToDecisions";
-import { DECISIONS_DEPRECATED_WARNING } from "./constants/loggerMessage";
 
 export default ({
   viewCache,
   executeDecisions,
   executeCachedViewDecisions,
-  showContainers,
-  logger
+  showContainers
 }) => {
   return ({ viewName, pageWideScopeDecisions, nonAutoRenderableDecisions }) => {
     if (viewName) {
@@ -31,11 +29,7 @@ export default ({
         showContainers();
 
         return {
-          get decisions() {
-            logger.warn(DECISIONS_DEPRECATED_WARNING);
-
-            return [...nonAutoRenderableDecisions];
-          },
+          decisions: [...nonAutoRenderableDecisions],
           propositions: [
             ...addRenderAttemptedToDecisions({
               decisions: [...pageWideScopeDecisions, ...currentViewDecisions],
@@ -54,11 +48,7 @@ export default ({
     showContainers();
 
     return {
-      get decisions() {
-        logger.warn(DECISIONS_DEPRECATED_WARNING);
-
-        return [...nonAutoRenderableDecisions];
-      },
+      decisions: [...nonAutoRenderableDecisions],
       propositions: [
         ...addRenderAttemptedToDecisions({
           decisions: pageWideScopeDecisions,

--- a/src/components/Personalization/createNonRenderingHandler.js
+++ b/src/components/Personalization/createNonRenderingHandler.js
@@ -10,7 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { DECISIONS_DEPRECATED_WARNING } from "./constants/loggerMessage";
 import addRenderAttemptedToDecisions from "./utils/addRenderAttemptedToDecisions";
 
 const getViewPropositions = ({ viewCache, viewName, propositions }) => {
@@ -23,14 +22,9 @@ const getViewPropositions = ({ viewCache, viewName, propositions }) => {
     .then(viewPropositions => [...viewPropositions, ...propositions]);
 };
 
-const buildFinalResult = ({ logger, propositions }) => {
+const buildFinalResult = ({ propositions }) => {
   return {
-    get decisions() {
-      // Added decisions for backward compatibility.
-      logger.warn(DECISIONS_DEPRECATED_WARNING);
-
-      return propositions;
-    },
+    decisions: propositions,
     propositions: addRenderAttemptedToDecisions({
       decisions: propositions,
       renderAttempted: false
@@ -38,7 +32,7 @@ const buildFinalResult = ({ logger, propositions }) => {
   };
 };
 
-export default ({ viewCache, logger }) => {
+export default ({ viewCache }) => {
   return ({
     viewName,
     redirectDecisions,
@@ -55,6 +49,6 @@ export default ({ viewCache, logger }) => {
       .then(items =>
         getViewPropositions({ viewCache, viewName, propositions: items })
       )
-      .then(items => buildFinalResult({ logger, propositions: items }));
+      .then(items => buildFinalResult({ propositions: items }));
   };
 };

--- a/src/components/Personalization/createOnResponseHandler.js
+++ b/src/components/Personalization/createOnResponseHandler.js
@@ -10,7 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import isNonEmptyArray from "../../utils/isNonEmptyArray";
-import { DECISIONS_DEPRECATED_WARNING } from "./constants/loggerMessage";
 
 const DECISIONS_HANDLE = "personalization:decisions";
 
@@ -19,8 +18,7 @@ export default ({
   nonRenderingHandler,
   groupDecisions,
   handleRedirectDecisions,
-  showContainers,
-  logger
+  showContainers
 }) => {
   return ({ decisionsDeferred, personalizationDetails, response }) => {
     const unprocessedDecisions = response.getPayloadsByType(DECISIONS_HANDLE);
@@ -31,10 +29,7 @@ export default ({
       showContainers();
       decisionsDeferred.resolve({});
       return {
-        get decisions() {
-          logger.warn(DECISIONS_DEPRECATED_WARNING);
-          return [];
-        },
+        decisions: [],
         propositions: []
       };
     }

--- a/src/components/Personalization/createViewChangeHandler.js
+++ b/src/components/Personalization/createViewChangeHandler.js
@@ -10,15 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { DECISIONS_DEPRECATED_WARNING } from "./constants/loggerMessage";
 import addRenderAttemptedToDecisions from "./utils/addRenderAttemptedToDecisions";
 
-export default ({
-  executeCachedViewDecisions,
-  viewCache,
-  showContainers,
-  logger
-}) => {
+export default ({ executeCachedViewDecisions, viewCache, showContainers }) => {
   return ({ personalizationDetails, onResponse, onRequestFailure }) => {
     const viewName = personalizationDetails.getViewName();
 
@@ -39,10 +33,7 @@ export default ({
               })
             }
           : {
-              get decisions() {
-                logger.warn(DECISIONS_DEPRECATED_WARNING);
-                return currentViewDecisions;
-              },
+              decisions: currentViewDecisions,
               propositions: addRenderAttemptedToDecisions({
                 decisions: currentViewDecisions,
                 renderAttempted: false

--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -69,17 +69,15 @@ const createPersonalization = ({ config, logger, eventManager }) => {
     viewCache,
     executeDecisions,
     executeCachedViewDecisions,
-    showContainers,
-    logger
+    showContainers
   });
-  const nonRenderingHandler = createNonRenderingHandler({ viewCache, logger });
+  const nonRenderingHandler = createNonRenderingHandler({ viewCache });
   const responseHandler = createOnResponseHandler({
     autoRenderingHandler,
     nonRenderingHandler,
     groupDecisions,
     handleRedirectDecisions,
-    showContainers,
-    logger
+    showContainers
   });
   const fetchDataHandler = createFetchDataHandler({
     config,
@@ -97,8 +95,7 @@ const createPersonalization = ({ config, logger, eventManager }) => {
   const viewChangeHandler = createViewChangeHandler({
     executeCachedViewDecisions,
     viewCache,
-    showContainers,
-    logger
+    showContainers
   });
   return createComponent({
     logger,

--- a/test/unit/specs/components/Personalization/createAutoRenderingHandler.spec.js
+++ b/test/unit/specs/components/Personalization/createAutoRenderingHandler.spec.js
@@ -24,7 +24,6 @@ describe("Personalization::createAutoRenderingHandler", () => {
   let showContainers;
   let pageWideScopeDecisions;
   let nonAutoRenderableDecisions;
-  let logger;
 
   beforeEach(() => {
     pageWideScopeDecisions = PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS;
@@ -35,7 +34,6 @@ describe("Personalization::createAutoRenderingHandler", () => {
     executeCachedViewDecisions = jasmine.createSpy(
       "executeCachedViewDecisions"
     );
-    logger = jasmine.createSpyObj("logger", ["warn"]);
   });
 
   it("it should fetch decisions from cache when viewName is present", () => {
@@ -49,8 +47,7 @@ describe("Personalization::createAutoRenderingHandler", () => {
       viewCache,
       executeDecisions,
       executeCachedViewDecisions,
-      showContainers,
-      logger
+      showContainers
     });
 
     const result = autorenderingHandler({
@@ -85,8 +82,7 @@ describe("Personalization::createAutoRenderingHandler", () => {
       viewCache,
       executeDecisions,
       executeCachedViewDecisions,
-      showContainers,
-      logger
+      showContainers
     });
 
     const result = autorenderingHandler({
@@ -124,8 +120,7 @@ describe("Personalization::createAutoRenderingHandler", () => {
       viewCache,
       executeDecisions,
       executeCachedViewDecisions,
-      showContainers,
-      logger
+      showContainers
     });
 
     const result = autorenderingHandler({

--- a/test/unit/specs/components/Personalization/createNonRenderingHandler.spec.js
+++ b/test/unit/specs/components/Personalization/createNonRenderingHandler.spec.js
@@ -24,10 +24,8 @@ describe("Personalization::createNonRenderingHandler", () => {
   let nonAutoRenderableDecisions;
   let cartViewDecisions;
   let redirectDecisions;
-  let logger;
 
   beforeEach(() => {
-    logger = jasmine.createSpyObj("logger", ["warn"]);
     redirectDecisions = REDIRECT_PAGE_WIDE_SCOPE_DECISION;
     cartViewDecisions = CART_VIEW_DECISIONS;
     pageWideScopeDecisions = PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS;
@@ -43,8 +41,7 @@ describe("Personalization::createNonRenderingHandler", () => {
     viewCache.getView.and.returnValue(promise);
 
     const nonRenderingHandler = createNonRenderingHandler({
-      viewCache,
-      logger
+      viewCache
     });
 
     nonRenderingHandler({
@@ -55,7 +52,6 @@ describe("Personalization::createNonRenderingHandler", () => {
     }).then(result => {
       expect(viewCache.getView).toHaveBeenCalledWith("cart");
       expect(result.decisions.length).toBe(5);
-      expect(logger.warn).toHaveBeenCalled();
       result.decisions.forEach(decision => {
         expect(decision.renderAttempted).toBeUndefined();
       });
@@ -68,8 +64,7 @@ describe("Personalization::createNonRenderingHandler", () => {
   it("it should not trigger viewCache when no viewName", () => {
     const viewName = undefined;
     const nonRenderingHandler = createNonRenderingHandler({
-      viewCache,
-      logger
+      viewCache
     });
 
     nonRenderingHandler({
@@ -80,7 +75,6 @@ describe("Personalization::createNonRenderingHandler", () => {
     }).then(result => {
       expect(viewCache.getView).not.toHaveBeenCalled();
       expect(result.decisions.length).toBe(4);
-      expect(logger.warn).toHaveBeenCalled();
       result.decisions.forEach(decision => {
         expect(decision.renderAttempted).toBeUndefined();
       });

--- a/test/unit/specs/components/Personalization/createOnResponseHandler.spec.js
+++ b/test/unit/specs/components/Personalization/createOnResponseHandler.spec.js
@@ -37,10 +37,8 @@ describe("Personalization::onResponseHandler", () => {
   let personalizationDetails;
   let decisionsDeferred;
   let handleRedirectDecisions;
-  let logger;
 
   beforeEach(() => {
-    logger = jasmine.createSpyObj("logger", ["warn"]);
     response = jasmine.createSpyObj("response", ["getPayloadsByType"]);
     personalizationDetails = jasmine.createSpyObj("personalizationDetails", [
       "isRenderDecisions",
@@ -78,8 +76,7 @@ describe("Personalization::onResponseHandler", () => {
       nonRenderingHandler,
       autoRenderingHandler,
       handleRedirectDecisions,
-      showContainers,
-      logger
+      showContainers
     });
 
     onResponse({
@@ -115,8 +112,7 @@ describe("Personalization::onResponseHandler", () => {
       nonRenderingHandler,
       autoRenderingHandler,
       handleRedirectDecisions,
-      showContainers,
-      logger
+      showContainers
     });
 
     onResponse({
@@ -149,8 +145,7 @@ describe("Personalization::onResponseHandler", () => {
       nonRenderingHandler,
       autoRenderingHandler,
       handleRedirectDecisions,
-      showContainers,
-      logger
+      showContainers
     });
     const result = onResponse({
       decisionsDeferred,
@@ -191,8 +186,7 @@ describe("Personalization::onResponseHandler", () => {
       nonRenderingHandler,
       autoRenderingHandler,
       handleRedirectDecisions,
-      showContainers,
-      logger
+      showContainers
     });
     const result = onResponse({
       decisionsDeferred,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removed deprecation warning when accessing result.decisions.

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/PDCL-6567
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
The SDK itself was accessing `result.decisions`, causing a warning to be logged in the console for customers who were not accessing `result.decisions`. This is fixable, but after discussions with the team, we've decided to remove the warning entirely.

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
