### PR TITLE
PDCL-6797: Return edge destinations in sendEvent.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/alloy",
-  "version": "2.6.4",
+  "version": "2.7.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/alloy",
-      "version": "2.6.4",
+      "version": "2.7.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/reactor-cookie": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/alloy",
-  "version": "2.6.4",
+  "version": "2.7.0-beta.0",
   "description": "Adobe Experience Platform Web SDK",
   "main": "libEs5/index.js",
   "module": "libEs6/index.js",

--- a/src/components/Audiences/index.js
+++ b/src/components/Audiences/index.js
@@ -12,19 +12,19 @@ governing permissions and limitations under the License.
 
 import { fireReferrerHideableImage } from "../../utils";
 import injectProcessDestinations from "./injectProcessDestinations";
+import injectProcessResponse from "./injectProcessResponse";
 
 const createAudiences = ({ logger }) => {
   const processDestinations = injectProcessDestinations({
     fireReferrerHideableImage,
     logger
   });
-  const processDestinationsFromResponse = ({ response }) => {
-    const destinations = response.getPayloadsByType("activation:push");
-    return processDestinations(destinations);
-  };
+
+  const processResponse = injectProcessResponse({ processDestinations });
+
   return {
     lifecycle: {
-      onResponse: processDestinationsFromResponse
+      onResponse: processResponse
     },
     commands: {}
   };

--- a/src/components/Audiences/injectProcessResponse.js
+++ b/src/components/Audiences/injectProcessResponse.js
@@ -28,7 +28,7 @@ export default ({ processDestinations }) => {
     const resolveValue = isNonEmptyArray(destinations)
       ? { destinations }
       : undefined;
-    return Promise.resolve(resolveValue);
+    return resolveValue;
   };
 
   return ({ response }) => {

--- a/src/components/Audiences/injectProcessResponse.js
+++ b/src/components/Audiences/injectProcessResponse.js
@@ -10,25 +10,16 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { isNonEmptyArray } from "../../utils";
-
 export default ({ processDestinations }) => {
   const processPushDestinations = ({ response }) => {
     const destinations = response.getPayloadsByType("activation:push");
     return processDestinations(destinations);
   };
 
-  // IMPORTANT: We are breaking our own interface here, and not returning
-  // a handle if it's not available in the response. We are doing this because
-  // a small group of customers need the edge destinations for a beta program.
-  // This behavior along with the `destinations` variable name will most probably
-  // change in the near future.
   const retrievePullDestinations = ({ response }) => {
-    const destinations = response.getPayloadsByType("activation:pull");
-    const resolveValue = isNonEmptyArray(destinations)
-      ? { destinations }
-      : undefined;
-    return resolveValue;
+    return {
+      destinations: response.getPayloadsByType("activation:pull")
+    };
   };
 
   return ({ response }) => {

--- a/src/components/Audiences/injectProcessResponse.js
+++ b/src/components/Audiences/injectProcessResponse.js
@@ -10,16 +10,25 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import { isNonEmptyArray } from "../../utils";
+
 export default ({ processDestinations }) => {
   const processPushDestinations = ({ response }) => {
     const destinations = response.getPayloadsByType("activation:push");
     return processDestinations(destinations);
   };
 
+  // IMPORTANT: We are breaking our own interface here, and not returning
+  // a handle if it's not available in the response. We are doing this because
+  // a small group of customers need the edge destinations for a beta program.
+  // This behavior along with the `destinations` variable name will most probably
+  // change in the near future.
   const retrievePullDestinations = ({ response }) => {
-    return Promise.resolve({
-      destinations: response.getPayloadsByType("activation:pull")
-    });
+    const destinations = response.getPayloadsByType("activation:pull");
+    const resolveValue = isNonEmptyArray(destinations)
+      ? { destinations }
+      : undefined;
+    return Promise.resolve(resolveValue);
   };
 
   return ({ response }) => {

--- a/src/components/Audiences/injectProcessResponse.js
+++ b/src/components/Audiences/injectProcessResponse.js
@@ -1,0 +1,30 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+export default ({ processDestinations }) => {
+  const processPushDestinations = ({ response }) => {
+    const destinations = response.getPayloadsByType("activation:push");
+    return processDestinations(destinations);
+  };
+
+  const retrievePullDestinations = ({ response }) => {
+    return Promise.resolve({
+      destinations: response.getPayloadsByType("activation:pull")
+    });
+  };
+
+  return ({ response }) => {
+    return processPushDestinations({ response }).then(() =>
+      retrievePullDestinations({ response })
+    );
+  };
+};

--- a/test/unit/specs/components/Audiences/injectProcessResponse.spec.js
+++ b/test/unit/specs/components/Audiences/injectProcessResponse.spec.js
@@ -36,12 +36,16 @@ describe("injectProcessResponse", () => {
     });
   });
 
-  it("returns undefined if no destinations were found", () => {
+  it("returns [] if no destinations were found", () => {
     const responseWithNoDestinations = jasmine.createSpyObj("response", {
       getPayloadsByType: []
     });
-    return processResponse({
-      response: responseWithNoDestinations
-    }).then(result => expect(result).toEqual(undefined));
+    return processResponse({ response: responseWithNoDestinations }).then(
+      result => {
+        expect(result).toEqual({
+          destinations: []
+        });
+      }
+    );
   });
 });

--- a/test/unit/specs/components/Audiences/injectProcessResponse.spec.js
+++ b/test/unit/specs/components/Audiences/injectProcessResponse.spec.js
@@ -36,16 +36,12 @@ describe("injectProcessResponse", () => {
     });
   });
 
-  it("returns [] if no destinations were found", () => {
+  it("returns undefined if no destinations were found", () => {
     const responseWithNoDestinations = jasmine.createSpyObj("response", {
       getPayloadsByType: []
     });
-    return processResponse({ response: responseWithNoDestinations }).then(
-      result => {
-        expect(result).toEqual({
-          destinations: []
-        });
-      }
-    );
+    return processResponse({
+      response: responseWithNoDestinations
+    }).then(result => expect(result).toEqual(undefined));
   });
 });

--- a/test/unit/specs/components/Audiences/injectProcessResponse.spec.js
+++ b/test/unit/specs/components/Audiences/injectProcessResponse.spec.js
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import injectProcessResponse from "../../../../../src/components/Audiences/injectProcessResponse";
+
+describe("injectProcessResponse", () => {
+  let response;
+  let processResponse;
+  let processDestinations;
+
+  beforeEach(() => {
+    processDestinations = jasmine
+      .createSpy("processDestinations")
+      .and.returnValue(Promise.resolve());
+    processResponse = injectProcessResponse({ processDestinations });
+
+    response = jasmine.createSpyObj("response", {
+      getPayloadsByType: ["An Edge Destination"]
+    });
+  });
+
+  it("fetches destinations from the response", () => {
+    return processResponse({ response }).then(result => {
+      expect(processDestinations).toHaveBeenCalled();
+      expect(result).toEqual({
+        destinations: ["An Edge Destination"]
+      });
+    });
+  });
+
+  it("returns [] if no destinations were found", () => {
+    const responseWithNoDestinations = jasmine.createSpyObj("response", {
+      getPayloadsByType: []
+    });
+    return processResponse({ response: responseWithNoDestinations }).then(
+      result => {
+        expect(result).toEqual({
+          destinations: []
+        });
+      }
+    );
+  });
+});


### PR DESCRIPTION
PLEASE DON'T MERGE THIS PR!

## Description

We are going to return the handles of type `activation:pull` in the sendEvent promise. This design might not be final, but we need it for a beta program. Please don't merge since we will be having more design conversations around returning additional handles from the response in the sendEvent command, without changing the SDK.

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-6797


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [X] I have made any necessary test changes and all tests pass.
- [X] I have run the Sandbox successfully.
