### PR TITLE
Disable older Alloy tag tests for prod workflow

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -4,36 +4,56 @@ on:
     - cron: "0 */24 * * *"
   workflow_dispatch:
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-  SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-  SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
-  SAUCE_JOB: "Alloy Prod Workflow"
-  ALLOY_ENV: prod
-
 jobs:
-  start_workflow:
-    name: "Prod E2E Tests"
+  get-testing-tags:
+    name: Fetch releases
     runs-on: ubuntu-latest
+    outputs:
+      matrixInput: ${{ steps.list-tags.outputs.matrixInput }}
     steps:
-      - name: "Get latest Alloy Release"
-        id: last_release
-        uses: InsonusK/get-latest-release@v1.0.1
+      - uses: actions/checkout@v2
         with:
-          myToken: ${{ github.token }}
-          exclude_types: "draft|prerelease"
-      - uses: actions/checkout@v2.3.3
+          fetch-depth: 0
+      - run: npm install @octokit/rest semver
+      - name: Retrieve tags
+        id: list-tags
+        uses: actions/github-script@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          ref: ${{ steps.last_release.outputs.tag_name }}
-      - name: Get version from package
-        id: package-version
-        uses: martinbeentjes/npm-get-version-action@master
+          script: |
+            const getTestingTags = require('./scripts/getTestingTags.js');
+            const tagsToTest = await getTestingTags();
+            const matrixInput = { include: tagsToTest.map(tag => ({tag})) }
+            core.setOutput("matrixInput", JSON.stringify(matrixInput));
+            console.log("matrixInput: ", matrixInput);
+
+  start_workflow:
+    name: Trigger Test Matrix
+    strategy:
+      matrix: ${{ fromJSON(needs.get-testing-tags.outputs.matrixInput) }}
+    needs: get-testing-tags
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+      SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+      SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
+      SAUCE_JOB: "Alloy Prod Workflow"
+      ALLOY_ENV: prod
+    steps:
+      - name: Create a workflow dispatch event with ${{ matrix.tag }}
+        uses: actions/checkout@v2.3.3
+        with:
+          ref: ${{ matrix.tag }}
       - uses: actions/cache@v2
         id: npm-cache
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
+      - name: Get version from package
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@master
       - name: Install dependencies
         if: steps.npm-cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -42,7 +62,7 @@ jobs:
       - name: Run TestCafe Tests
         run: npx testcafe -q -c 5 'saucelabs:Chrome@latest:macOS 11.00','saucelabs:IE@latest:Windows 10','saucelabs:Firefox@latest:Windows 10','saucelabs:Safari@latest:macOS 11.00'
         env:
-          ALLOY_PROD_VERSION: ${{ steps.package-version.outputs.current-version }}
+          ALLOY_PROD_VERSION: ${{ steps.package-version.outputs.current-version }}    
       - uses: craftech-io/slack-action@v1
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -4,56 +4,36 @@ on:
     - cron: "0 */24 * * *"
   workflow_dispatch:
 
-jobs:
-  get-testing-tags:
-    name: Fetch releases
-    runs-on: ubuntu-latest
-    outputs:
-      matrixInput: ${{ steps.list-tags.outputs.matrixInput }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - run: npm install @octokit/rest semver
-      - name: Retrieve tags
-        id: list-tags
-        uses: actions/github-script@v4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          script: |
-            const getTestingTags = require('./scripts/getTestingTags.js');
-            const tagsToTest = await getTestingTags();
-            const matrixInput = { include: tagsToTest.map(tag => ({tag})) }
-            core.setOutput("matrixInput", JSON.stringify(matrixInput));
-            console.log("matrixInput: ", matrixInput);
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+  SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+  SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
+  SAUCE_JOB: "Alloy Prod Workflow"
+  ALLOY_ENV: prod
 
+jobs:
   start_workflow:
-    name: Trigger Test Matrix
-    strategy:
-      matrix: ${{ fromJSON(needs.get-testing-tags.outputs.matrixInput) }}
-    needs: get-testing-tags
+    name: "Prod E2E Tests"
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-      SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-      SAUCE_CAPABILITIES_OVERRIDES_PATH: 'sauceLabsCapabilities.json'
-      SAUCE_JOB: "Alloy Prod Workflow"
-      ALLOY_ENV: prod
     steps:
-      - name: Create a workflow dispatch event with ${{ matrix.tag }}
-        uses: actions/checkout@v2.3.3
+      - name: "Get latest Alloy Release"
+        id: last_release
+        uses: InsonusK/get-latest-release@v1.0.1
         with:
-          ref: ${{ matrix.tag }}
+          myToken: ${{ github.token }}
+          exclude_types: "draft|prerelease"
+      - uses: actions/checkout@v2.3.3
+        with:
+          ref: ${{ steps.last_release.outputs.tag_name }}
+      - name: Get version from package
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@master
       - uses: actions/cache@v2
         id: npm-cache
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
-      - name: Get version from package
-        id: package-version
-        uses: martinbeentjes/npm-get-version-action@master
       - name: Install dependencies
         if: steps.npm-cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -62,7 +42,7 @@ jobs:
       - name: Run TestCafe Tests
         run: npx testcafe -q -c 5 'saucelabs:Chrome@latest:macOS 11.00','saucelabs:IE@latest:Windows 10','saucelabs:Firefox@latest:Windows 10','saucelabs:Safari@latest:macOS 11.00'
         env:
-          ALLOY_PROD_VERSION: ${{ steps.package-version.outputs.current-version }}    
+          ALLOY_PROD_VERSION: ${{ steps.package-version.outputs.current-version }}
       - uses: craftech-io/slack-action@v1
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7642,6 +7642,7 @@
       "resolved": "https://registry.npmjs.org/iltorb/-/iltorb-2.4.5.tgz",
       "integrity": "sha512-EMCMl3LnnNSZJS5QrxyZmMTaAC4+TJkM5woD+xbpm9RB+mFYCr7C05GFE3TEGCsVQSVHmjX+3sf5AiwsylNInQ==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
         "nan": "^2.14.0",

--- a/scripts/getTestingTags.js
+++ b/scripts/getTestingTags.js
@@ -42,7 +42,7 @@ module.exports = () => {
         .filter(release => !release.draft && !release.prerelease)
         .map(release => release.tag_name);
       const prodReleasesToTest = prodReleases.filter(tag =>
-        semver.lte("2.4.0", semver.clean(tag))
+        semver.lte("2.6.4", semver.clean(tag))
       );
       if (prodReleasesToTest.length < prodReleases.length) {
         done();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently the Prod Github Actions workflow runs on release versions > 2.4.0 using the getTestingTags script. The test changes introduced in "[[PDCL-6220]](https://github.com/adobe/alloy/commit/89ccc41e0721312b23efd50393b2d52e31a4df1f) - Single identity:result handle retured on consent update" has breaking changes to the test suite. 

The "start_workflow" test matrix runs the functional test cases within the release tags. Disabling the test matrix and testing only v2.6.4 with the latest test changes.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:



- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
