### PR TITLE
Fix broken documentation links in code

### DIFF
--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -16,7 +16,7 @@ const createDataCollector = ({ eventManager }) => {
   return {
     commands: {
       sendEvent: {
-        documentationUri: "https://adobe.ly/2r0uUjh",
+        documentationUri: "https://adobe.ly/3GQ3Q7t",
         optionsValidator: options => {
           return validateUserEventOptions({ options });
         },

--- a/src/core/buildAndValidateConfig.js
+++ b/src/core/buildAndValidateConfig.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 import { assign } from "../utils";
 import { objectOf } from "../utils/validation";
 
-const CONFIG_DOC_URI = "https://adobe.ly/2M4ErNE";
+const CONFIG_DOC_URI = "https://adobe.ly/3sHh553";
 
 const buildSchema = (coreConfigValidators, componentCreators) => {
   const schema = {};

--- a/src/core/validateCommandOptions.js
+++ b/src/core/validateCommandOptions.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const COMMAND_DOC_URI = "https://adobe.ly/2UH0qO7";
+const COMMAND_DOC_URI = "https://adobe.ly/3sHgQHb";
 
 export default ({ command, options }) => {
   const {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
I fixed 3 broken documentation links.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#808 first made us aware of the issue.

#813 fixes the issue in the README, this fixes a few of the issues throughout the code, in error messages and comments.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

https://developer.adobe.com/apis/experience-platform was deprecated, which all our short links pointed to. The new home for Alloy user documentation is now at https://experienceleague.adobe.com/docs/experience-platform/edge/

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
