### PR TITLE
PDCL-7265: Use standard names for notifications event types

### DIFF
--- a/src/components/Personalization/createCollect.js
+++ b/src/components/Personalization/createCollect.js
@@ -14,7 +14,7 @@ export default ({ eventManager, mergeDecisionsMeta }) => {
   // Called when a decision is auto-rendered for the __view__ scope (non-SPA view).
   return ({ decisionsMeta, documentMayUnload = false }) => {
     const event = eventManager.createEvent();
-    event.mergeXdm({ eventType: "display" });
+    event.mergeXdm({ eventType: "decisioning.propositionDisplay" });
     mergeDecisionsMeta(event, decisionsMeta);
 
     if (documentMayUnload) {

--- a/src/components/Personalization/createOnClickHandler.js
+++ b/src/components/Personalization/createOnClickHandler.js
@@ -29,7 +29,7 @@ export default ({
       );
 
       if (isNonEmptyArray(decisionsMeta)) {
-        event.mergeXdm({ eventType: "click" });
+        event.mergeXdm({ eventType: "decisioning.propositionInteract" });
         mergeDecisionsMeta(event, decisionsMeta);
       }
     }

--- a/src/components/Personalization/createViewCollect.js
+++ b/src/components/Personalization/createViewCollect.js
@@ -15,7 +15,7 @@ import { isNonEmptyArray } from "../../utils";
 export default ({ eventManager, mergeDecisionsMeta }) => {
   // Called when an offer for a specific SPA view is auto-rendered.
   return ({ decisionsMeta, xdm }) => {
-    const data = { eventType: "display" };
+    const data = { eventType: "decisioning.propositionDisplay" };
     const event = eventManager.createEvent();
 
     if (isNonEmptyArray(decisionsMeta)) {

--- a/test/functional/specs/Personalization/C28760.js
+++ b/test/functional/specs/Personalization/C28760.js
@@ -81,7 +81,7 @@ test("Test C28760: A notification collect should be triggered if a VEC dom actio
 
   await t
     .expect(notificationRequestBody.events[0].xdm.eventType)
-    .eql("display");
+    .eql("decisioning.propositionDisplay");
   await t
     .expect(
       // eslint-disable-next-line no-underscore-dangle

--- a/test/functional/specs/Personalization/C782718.js
+++ b/test/functional/specs/Personalization/C782718.js
@@ -106,7 +106,7 @@ const simulatePageLoad = async alloy => {
   const notificationRequestBody = JSON.parse(notificationRequest.request.body);
   await t
     .expect(notificationRequestBody.events[0].xdm.eventType)
-    .eql("display");
+    .eql("decisioning.propositionDisplay");
   const pageWideScopeDecisionsMeta = getDecisionsMetaByScope(
     personalizationPayload,
     PAGE_WIDE_SCOPE
@@ -169,7 +169,7 @@ const simulateViewChange = async (alloy, personalizationPayload) => {
   );
   await t
     .expect(cartViewNotificationRequestBody.events[0].xdm.eventType)
-    .eql("display");
+    .eql("decisioning.propositionDisplay");
   const cartViewDecisionsMeta = getDecisionsMetaByScope(
     personalizationPayload,
     "cart"
@@ -218,7 +218,7 @@ const simulateViewChangeForNonExistingView = async alloy => {
   );
   await t
     .expect(noViewNotificationRequestBody.events[0].xdm.eventType)
-    .eql("display");
+    .eql("decisioning.propositionDisplay");
   await t
     .expect(
       noViewNotificationRequestBody.events[0].xdm.web.webPageDetails.viewName

--- a/test/unit/specs/components/Personalization/createCollect.spec.js
+++ b/test/unit/specs/components/Personalization/createCollect.spec.js
@@ -36,7 +36,9 @@ describe("Personalization::createCollect", () => {
     const collect = createCollect({ eventManager, mergeDecisionsMeta });
     collect({ decisionsMeta });
     expect(eventManager.createEvent).toHaveBeenCalled();
-    expect(event.mergeXdm).toHaveBeenCalledWith({ eventType: "display" });
+    expect(event.mergeXdm).toHaveBeenCalledWith({
+      eventType: "decisioning.propositionDisplay"
+    });
     expect(mergeDecisionsMeta).toHaveBeenCalledWith(event, decisionsMeta);
     expect(eventManager.sendEvent).toHaveBeenCalled();
   });

--- a/test/unit/specs/components/Personalization/createOnClickHandler.spec.js
+++ b/test/unit/specs/components/Personalization/createOnClickHandler.spec.js
@@ -52,7 +52,9 @@ describe("Personalization::createOnClickHandler", () => {
 
     handleOnClick({ event, clickedElement });
 
-    expect(event.mergeXdm).toHaveBeenCalledWith({ eventType: "click" });
+    expect(event.mergeXdm).toHaveBeenCalledWith({
+      eventType: "decisioning.propositionInteract"
+    });
     expect(mergeDecisionsMeta).toHaveBeenCalledWith(event, decisionsMeta);
     expect(collectClicks).toHaveBeenCalledWith(
       clickedElement,

--- a/test/unit/specs/components/Personalization/createViewCollect.spec.js
+++ b/test/unit/specs/components/Personalization/createViewCollect.spec.js
@@ -34,7 +34,7 @@ describe("Personalization::createViewCollect", () => {
 
   it("sends event with metadata when decisions is not empty", () => {
     const expectedXdmObject = {
-      eventType: "display",
+      eventType: "decisioning.propositionDisplay",
       web: {
         webPageDetails: {
           viewName: "cart"
@@ -60,7 +60,7 @@ describe("Personalization::createViewCollect", () => {
       }
     };
     const data = {
-      eventType: "display"
+      eventType: "decisioning.propositionDisplay"
     };
     const collect = createViewCollect({ eventManager, mergeDecisionsMeta });
 


### PR DESCRIPTION
## Description

Use standard names for Personalization notification event types. Replace display and click with:

display - decisioning.propositionDisplay
click - decisioning.propositionInteract

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-7265

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [X] I have made any necessary test changes and all tests pass.
- [X] I have run the Sandbox successfully.
