### PR TITLE
[PDCL-6220] - Single identity:result handle retured on consent update

### DIFF
--- a/test/functional/specs/Privacy/IAB/C224670.js
+++ b/test/functional/specs/Privacy/IAB/C224670.js
@@ -55,7 +55,9 @@ test("Test C224670: Opt in to IAB", async () => {
 
   // 2. The ECID should exist in the response payload as well, if queried
   const identityHandle = consentResponse.getPayloadsByType("identity:result");
-  await t.expect(identityHandle.length).eql(2);
+  const returnedNamespaces = identityHandle.map(i => i.namespace.code);
+  await t.expect(identityHandle.length).eql(1);
+  await t.expect(returnedNamespaces).contains("ECID");
 
   await alloy.sendEvent();
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);

--- a/test/functional/specs/Privacy/IAB/C224672.js
+++ b/test/functional/specs/Privacy/IAB/C224672.js
@@ -56,7 +56,9 @@ test("Test C224672: Passing the `gdprContainsPersonalData` flag should return in
 
   // 2. The ECID should exist in the response payload as well, if queried
   const identityHandle = consentResponse.getPayloadsByType("identity:result");
-  await t.expect(identityHandle.length).eql(2);
+  const returnedNamespaces = identityHandle.map(i => i.namespace.code);
+  await t.expect(identityHandle.length).eql(1);
+  await t.expect(returnedNamespaces).contains("ECID");
 
   await alloy.sendEvent();
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);

--- a/test/functional/specs/Privacy/IAB/C224673.js
+++ b/test/functional/specs/Privacy/IAB/C224673.js
@@ -55,7 +55,9 @@ test("Test C224673: Opt in to IAB while gdprApplies is FALSE", async () => {
 
   // 2. The ECID should exist in the response payload as well, if queried
   const identityHandle = consentResponse.getPayloadsByType("identity:result");
-  await t.expect(identityHandle.length).eql(2);
+  const returnedNamespaces = identityHandle.map(i => i.namespace.code);
+  await t.expect(identityHandle.length).eql(1);
+  await t.expect(returnedNamespaces).contains("ECID");
 
   await alloy.sendEvent();
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);

--- a/test/functional/specs/Privacy/IAB/C224674.js
+++ b/test/functional/specs/Privacy/IAB/C224674.js
@@ -55,7 +55,9 @@ test("Test C224674: Opt out to IAB while gdprApplies is FALSE", async () => {
 
   // 2. The ECID should exist in the response payload as well, if queried
   const identityHandle = consentResponse.getPayloadsByType("identity:result");
-  await t.expect(identityHandle.length).eql(2);
+  const returnedNamespaces = identityHandle.map(i => i.namespace.code);
+  await t.expect(identityHandle.length).eql(1);
+  await t.expect(returnedNamespaces).contains("ECID");
 
   await alloy.sendEvent();
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);

--- a/test/functional/specs/Privacy/IAB/C224677.js
+++ b/test/functional/specs/Privacy/IAB/C224677.js
@@ -53,7 +53,9 @@ test("Test C224677: Call setConsent when purpose 10 is FALSE", async () => {
 
   // 2. The ECID should exist in the response payload as well, if queried
   const identityHandle = response.getPayloadsByType("identity:result");
-  await t.expect(identityHandle.length).eql(2);
+  const returnedNamespaces = identityHandle.map(i => i.namespace.code);
+  await t.expect(identityHandle.length).eql(1);
+  await t.expect(returnedNamespaces).contains("ECID");
 
   // 3. Event calls going forward should be opted out because AAM opts out consents with no purpose 10.
   await alloy.sendEvent();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

A bug which caused to have two `identity:result` handles returned was fixed in the Edge Gateway.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Updated tests to expect a single `identity:result` handle and further validate its content.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
