### PR TITLE
PDCL-4597 - enabled the spa implementation test

### DIFF
--- a/test/functional/specs/Personalization/C782718.js
+++ b/test/functional/specs/Personalization/C782718.js
@@ -183,7 +183,7 @@ const simulateViewChange = async (alloy, personalizationPayload) => {
     )
     .eql(cartViewDecisionsMeta);
 
-  // assert we return the renderAttempted flag
+  // assert we return the renderAttempted flag set to true
   const assertRenderAttemptedFlag = resultingObject.propositions.every(
     proposition => proposition.renderAttempted === true
   );

--- a/test/functional/specs/Personalization/C782718.js
+++ b/test/functional/specs/Personalization/C782718.js
@@ -137,6 +137,8 @@ const simulatePageLoad = async alloy => {
     proposition => proposition.renderAttempted === true
   );
   await t.expect(assertRenderAttemptedFlag).eql(true);
+
+  return personalizationPayload;
 };
 
 const simulateViewChange = async (alloy, personalizationPayload) => {
@@ -232,8 +234,8 @@ test("Test C782718: SPA support with auto-rendering and view notifications", asy
   const alloy = createAlloyProxy();
   await alloy.configure(config);
 
-  await simulatePageLoad(alloy);
+  const personalizationPayload = await simulatePageLoad(alloy);
 
-  await simulateViewChange(alloy, {});
+  await simulateViewChange(alloy, personalizationPayload);
   await simulateViewChangeForNonExistingView(alloy);
 });

--- a/test/functional/specs/Personalization/C782718.js
+++ b/test/functional/specs/Personalization/C782718.js
@@ -41,33 +41,28 @@ const getDecisionsMetaByScope = (decisions, scope) => {
     if (decision.scope === scope) {
       metas.push({
         id: decision.id,
-        scope: decision.scope
+        scope: decision.scope,
+        scopeDetails: decision.scopeDetails
       });
     }
   });
   return metas;
 };
 
