### PR TITLE
PDCL-1310 - move SRC out of tagName constants file

### DIFF
--- a/src/components/Personalization/dom-actions/addNonceToInlineStyleElements.js
+++ b/src/components/Personalization/dom-actions/addNonceToInlineStyleElements.js
@@ -11,7 +11,8 @@ governing permissions and limitations under the License.
 */
 
 import { selectNodes } from "../../../utils/dom";
-import { SRC, STYLE } from "../../../constants/tagName";
+import { STYLE } from "../../../constants/tagName";
+import { SRC } from "../../../constants/elementAttribute";
 import { getAttribute, getNonce } from "./dom";
 
 const is = (element, tagName) => element.tagName === tagName;

--- a/src/components/Personalization/dom-actions/images.js
+++ b/src/components/Personalization/dom-actions/images.js
@@ -11,7 +11,8 @@ governing permissions and limitations under the License.
 */
 
 import { createNode, selectNodes } from "../../../utils/dom";
-import { IMG, SRC } from "../../../constants/tagName";
+import { IMG } from "../../../constants/tagName";
+import { SRC } from "../../../constants/elementAttribute";
 import { getAttribute } from "./dom";
 
 export const isImage = element => element.tagName === IMG;

--- a/src/components/Personalization/dom-actions/scripts.js
+++ b/src/components/Personalization/dom-actions/scripts.js
@@ -12,7 +12,8 @@ governing permissions and limitations under the License.
 
 import loadScript from "@adobe/reactor-load-script";
 import { selectNodes, createNode } from "../../../utils/dom";
-import { SRC, SCRIPT } from "../../../constants/tagName";
+import { SCRIPT } from "../../../constants/tagName";
+import { SRC } from "../../../constants/elementAttribute";
 import { getAttribute, getNonce } from "./dom";
 
 export const is = (element, tagName) =>

--- a/src/constants/elementAttribute.js
+++ b/src/constants/elementAttribute.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Adobe. All rights reserved.
+Copyright 2022 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,21 +10,4 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { SRC } from "../../../constants/elementAttribute";
-import { setAttribute, removeAttribute } from "./dom";
-import { isImage, loadImage } from "./images";
-
-export default (container, url) => {
-  if (!isImage(container)) {
-    return;
-  }
-
-  // Start downloading the image
-  loadImage(url);
-
-  // Remove "src" so there is no flicker
-  removeAttribute(container, SRC);
-
-  // Replace the image "src"
-  setAttribute(container, SRC, url);
-};
+export const SRC = "src";

--- a/src/constants/tagName.js
+++ b/src/constants/tagName.js
@@ -16,5 +16,4 @@ export const IMG = "IMG";
 export const DIV = "DIV";
 export const STYLE = "STYLE";
 export const SCRIPT = "SCRIPT";
-export const SRC = "src";
 export const HEAD = "HEAD";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

I have move the constant `SRC` out of [`src/constants/tagName.js`](https://github.com/adobe/alloy/blob/main/src/constants/tagName.js) and into a new file called `src/constants/elementAttribute.js`, as Jon suggested in the Jira ticket. References have also been updated.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[PDCL-1310 on Jira](https://jira.corp.adobe.com/browse/PDCL-1310)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
