### PR TITLE
PDCL-4508 Resolve promise with empty object from configure command.

### DIFF
--- a/src/core/injectExecuteCommand.js
+++ b/src/core/injectExecuteCommand.js
@@ -37,7 +37,9 @@ export default ({
       }
       executor = () => {
         configurePromise = configureCommand(options);
-        return configurePromise;
+        return configurePromise.then(() => {
+          // Don't expose internals to the user.
+        });
       };
     } else {
       if (!configurePromise) {

--- a/test/functional/specs/Command Logic/C3484892.js
+++ b/test/functional/specs/Command Logic/C3484892.js
@@ -1,0 +1,33 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import createFixture from "../../helpers/createFixture";
+import { orgMainConfigMain } from "../../helpers/constants/configParts";
+import createAlloyProxy from "../../helpers/createAlloyProxy";
+
+const title =
+  "C3484892: Resolves promise with empty result object from configure command.";
+
+createFixture({
+  title
+});
+
+test.meta({
+  ID: "C3484892",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+
+test(title, async t => {
+  const alloy = createAlloyProxy();
+  const result = await alloy.configure(orgMainConfigMain);
+  await t.expect(result).eql({});
+});

--- a/test/unit/specs/core/injectExecuteCommand.spec.js
+++ b/test/unit/specs/core/injectExecuteCommand.spec.js
@@ -210,9 +210,12 @@ describe("injectExecuteCommand", () => {
   });
 
   it("executes the core commands", () => {
+    const componentRegistry = {
+      getCommand() {}
+    };
     const configureCommand = jasmine
       .createSpy()
-      .and.returnValue(Promise.resolve("configureResult"));
+      .and.returnValue(Promise.resolve(componentRegistry));
     const setDebugCommand = jasmine.createSpy();
     const executeCommand = injectExecuteCommand({
       logger,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Previously, when a user executed the `configure` command, the returned promise would be resolved with the component registry. It should have been resolved with an empty object, since the component registry isn't intended to be exposed.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/PDCL-4508
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
We shouldn't be exposing internal details to the user.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
