### PR TITLE
TNT-42028 Support Shadow DOM selectors (updated)

### DIFF
--- a/src/components/Personalization/dom-actions/dom/querySelectorAll.js
+++ b/src/components/Personalization/dom-actions/dom/querySelectorAll.js
@@ -1,0 +1,16 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import toArray from "../../../../utils/toArray";
+
+export default (context, selector) =>
+  toArray(context.querySelectorAll(selector));

--- a/src/components/Personalization/dom-actions/dom/selectNodesWithShadow.js
+++ b/src/components/Personalization/dom-actions/dom/selectNodesWithShadow.js
@@ -1,0 +1,70 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import querySelectorAll from "./querySelectorAll";
+import { startsWith } from "../../../../utils";
+
+const SHADOW_SEPARATOR = ":shadow";
+
+const splitWithShadow = selector => {
+  return selector.split(SHADOW_SEPARATOR);
+};
+
+const transformPrefix = (parent, selector) => {
+  const result = selector.trim();
+  const hasChildCombinatorPrefix = startsWith(result, ">");
+  if (!hasChildCombinatorPrefix) {
+    return result;
+  }
+
+  // IE doesn't support :scope
+  if (window.document.documentMode) {
+    return result.substring(1).trim();
+  }
+
+  const prefix =
+    parent instanceof Element || parent instanceof HTMLDocument
+      ? ":scope"
+      : ":host"; // see https://bugs.webkit.org/show_bug.cgi?id=233380
+
+  return `${prefix} ${result}`;
+};
+
+export const isShadowSelector = str => str.indexOf(SHADOW_SEPARATOR) !== -1;
+
+export default (context, selector) => {
+  // Shadow DOM should be supported
+  if (!window.document.documentElement.attachShadow) {
+    return querySelectorAll(context, selector.replace(SHADOW_SEPARATOR, ""));
+  }
+
+  const parts = splitWithShadow(selector);
+
+  if (parts.length < 2) {
+    return querySelectorAll(context, selector);
+  }
+
+  // split the selector into parts separated by :shadow pseudo-selectors
+  // find each subselector element based on the previously selected node's shadowRoot
+  let parent = context;
+  for (let i = 0; i < parts.length; i += 1) {
+    const part = transformPrefix(parent, parts[i]);
+    const partNode = querySelectorAll(parent, part);
+
+    if (partNode.length === 0 || !partNode[0] || !partNode[0].shadowRoot) {
+      return partNode;
+    }
+
+    parent = partNode[0].shadowRoot;
+  }
+  return undefined;
+};

--- a/src/utils/dom/selectNodes.js
+++ b/src/utils/dom/selectNodes.js
@@ -10,7 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import toArray from "../toArray";
+import querySelectorAll from "../../components/Personalization/dom-actions/dom/querySelectorAll";
+import selectNodesWithShadow, {
+  isShadowSelector
+} from "../../components/Personalization/dom-actions/dom/selectNodesWithShadow";
 
 /**
  * Returns an array of matched DOM nodes.
@@ -19,5 +22,9 @@ import toArray from "../toArray";
  * @returns {Array} an array of DOM nodes
  */
 export default (selector, context = document) => {
-  return toArray(context.querySelectorAll(selector));
+  if (!isShadowSelector(selector)) {
+    return querySelectorAll(context, selector);
+  }
+
+  return selectNodesWithShadow(context, selector);
 };

--- a/test/functional/fixtures/Personalization/C28758.js
+++ b/test/functional/fixtures/Personalization/C28758.js
@@ -1,0 +1,46 @@
+export const shadowDomScript = `
+    const buyNowContent = \`
+    <div>
+      <input type="radio" id="buy" name="buy_btn" value="Buy NOW">
+      <label for="buy">Buy Now</label><br>
+      <div>
+        <input type="radio" id="buy_later" name="buy_btn_ltr" value="Buy LATER">
+        <label for="buy_later">Buy Later</label><br>
+      </div>
+    </div>
+  \`;
+    customElements.define(
+      "buy-now-button",
+      class extends HTMLElement {
+        constructor() {
+          super();
+
+          const shadowRoot = this.attachShadow({ mode: "open" });
+          shadowRoot.innerHTML = buyNowContent;
+        }
+      }
+    );
+
+    const productOrderContent = \`<div><p>Product order</p><buy-now-button>Buy</buy-now-button></div>\`;
+    customElements.define(
+      "product-order",
+      class extends HTMLElement {
+        constructor() {
+          super();
+
+          const shadowRoot = this.attachShadow({ mode: "open" });
+          shadowRoot.innerHTML = productOrderContent;
+        }
+      }
+    );
+`;
+
+export const shadowDomFixture = `
+  <form id="form" action="https://www.adobe.com" method="post">
+    <buy-now-button>FirstButton</buy-now-button>
+    <buy-now-button>SecondButton</buy-now-button>
+    <product-order>FirstOrder</product-order>
+    <product-order>SecondOrder</product-order>
+    <input type="submit" value="Submit"/>
+  </form>
+  `;

