### PR TITLE
TNT-43421 Fix circular dependency in Web SDK (alternate implementation)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,45 @@ module.exports = {
     // want to disallow importing extraneous dependencies.
     "import/no-extraneous-dependencies": "off",
     "prefer-destructuring": "off",
-    "import/prefer-default-export": "off"
+    "import/prefer-default-export": "off",
+    // Make rules about importing between the top level folders
+    // core can import from components, utils, and constants
+    // components can import from utils, and constants
+    // utils can import from constants
+    "import/no-restricted-paths": [
+      "error",
+      {
+        zones: [
+          // TODO: Remove dependencies from components into core
+          // Identity -> createIdentityRequest
+          // Consent -> createConsentRequest
+          // {
+          //  from: "./src/core",
+          //  target: "./src/components"
+          // },
+          {
+            from: "./src/core",
+            target: "./src/utils"
+          },
+          {
+            from: "./src/core",
+            target: "./src/constants"
+          },
+          {
+            from: "./src/components",
+            target: "./src/utils"
+          },
+          {
+            from: "./src/components",
+            target: "./src/constants"
+          },
+          {
+            from: "./src/utils",
+            target: "./src/constants"
+          }
+        ]
+      }
+    ]
   },
   globals: {
     expectAsync: "readonly", // newer jasmine feature

--- a/src/constants/shadowSeparator.js
+++ b/src/constants/shadowSeparator.js
@@ -1,0 +1,13 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+export default ":shadow";

--- a/src/utils/dom/index.js
+++ b/src/utils/dom/index.js
@@ -14,5 +14,7 @@ export { default as awaitSelector } from "./awaitSelector";
 export { default as appendNode } from "./appendNode";
 export { default as createNode } from "./createNode";
 export { default as matchesSelector } from "./matchesSelector";
+export { default as querySelectorAll } from "./querySelectorAll";
 export { default as removeNode } from "./removeNode";
 export { default as selectNodes } from "./selectNodes";
+export { default as selectNodesWithShadow } from "./selectNodesWithShadow";

--- a/src/utils/dom/isShadowSelector.js
+++ b/src/utils/dom/isShadowSelector.js
@@ -1,0 +1,15 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import SHADOW_SEPARATOR from "../../constants/shadowSeparator";
+
+export default str => str.indexOf(SHADOW_SEPARATOR) !== -1;

--- a/src/utils/dom/querySelectorAll.js
+++ b/src/utils/dom/querySelectorAll.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import toArray from "../../../../utils/toArray";
+import toArray from "../toArray";
 
 export default (context, selector) =>
   toArray(context.querySelectorAll(selector));

--- a/src/utils/dom/selectNodes.js
+++ b/src/utils/dom/selectNodes.js
@@ -10,10 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import querySelectorAll from "../../components/Personalization/dom-actions/dom/querySelectorAll";
+import querySelectorAll from "./querySelectorAll";
 import selectNodesWithShadow, {
   isShadowSelector
-} from "../../components/Personalization/dom-actions/dom/selectNodesWithShadow";
+} from "./selectNodesWithShadow";
 
 /**
  * Returns an array of matched DOM nodes.

--- a/src/utils/dom/selectNodes.js
+++ b/src/utils/dom/selectNodes.js
@@ -11,9 +11,8 @@ governing permissions and limitations under the License.
 */
 
 import querySelectorAll from "./querySelectorAll";