-// This test is skipped until the related activities are properly configured.
-// https://jira.corp.adobe.com/browse/PDCL-4597
-test.skip("Test C782718: SPA support with auto-rendering and view notifications", async () => {
-  const alloy = createAlloyProxy();
-  await alloy.configure(config);
-
-  await alloy.sendEvent({
+const simulatePageLoad = async alloy => {
+  const resultingObject = await alloy.sendEvent({
     renderDecisions: true,
-    decisionScopes: [],
     xdm: {
       web: {
         webPageDetails: {
-          viewName: "/products"
+          viewName: "products"
         }
       }
     }
   });
-  await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
 
-  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(3);
+  // asserts the request fired to Experience Edge has the expected event query
+  await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
 
   const sendEventRequest = networkLogger.edgeEndpointLogs.requests[0];
   const requestBody = JSON.parse(sendEventRequest.request.body);
@@ -95,13 +90,14 @@ test.skip("Test C782718: SPA support with auto-rendering and view notifications"
   }).getPayloadsByType("personalization:decisions");
 
   await t.expect(personalizationPayload.length).eql(3);
-  // here we should verify that we have rendered decisions for page-wide scope and for /products view
+
+  // assert propositions were rendered for both page_load and view
   await t
-    .expect(getDecisionContent("page-wide-scope-SPA_FUNCTIONAL_TEST"))
-    .eql("spa functional test - page wide scope");
+    .expect(getDecisionContent("pageWideScope"))
+    .eql("test for a page wide scope");
   await t
-    .expect(getDecisionContent("products-view-spa-functional-test"))
-    .eql("products decision for spa functional test");
+    .expect(getDecisionContent("personalization-products-container"))
+    .eql("This is product view");
 
   // Let promises resolve so that the notification is sent.
   await flushPromiseChains();
@@ -128,7 +124,7 @@ test.skip("Test C782718: SPA support with auto-rendering and view notifications"
   );
   const productsViewDecisionsMeta = getDecisionsMetaByScope(
     personalizationPayload,
-    "/products"
+    "products"
   );
   await t
     .expect(
@@ -137,15 +133,21 @@ test.skip("Test C782718: SPA support with auto-rendering and view notifications"
         .propositions
     )
     .eql(productsViewDecisionsMeta);
+  const assertRenderAttemptedFlag = resultingObject.propositions.every(
+    proposition => proposition.renderAttempted === true
+  );
+  await t.expect(assertRenderAttemptedFlag).eql(true);
+};
 
+const simulateViewChange = async (alloy, personalizationPayload) => {
   // sendEvent at a view change, this shouldn't request any target data, it should use the existing cache
-  await alloy.sendEvent({
+  const resultingObject = await alloy.sendEvent({
     renderDecisions: true,
     decisionScopes: [],
     xdm: {
       web: {
         webPageDetails: {
-          viewName: "/transformers"
+          viewName: "cart"
         }
       }
     }
@@ -154,33 +156,39 @@ test.skip("Test C782718: SPA support with auto-rendering and view notifications"
   const viewChangeRequestBody = JSON.parse(viewChangeRequest.request.body);
   // assert that no personalization query was attached to the request
   await t.expect(viewChangeRequestBody.events[0].query).eql(undefined);
-  await t
-    .expect(getDecisionContent("transformers-view-spa-functional-test"))
-    .eql("transformers decision for spa functional test");
+  await t.expect(getDecisionContent("cart")).eql("cart view proposition");
   // Let promises resolve so that the notification is sent.
   await flushPromiseChains();
   // check that a render view decision notification was sent
-  const transformersViewNotificationRequest =
+  const cartViewNotificationRequest =
     networkLogger.edgeEndpointLogs.requests[4];
-  const transformersViewNotificationRequestBody = JSON.parse(
-    transformersViewNotificationRequest.request.body
+  const cartViewNotificationRequestBody = JSON.parse(
+    cartViewNotificationRequest.request.body
   );
   await t
-    .expect(transformersViewNotificationRequestBody.events[0].xdm.eventType)
+    .expect(cartViewNotificationRequestBody.events[0].xdm.eventType)
     .eql("display");
-  const transformersViewDecisionsMeta = getDecisionsMetaByScope(
+  const cartViewDecisionsMeta = getDecisionsMetaByScope(
     personalizationPayload,
-    "/transformers"
+    "cart"
   );
 
   await t
     .expect(
       // eslint-disable-next-line no-underscore-dangle
-      transformersViewNotificationRequestBody.events[0].xdm._experience
-        .decisioning.propositions
+      cartViewNotificationRequestBody.events[0].xdm._experience.decisioning
+        .propositions
     )
-    .eql(transformersViewDecisionsMeta);
+    .eql(cartViewDecisionsMeta);
 
+  // assert we return the renderAttempted flag
+  const assertRenderAttemptedFlag = resultingObject.propositions.every(
+    proposition => proposition.renderAttempted === true
+  );
+  await t.expect(assertRenderAttemptedFlag).eql(true);
+};
+
+const simulateViewChangeForNonExistingView = async alloy => {
   // no decisions in cache for this specific view, should only send a notification
   await alloy.sendEvent({
     renderDecisions: true,
@@ -188,35 +196,44 @@ test.skip("Test C782718: SPA support with auto-rendering and view notifications"
     xdm: {
       web: {
         webPageDetails: {
-          viewName: "/cart"
+          viewName: "noView"
         }
       }
     }
   });
 
-  const cartViewChangeRequest = networkLogger.edgeEndpointLogs.requests[5];
-  const cartViewChangeRequestBody = JSON.parse(
-    cartViewChangeRequest.request.body
+  const noViewViewChangeRequest = networkLogger.edgeEndpointLogs.requests[5];
+  const noViewViewChangeRequestBody = JSON.parse(
+    noViewViewChangeRequest.request.body
   );
   // assert that no personalization query was attached to the request
-  await t.expect(cartViewChangeRequestBody.events[0].query).eql(undefined);
+  await t.expect(noViewViewChangeRequestBody.events[0].query).eql(undefined);
   // assert that a notification call with xdm.web.webPageDetails.viewName and no personalization meta is sent
   await flushPromiseChains();
-  const cartViewNotificationRequest =
-    networkLogger.edgeEndpointLogs.requests[6];
-  const cartViewNotificationRequestBody = JSON.parse(
-    cartViewNotificationRequest.request.body
+  const noViewNotificationRequest = networkLogger.edgeEndpointLogs.requests[6];
+  const noViewNotificationRequestBody = JSON.parse(
+    noViewNotificationRequest.request.body
   );
   await t
-    .expect(cartViewNotificationRequestBody.events[0].xdm.eventType)
+    .expect(noViewNotificationRequestBody.events[0].xdm.eventType)
     .eql("display");
   await t
     .expect(
-      cartViewNotificationRequestBody.events[0].xdm.web.webPageDetails.viewName
+      noViewNotificationRequestBody.events[0].xdm.web.webPageDetails.viewName
     )
-    .eql("/cart");
+    .eql("noView");
   await t
     // eslint-disable-next-line no-underscore-dangle
-    .expect(cartViewNotificationRequestBody.events[0].xdm._experience)
+    .expect(noViewNotificationRequestBody.events[0].xdm._experience)
     .eql(undefined);
+};
+
+test("Test C782718: SPA support with auto-rendering and view notifications", async () => {
+  const alloy = createAlloyProxy();
+  await alloy.configure(config);
+
+  await simulatePageLoad(alloy);
+
+  await simulateViewChange(alloy, {});
+  await simulateViewChangeForNonExistingView(alloy);
 });

--- a/test/functional/specs/Personalization/C782718.js
+++ b/test/functional/specs/Personalization/C782718.js
@@ -133,10 +133,10 @@ const simulatePageLoad = async alloy => {
         .propositions
     )
     .eql(productsViewDecisionsMeta);
-  const assertRenderAttemptedFlag = resultingObject.propositions.every(
-    proposition => proposition.renderAttempted === true
+  const allPropositionsWereRendered = resultingObject.propositions.every(
+    proposition => proposition.renderAttempted
   );
-  await t.expect(assertRenderAttemptedFlag).eql(true);
+  await t.expect(allPropositionsWereRendered).eql(true);
 
   return personalizationPayload;
 };
@@ -184,10 +184,10 @@ const simulateViewChange = async (alloy, personalizationPayload) => {
     .eql(cartViewDecisionsMeta);
 
   // assert we return the renderAttempted flag set to true
-  const assertRenderAttemptedFlag = resultingObject.propositions.every(
-    proposition => proposition.renderAttempted === true
+  const allPropositionsWereRendered = resultingObject.propositions.every(
+    proposition => proposition.renderAttempted
   );
-  await t.expect(assertRenderAttemptedFlag).eql(true);
+  await t.expect(allPropositionsWereRendered).eql(true);
 };
 
 const simulateViewChangeForNonExistingView = async alloy => {

--- a/test/functional/specs/Personalization/C782719.js
+++ b/test/functional/specs/Personalization/C782719.js
@@ -75,10 +75,10 @@ const simulatePageLoad = async alloy => {
 
   await t.expect(personalizationPayload.length).eql(3);
 
-  const allPropositionsWereRendered = resultingObject.propositions.every(
+  const noPropositionsWereRendered = resultingObject.propositions.every(
     proposition => !proposition.renderAttempted
   );
-  await t.expect(allPropositionsWereRendered).eql(true);
+  await t.expect(noPropositionsWereRendered).eql(true);
 
   return personalizationPayload;
 };
@@ -102,10 +102,10 @@ const simulateViewChange = async alloy => {
   await t.expect(viewChangeRequestBody.events[0].query).eql(undefined);
 
   // assert we return the renderAttempted flag set to false
-  const allPropositionsWereRendered = resultingObject.propositions.every(
+  const noPropositionsWereRendered = resultingObject.propositions.every(
     proposition => !proposition.renderAttempted
   );
-  await t.expect(allPropositionsWereRendered).eql(true);
+  await t.expect(noPropositionsWereRendered).eql(true);
 };
 
 const simulateViewChangeForNonExistingView = async alloy => {

--- a/test/functional/specs/Personalization/C782719.js
+++ b/test/functional/specs/Personalization/C782719.js
@@ -76,7 +76,7 @@ const simulatePageLoad = async alloy => {
   await t.expect(personalizationPayload.length).eql(3);
 
   const allPropositionsWereRendered = resultingObject.propositions.every(
-    proposition => proposition.renderAttempted
+    proposition => !proposition.renderAttempted
   );
   await t.expect(allPropositionsWereRendered).eql(true);
 
@@ -103,7 +103,7 @@ const simulateViewChange = async alloy => {
 
   // assert we return the renderAttempted flag set to false
   const allPropositionsWereRendered = resultingObject.propositions.every(
-    proposition => proposition.renderAttempted
+    proposition => !proposition.renderAttempted
   );
   await t.expect(allPropositionsWereRendered).eql(true);
 };

--- a/test/functional/specs/Personalization/C782719.js
+++ b/test/functional/specs/Personalization/C782719.js
@@ -75,10 +75,10 @@ const simulatePageLoad = async alloy => {
 
   await t.expect(personalizationPayload.length).eql(3);
 
-  const assertRenderAttemptedFlag = resultingObject.propositions.every(
-    proposition => proposition.renderAttempted === false
+  const allPropositionsWereRendered = resultingObject.propositions.every(
+    proposition => proposition.renderAttempted
   );
-  await t.expect(assertRenderAttemptedFlag).eql(true);
+  await t.expect(allPropositionsWereRendered).eql(true);
 
   return personalizationPayload;
 };
@@ -102,10 +102,10 @@ const simulateViewChange = async alloy => {
   await t.expect(viewChangeRequestBody.events[0].query).eql(undefined);
 
   // assert we return the renderAttempted flag set to false
-  const assertRenderAttemptedFlag = resultingObject.propositions.every(
-    proposition => proposition.renderAttempted === false
+  const allPropositionsWereRendered = resultingObject.propositions.every(
+    proposition => proposition.renderAttempted
   );
-  await t.expect(assertRenderAttemptedFlag).eql(true);
+  await t.expect(allPropositionsWereRendered).eql(true);
 };
 
 const simulateViewChangeForNonExistingView = async alloy => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Created a new Activity and fixed the SPA functional test. Also as we support the response tokens, I have added another check on the `renderAttempted` flag for the `propositions` array.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