--- a/test/functional/helpers/createFixture/clientScripts.js
+++ b/test/functional/helpers/createFixture/clientScripts.js
@@ -74,7 +74,7 @@ const getProdNpmLibraryCode = () => {
   return readCache.sync(prodNpmLibraryPath, "utf8");
 };
 
-const injectInlineScript = ClientFunction(code => {
+export const injectInlineScript = ClientFunction(code => {
   const scriptElement = document.createElement("script");
   // eslint-disable-next-line no-undef
   scriptElement.innerHTML = code;

--- a/test/functional/specs/Personalization/C28758.js
+++ b/test/functional/specs/Personalization/C28758.js
@@ -1,0 +1,107 @@
+import { t, ClientFunction } from "testcafe";
+import createNetworkLogger from "../../helpers/networkLogger";
+import { responseStatus } from "../../helpers/assertions/index";
+import createFixture from "../../helpers/createFixture";
+import addHtmlToBody from "../../helpers/dom/addHtmlToBody";
+import {
+  compose,
+  orgMainConfigMain,
+  debugEnabled
+} from "../../helpers/constants/configParts";
+import getResponseBody from "../../helpers/networkLogger/getResponseBody";
+import createResponse from "../../helpers/createResponse";
+import { TEST_PAGE as TEST_PAGE_URL } from "../../helpers/constants/url";
+import createAlloyProxy from "../../helpers/createAlloyProxy";
+import { injectInlineScript } from "../../helpers/createFixture/clientScripts";
+import {
+  shadowDomScript,
+  shadowDomFixture
+} from "../../fixtures/Personalization/C28758";
+
+const networkLogger = createNetworkLogger();
+const config = compose(orgMainConfigMain, debugEnabled);
+const PAGE_WIDE_SCOPE = "__view__";
+
+const ieDetected = ClientFunction(() => !!document.documentMode);
+
+createFixture({
+  title: "C28758 A VEC offer with ShadowDOM selectors should render",
+  url: `${TEST_PAGE_URL}?test=C28758`,
+  requestHooks: [networkLogger.edgeEndpointLogs]
+});
+
+test.meta({
+  ID: "C28758",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+
+const getSimpleShadowLabelText = ClientFunction(() => {
+  const form = document.getElementById("form");
+  const simpleShadowLabel = form.children[1].shadowRoot.children[0].getElementsByTagName(
+    "label"
+  )[1];
+
+  return simpleShadowLabel.innerText;
+});
+
+const getNestedShadowLabelText = ClientFunction(() => {
+  const form = document.getElementById("form");
+  const nestedShadowLabel = form.children[3].shadowRoot
+    .querySelector("buy-now-button")
+    .shadowRoot.children[0].getElementsByTagName("label")[0];
+
+  return nestedShadowLabel.innerText;
+});
+
+test("Test C28758: A VEC offer with ShadowDOM selectors should render", async () => {
+  if (await ieDetected()) {
+    return;
+  }
+
+  await injectInlineScript(shadowDomScript);
+  await addHtmlToBody(shadowDomFixture);
+
+  const alloy = createAlloyProxy();
+  await alloy.configure(config);
+
+  const eventResult = await alloy.sendEvent({ renderDecisions: true });
+
+  await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
+
+  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(2);
+
+  const sendEventRequest = networkLogger.edgeEndpointLogs.requests[0];
+  const requestBody = JSON.parse(sendEventRequest.request.body);
+
+  await t
+    .expect(requestBody.events[0].query.personalization.decisionScopes)
+    .eql([PAGE_WIDE_SCOPE]);
+
+  const personalizationSchemas =
+    requestBody.events[0].query.personalization.schemas;
+
+  const result = [
+    "https://ns.adobe.com/personalization/dom-action",
+    "https://ns.adobe.com/personalization/html-content-item",
+    "https://ns.adobe.com/personalization/json-content-item",
+    "https://ns.adobe.com/personalization/redirect-item"
+  ].every(schema => personalizationSchemas.includes(schema));
+
+  await t.expect(result).eql(true);
+
+  const response = JSON.parse(
+    getResponseBody(networkLogger.edgeEndpointLogs.requests[0])
+  );
+  const personalizationPayload = createResponse({
+    content: response
+  }).getPayloadsByType("personalization:decisions");
+
+  await t.expect(personalizationPayload[0].scope).eql(PAGE_WIDE_SCOPE);
+
+  await t.expect(getSimpleShadowLabelText()).eql("Simple Shadow offer!");
+  await t.expect(getNestedShadowLabelText()).eql("Nested Shadow offer!");
+
+  await t.expect(eventResult.decisions).eql([]);
+  await t.expect(eventResult.propositions[0].renderAttempted).eql(true);
+});

--- a/test/unit/specs/components/Personalization/dom-actions/dom/querySelectorAll.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/dom/querySelectorAll.spec.js
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+  appendNode,
+  createNode,
+  removeNode,
+  selectNodes
+} from "../../../../../../../src/utils/dom";
+import querySelectorAll from "../../../../../../../src/components/Personalization/dom-actions/dom/querySelectorAll";
+
+describe("Personalization::DOM::querySelectorAll", () => {
+  afterEach(() => {
+    selectNodes(".qsa").forEach(removeNode);
+  });
+
+  it("should select with querySelectorAll", () => {
+    const node = createNode(
+      "DIV",
+      { id: "abc", class: "qsa" },
+      {
+        innerHTML: `<div class="test">Test</div>`
+      }
+    );
+
+    appendNode(document.body, node);
+
+    const selector = ".test";
+    const result = querySelectorAll(document, selector);
+    expect(Array.isArray(result)).toBeTrue();
+    expect(result[0]).toEqual(node.children[0]);
+  });
+});

--- a/test/unit/specs/components/Personalization/dom-actions/dom/selectNodesWithShadow.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/dom/selectNodesWithShadow.spec.js
@@ -1,0 +1,152 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+// eslint-disable-next-line max-classes-per-file
+import {
+  createNode,
+  appendNode,
+  selectNodes,
+  removeNode
+} from "../../../../../../../src/utils/dom";
+import { selectNodesWithEq } from "../../../../../../../src/components/Personalization/dom-actions/dom";
+import { isShadowSelector } from "../../../../../../../src/components/Personalization/dom-actions/dom/selectNodesWithShadow";
+
+const ieDetected = () => !!document.documentMode;
+
+const defineCustomElements = () => {
+  if (!customElements || customElements.get("buy-now-button")) {
+    return;
+  }
+
+  const buyNowContent = `
+    <div>
+      <input type="radio" id="buy" name="buy_btn" value="Buy NOW">
+      <label for="buy">Buy Now</label><br>
+      <div>
+        <input type="radio" id="buy_later" name="buy_btn_ltr" value="Buy LATER">
+        <label for="buy_later">Buy Later</label><br>
+      </div>
+    </div>
+  `;
+  customElements.define(
+    "buy-now-button",
+    class extends HTMLElement {
+      constructor() {
+        super();
+
+        const shadowRoot = this.attachShadow({ mode: "open" });
+        shadowRoot.innerHTML = buyNowContent;
+      }
+    }
+  );
+
+  const productOrderContent = `<div><p>Product order</p><buy-now-button>Buy</buy-now-button></div>`;
+  customElements.define(
+    "product-order",
+    class extends HTMLElement {
+      constructor() {
+        super();
+
+        const shadowRoot = this.attachShadow({ mode: "open" });
+        shadowRoot.innerHTML = productOrderContent;
+      }
+    }
+  );
+};
+
+describe("Personalization::DOM::selectNodesWithShadow", () => {
+  afterEach(() => {
+    selectNodes(".shadow").forEach(removeNode);
+  });
+
+  it("should select when no shadow", () => {
+    appendNode(
+      document.body,
+      createNode("DIV", { id: "noShadow", class: "shadow" })
+    );
+
+    const result = selectNodes("#noShadow");
+
+    expect(result[0].tagName).toEqual("DIV");
+    expect(result[0].id).toEqual("noShadow");
+  });
+
+  it("should select when one shadow node", () => {
+    if (ieDetected()) {
+      return;
+    }
+
+    defineCustomElements();
+
+    const content = `
+    <form id="form" action="https://www.adobe.com" method="post">
+      <buy-now-button>FirstButton</buy-now-button>
+      <buy-now-button>SecondButton</buy-now-button>
+      <input type="submit" value="Submit"/>
+    </form>`;
+
+    appendNode(
+      document.body,
+      createNode("DIV", { id: "abc", class: "shadow" }, { innerHTML: content })
+    );
+
+    const result = selectNodesWithEq(
+      "#abc:eq(0) > FORM:nth-of-type(1) > BUY-NOW-BUTTON:nth-of-type(2):shadow > DIV:nth-of-type(1) > LABEL:nth-of-type(1)"
+    );
+
+    expect(result.length).toEqual(1);
+
+    expect(result[0].tagName).toEqual("LABEL");
+    expect(result[0].textContent).toEqual("Buy Now");
+  });
+
+  it("should select when multiple nested shadow nodes", () => {
+    if (ieDetected()) {
+      return;
+    }
+
+    defineCustomElements();
+
+    const content = `
+    <form id="form" action="https://www.adobe.com" method="post">
+      <buy-now-button>FirstButton</buy-now-button>
+      <buy-now-button>SecondButton</buy-now-button>
+      <product-order>FirstOrder</product-order>
+      <product-order>SecondOrder</product-order>
+      <input type="submit" value="Submit"/>
+    </form>`;
+
+    appendNode(
+      document.body,
+      createNode("DIV", { id: "abc", class: "shadow" }, { innerHTML: content })
+    );
+
+    const result = selectNodesWithEq(
+      "#abc:eq(0) > FORM:nth-of-type(1) > PRODUCT-ORDER:nth-of-type(2):shadow > *:eq(0) > BUY-NOW-BUTTON:nth-of-type(1):shadow > DIV:nth-of-type(1) > LABEL:nth-of-type(1)"
+    );
+
+    expect(result[0].tagName).toEqual("LABEL");
+    expect(result[0].textContent).toEqual("Buy Now");
+  });
+});
+
+describe("Personalization::DOM::selectNodesWithShadow:isShadowSelector", () => {
+  it("should detect shadow selectors", () => {
+    let selector =
+      "BODY > BUY-NOW-BUTTON:nth-of-type(2):shadow > DIV:nth-of-type(1)";
+    let result = isShadowSelector(selector);
+    expect(result).toBeTrue();
+    selector = "BODY > BUY-NOW-BUTTON:nth-of-type(2) > DIV:nth-of-type(1)";
+    result = isShadowSelector(selector);
+    expect(result).toBeFalse();
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Previously merged TNT-42028 Support Shadow DOM selectors #773 was reverted as the tests were failing in Firefox and Safari.
This PR fixes the Shadow DOM support implementation, so it works across all browsers (except IE, which is expected).

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://jira.corp.adobe.com/browse/TNT-42028
https://jira.corp.adobe.com/browse/TNT-43043

## Motivation and Context

Previously merged TNT-42028 Support Shadow DOM selectors #773 was reverted as the tests were failing in Firefox and Safari.

Applying of offers with Shadow DOM :shadow selectors only worked in Chrome/Edge, and didn't work in Firefox/Safari - although the `:scope` pseudo-class which we're using in the implementation is supposed to be supported in FF/Safari - https://caniuse.com/mdn-css_selectors_scope_dom_api it isn't actually working as expected in FF and Safari, not matching any child nodes when `querySelectorAll` is called on a shadow root.

I have opened a  bug report with WebKit - https://bugs.webkit.org/show_bug.cgi?id=233380 and reopened an older bug in Firefox(Gecko) - https://bugzilla.mozilla.org/show_bug.cgi?id=1689893

Based on the latest discussion there, it turns out that `:scope` is not supposed to be working when called on a shadow tree, instead it is the Chrome/Edge support of this that is unexpected, and thus a bug was opened with Chromium - https://bugs.chromium.org/p/chromium/issues/detail?id=1272434

Thankfully, there's an alternate solution for selecting direct descendants of the shadow root using `:host` pseudo-class, which I've confirmed to be working across all browsers (except IE, which is expected).

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
