### PR TITLE
PDCL-6683 Remap render actions to appendHtml for HEAD offers

### DIFF
--- a/src/components/Personalization/dom-actions/executeActions.js
+++ b/src/components/Personalization/dom-actions/executeActions.js
@@ -10,6 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import preprocess from "./remapHeadOffers";
+
 const logActionError = (logger, action, error) => {
   if (logger.enabled) {
     const details = JSON.stringify(action);
@@ -43,15 +45,16 @@ const executeAction = (logger, modules, type, args) => {
 
 export default (actions, modules, logger) => {
   const actionPromises = actions.map(action => {
-    const { type } = action;
+    const processedAction = preprocess(action);
+    const { type } = processedAction;
 
-    return executeAction(logger, modules, type, [action])
+    return executeAction(logger, modules, type, [processedAction])
       .then(result => {
-        logActionCompleted(logger, action);
+        logActionCompleted(logger, processedAction);
         return result;
       })
       .catch(error => {
-        logActionError(logger, action, error);
+        logActionError(logger, processedAction, error);
         throw error;
       });
   });

--- a/src/components/Personalization/dom-actions/remapHeadOffers.js
+++ b/src/components/Personalization/dom-actions/remapHeadOffers.js
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/*
+ * Preprocess actions before rendering, so that offers are remapped to appendHtml when these are
+ * to be applied to page HEAD, to align with the way it works in at.js.
+ * Offer content should also be filtered, so that only tags allowed in HEAD are preserved.
+ */
+
+import { selectNodes } from "../../../utils/dom";
+import { is } from "./scripts";
+import { createFragment, selectNodesWithEq } from "./dom";
+import { assign } from "../../../utils";
+import isBlankString from "../../../utils/isBlankString";
+import { HEAD } from "../../../constants/tagName";
+
+const APPEND_HTML = "appendHtml";
+const HEAD_TAGS_SELECTOR = "SCRIPT,LINK,STYLE";
+
+const filterHeadContent = content => {
+  const container = createFragment(content);
+  const headNodes = selectNodes(HEAD_TAGS_SELECTOR, container);
+  return headNodes.map(node => node.outerHTML).join("");
+};
+
+export default action => {
+  const result = assign({}, action);
+  const { content, selector } = result;
+
+  if (isBlankString(content)) {
+    return result;
+  }
+
+  const container = selectNodesWithEq(selector);
+  if (!is(container[0], HEAD)) {
+    return result;
+  }
+
+  result.type = APPEND_HTML;
+  result.content = filterHeadContent(content);
+
+  return result;
+};

--- a/src/components/Personalization/dom-actions/scripts.js
+++ b/src/components/Personalization/dom-actions/scripts.js
@@ -15,9 +15,12 @@ import { selectNodes, createNode } from "../../../utils/dom";
 import { SRC, SCRIPT } from "../../../constants/tagName";
 import { getAttribute, getNonce } from "./dom";
 
-const is = (element, tagName) => element.tagName === tagName;
+export const is = (element, tagName) =>
+  !!element && element.tagName === tagName;
+
 const isInlineScript = element =>
   is(element, SCRIPT) && !getAttribute(element, SRC);
+
 const isRemoteScript = element =>
   is(element, SCRIPT) && getAttribute(element, SRC);
 

--- a/src/utils/isBlankString.js
+++ b/src/utils/isBlankString.js
@@ -1,0 +1,20 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import isString from "./isString";
+
+/**
+ * Returns whether a string value is blank. Also returns true if the value is not a string.
+ * @param {*} value
+ * @returns {boolean}
+ */
+export default value => (isString(value) ? !value.trim() : true);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Preprocess actions before rendering, so that offers are remapped to `appendHtml` when these are to be applied to page HEAD, to align with the way it works in at.js.
Similarly to at.js, offer content should be filtered, so that only tags allowed in HEAD are preserved in offer content before it is rendered.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://jira.corp.adobe.com/browse/PDCL-6683

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fix personalization offer rendering behavior, which currently differs from at.js.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
