### PR TITLE
PDCL-1333 - remove event name validation logic

### DIFF
--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -12,13 +12,13 @@ governing permissions and limitations under the License.
 
 import validateUserEventOptions from "./validateUserEventOptions";
 
-const createDataCollector = ({ eventManager, logger }) => {
+const createDataCollector = ({ eventManager }) => {
   return {
     commands: {
       sendEvent: {
         documentationUri: "https://adobe.ly/2r0uUjh",
         optionsValidator: options => {
-          return validateUserEventOptions({ options, logger });
+          return validateUserEventOptions({ options });
         },
         run: options => {
           const {

--- a/src/components/DataCollector/validateUserEventOptions.js
+++ b/src/components/DataCollector/validateUserEventOptions.js
@@ -15,10 +15,9 @@ import { validateIdentityMap } from "../../utils";
 /**
  * Verifies user provided event options.
  * @param {*} options The user event options to validate
- * @param {*} logger
  * @returns {*} Validated options
  */
-export default ({ options, logger }) => {
+export default ({ options }) => {
   const eventOptionsValidator = objectOf({
     type: string(),
     xdm: objectOf({
@@ -30,10 +29,5 @@ export default ({ options, logger }) => {
     decisionScopes: arrayOf(string()),
     datasetId: string()
   }).required();
-  const validatedOptions = eventOptionsValidator(options);
-  const { type, xdm } = validatedOptions;
-  if (xdm && !xdm.eventType && !type) {
-    logger.warn("No type or xdm.eventType specified.");
-  }
-  return validatedOptions;
+  return eventOptionsValidator(options);
 };

--- a/test/unit/specs/components/DataCollector/index.spec.js
+++ b/test/unit/specs/components/DataCollector/index.spec.js
@@ -14,7 +14,6 @@ import { noop } from "../../../../../src/utils";
 
 describe("Event Command", () => {
   let event;
-  let logger;
   let eventManager;
   let sendEventCommand;
   beforeEach(() => {
@@ -25,7 +24,6 @@ describe("Event Command", () => {
       "mergeXdm",
       "mergeMeta"
     ]);
-    logger = jasmine.createSpyObj("logger", ["warn"]);
 
     eventManager = {
       createEvent() {
@@ -40,8 +38,7 @@ describe("Event Command", () => {
     };
 
     const dataCollector = createDataCollector({
-      eventManager,
-      logger
+      eventManager
     });
     sendEventCommand = dataCollector.commands.sendEvent;
   });

--- a/test/unit/specs/components/DataCollector/validateUserEventOptions.spec.js
+++ b/test/unit/specs/components/DataCollector/validateUserEventOptions.spec.js
@@ -56,42 +56,4 @@ describe("DataCollector::validateUserEventOptions", () => {
       }).toThrowError();
     });
   });
-  it("logs warning when event type is required and missing", () => {
-    const options = { xdm: { test: "" } };
-    const logger = {
-      warn: jasmine.createSpy()
-    };
-    validateUserEventOptions({ options, logger });
-    expect(logger.warn).toHaveBeenCalledWith(
-      "No type or xdm.eventType specified."
-    );
-  });
-  it("does not throw errors when event options are valid", () => {
-    [
-      {},
-      { xdm: { eventType: "test" } },
-      { type: "test", xdm: { test: "" } },
-      { renderDecisions: true },
-      { data: { test: "" } },
-      { renderDecisions: true, data: { test: "" } },
-      { decisionScopes: ["test"] },
-      { datasetId: "12432ewfr12" },
-      {
-        xdm: {
-          eventType: "test",
-          identityMap: {
-            namespace1: [
-              { id: "123", primary: true, authenticatedState: "authenticated" },
-              { id: "3" }
-            ],
-            namespace2: [{ id: "23", authenticatedState: "ambiguous" }]
-          }
-        }
-      }
-    ].forEach(options => {
-      expect(() => {
-        validateUserEventOptions({ options });
-      }).not.toThrowError();
-    });
-  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The [JIRA ticket](https://jira.corp.adobe.com/browse/PDCL-1333) states that customers are getting confused by the warning when sending an event without an `eventType`. According to Daniel Vivas, event types are always optional and currently only used by Platform. Therefore, I think that there isn't any harm in just removing the logic that warns the user when there isn't an `eventType`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[PDCL-1333](https://jira.corp.adobe.com/browse/PDCL-1333)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
