### PR TITLE
Run Lighthouse Audits on dev and prod workflows

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -48,6 +48,7 @@ jobs:
       run: npx testcafe -q -c 5 'saucelabs:Chrome@latest:macOS 11.00','saucelabs:IE@latest:Windows 10','saucelabs:Firefox@latest:Windows 10','saucelabs:Safari@latest:macOS 11.00'
 
   audit:
+    name: "Lighthouse Audit"
     runs-on: ubuntu-latest
     steps:
     - name: Audit AlloyIO

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -46,3 +46,16 @@ jobs:
       run: npm run test:functional:build:int
     - name: Run Functional Test
       run: npx testcafe -q -c 5 'saucelabs:Chrome@latest:macOS 11.00','saucelabs:IE@latest:Windows 10','saucelabs:Firefox@latest:Windows 10','saucelabs:Safari@latest:macOS 11.00'
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Audit AlloyIO
+      uses: jakejarvis/lighthouse-action@master
+      with:
+        url: 'https://alloyio.com/demo/'
+    - name: Upload results as an artifact
+      uses: actions/upload-artifact@master
+      with:
+        name: report
+        path: './report'

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -68,3 +68,17 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: failure
         if: failure()
+
+  audit:
+    name: "Lighthouse Audit"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Audit AlloyIO
+      uses: jakejarvis/lighthouse-action@master
+      with:
+        url: 'https://alloyio.com/demo/'
+    - name: Upload results as an artifact
+      uses: actions/upload-artifact@master
+      with:
+        name: report
+        path: './report'


### PR DESCRIPTION
Currently the reports are stored in the github antifactory. 

We can use integrate with Netlify's Deploy Preview feature, allowing us to test PRs before accepting them by hosting a build from the PR. 

Example: 

`jobs:
  audit:
    runs-on: ubuntu-latest
    steps:
    - name: Audit Netlify deploy preview
      uses: jakejarvis/lighthouse-action@master
      with:
        netlify_site: 'alloy-lighthouse-report.netlify.com'
    - uses: actions/upload-artifact@master
      with:
        name: report
        path: './report'`

The light house audit is currently running against https://alloyio.com/demo/ as a place holder.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