-import selectNodesWithShadow, {
-  isShadowSelector
-} from "./selectNodesWithShadow";
+import selectNodesWithShadow from "./selectNodesWithShadow";
+import isShadowSelector from "./isShadowSelector";
 
 /**
  * Returns an array of matched DOM nodes.

--- a/src/utils/dom/selectNodesWithShadow.js
+++ b/src/utils/dom/selectNodesWithShadow.js
@@ -12,8 +12,7 @@ governing permissions and limitations under the License.
 
 import querySelectorAll from "./querySelectorAll";
 import startsWith from "../startsWith";
-
-const SHADOW_SEPARATOR = ":shadow";
+import SHADOW_SEPARATOR from "../../constants/shadowSeparator";
 
 const splitWithShadow = selector => {
   return selector.split(SHADOW_SEPARATOR);
@@ -38,8 +37,6 @@ const transformPrefix = (parent, selector) => {
 
   return `${prefix} ${result}`;
 };
-
-export const isShadowSelector = str => str.indexOf(SHADOW_SEPARATOR) !== -1;
 
 export default (context, selector) => {
   // Shadow DOM should be supported

--- a/src/utils/dom/selectNodesWithShadow.js
+++ b/src/utils/dom/selectNodesWithShadow.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import querySelectorAll from "./querySelectorAll";
-import { startsWith } from "../../../../utils";
+import startsWith from "../startsWith";
 
 const SHADOW_SEPARATOR = ":shadow";
 

--- a/test/unit/specs/utils/dom/isShadowSelector.spec.js
+++ b/test/unit/specs/utils/dom/isShadowSelector.spec.js
@@ -1,0 +1,25 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import isShadowSelector from "../../../../../src/utils/dom/isShadowSelector";
+
+describe("Utils::DOM::isShadowSelector", () => {
+  it("should detect shadow selectors", () => {
+    let selector =
+      "BODY > BUY-NOW-BUTTON:nth-of-type(2):shadow > DIV:nth-of-type(1)";
+    let result = isShadowSelector(selector);
+    expect(result).toBeTrue();
+    selector = "BODY > BUY-NOW-BUTTON:nth-of-type(2) > DIV:nth-of-type(1)";
+    result = isShadowSelector(selector);
+    expect(result).toBeFalse();
+  });
+});

--- a/test/unit/specs/utils/dom/querySelectorAll.spec.js
+++ b/test/unit/specs/utils/dom/querySelectorAll.spec.js
@@ -15,8 +15,8 @@ import {
   createNode,
   removeNode,
   selectNodes
-} from "../../../../../../../src/utils/dom";
-import querySelectorAll from "../../../../../../../src/components/Personalization/dom-actions/dom/querySelectorAll";
+} from "../../../../../src/utils/dom";
+import querySelectorAll from "../../../../../src/utils/dom/querySelectorAll";
 
 describe("Personalization::DOM::querySelectorAll", () => {
   afterEach(() => {

--- a/test/unit/specs/utils/dom/selectNodesWithShadow.spec.js
+++ b/test/unit/specs/utils/dom/selectNodesWithShadow.spec.js
@@ -18,7 +18,6 @@ import {
   removeNode
 } from "../../../../../src/utils/dom";
 import { selectNodesWithEq } from "../../../../../src/components/Personalization/dom-actions/dom";
-import { isShadowSelector } from "../../../../../src/utils/dom/selectNodesWithShadow";
 
 const ieDetected = () => !!document.documentMode;
 
@@ -63,7 +62,7 @@ const defineCustomElements = () => {
   );
 };
 
-describe("Personalization::DOM::selectNodesWithShadow", () => {
+describe("Utils::DOM::selectNodesWithShadow", () => {
   afterEach(() => {
     selectNodes(".shadow").forEach(removeNode);
   });
@@ -136,17 +135,5 @@ describe("Personalization::DOM::selectNodesWithShadow", () => {
 
     expect(result[0].tagName).toEqual("LABEL");
     expect(result[0].textContent).toEqual("Buy Now");
-  });
-});
-
-describe("Personalization::DOM::selectNodesWithShadow:isShadowSelector", () => {
-  it("should detect shadow selectors", () => {
-    let selector =
-      "BODY > BUY-NOW-BUTTON:nth-of-type(2):shadow > DIV:nth-of-type(1)";
-    let result = isShadowSelector(selector);
-    expect(result).toBeTrue();
-    selector = "BODY > BUY-NOW-BUTTON:nth-of-type(2) > DIV:nth-of-type(1)";
-    result = isShadowSelector(selector);
-    expect(result).toBeFalse();
   });
 });

--- a/test/unit/specs/utils/dom/selectNodesWithShadow.spec.js
+++ b/test/unit/specs/utils/dom/selectNodesWithShadow.spec.js
@@ -16,9 +16,9 @@ import {
   appendNode,
   selectNodes,
   removeNode
-} from "../../../../../../../src/utils/dom";
-import { selectNodesWithEq } from "../../../../../../../src/components/Personalization/dom-actions/dom";
-import { isShadowSelector } from "../../../../../../../src/components/Personalization/dom-actions/dom/selectNodesWithShadow";
+} from "../../../../../src/utils/dom";
+import { selectNodesWithEq } from "../../../../../src/components/Personalization/dom-actions/dom";
+import { isShadowSelector } from "../../../../../src/utils/dom/selectNodesWithShadow";
 
 const ieDetected = () => !!document.documentMode;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix circular dependency introduced after ShadowDOM implementation. This is an alternate implementation to #794.

The issue is that src/utils/dom/selectNodes.js was importing querySelectorAll and selectNodesWithShadow from the personalization component. Utils should not import files from components. I've added a lint rule to make sure imports are not done from src/utils to src/components.

I considered going the other way and moving selectNodes into the personalization components, but selectNodes is used by awaitSelector, and awaitSelector is used by fireReferrerHideableImage, which is used by Audiences and Identity.

I also separated isShadowSelector so that each util is only exporting one thing.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

https://jira.corp.adobe.com/browse/TNT-43421

I'd like to include this in the 2.8.0 release because it would throw warnings for customers using the NPM version.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
