### PR TITLE
PDCL-6476 - Include propositions on every request response

### DIFF
--- a/src/components/Personalization/createComponent.js
+++ b/src/components/Personalization/createComponent.js
@@ -32,6 +32,7 @@ export default ({
         onResponse = noop,
         onRequestFailure = noop
       }) {
+        // Include proositions on all responses, overridden with data as needed
         onResponse(() => ({ propositions: [] }));
 
         if (isAuthoringModeEnabled()) {

--- a/src/components/Personalization/createComponent.js
+++ b/src/components/Personalization/createComponent.js
@@ -72,6 +72,11 @@ export default ({
       },
       onClick({ event, clickedElement }) {
         onClickHandler({ event, clickedElement });
+      },
+      onResponse({ response }) {
+        const content = response.toJSON();
+        content.propositions = content.propositions || [];
+        return content;
       }
     }
   };

--- a/src/components/Personalization/createComponent.js
+++ b/src/components/Personalization/createComponent.js
@@ -32,6 +32,8 @@ export default ({
         onResponse = noop,
         onRequestFailure = noop
       }) {
+        onResponse(() => ({ propositions: [] }));
+
         if (isAuthoringModeEnabled()) {
           logger.warn(AUTHORING_ENABLED);
 
@@ -68,10 +70,7 @@ export default ({
             onResponse,
             onRequestFailure
           });
-          return;
         }
-
-        onResponse(() => ({ propositions: [] }));
       },
       onClick({ event, clickedElement }) {
         onClickHandler({ event, clickedElement });

--- a/src/components/Personalization/createComponent.js
+++ b/src/components/Personalization/createComponent.js
@@ -68,15 +68,13 @@ export default ({
             onResponse,
             onRequestFailure
           });
+          return;
         }
+
+        onResponse(() => ({ propositions: [] }));
       },
       onClick({ event, clickedElement }) {
         onClickHandler({ event, clickedElement });
-      },
-      onResponse({ response }) {
-        const content = response.toJSON();
-        content.propositions = content.propositions || [];
-        return content;
       }
     }
   };

--- a/test/functional/specs/Data Collector/C455258.js
+++ b/test/functional/specs/Data Collector/C455258.js
@@ -1,3 +1,4 @@
+import { t } from "testcafe";
 import createFixture from "../../helpers/createFixture";
 import { orgMainConfigMain } from "../../helpers/constants/configParts";
 import createAlloyProxy from "../../helpers/createAlloyProxy";
@@ -21,18 +22,30 @@ test("Test C455258: sendEvent command sends a request to the collect endpoint wh
 
   // An identity has not yet been established. This request should go to the
   // interact endpoint.
-  await alloy.sendEvent({ documentUnloading: true });
+  let response = await alloy.sendEvent({ documentUnloading: true });
   await collectEndpointAsserter.assertInteractCalledAndNotCollect();
+  await t
+    .expect("propositions" in response)
+    .ok("The 'sendEvent()' response was missing the 'propositions' property");
+  response = null;
   await collectEndpointAsserter.reset();
 
   // An identity has been established. This request should go to the
   // collect endpoint.
-  await alloy.sendEvent({ documentUnloading: true });
+  response = await alloy.sendEvent({ documentUnloading: true });
   await collectEndpointAsserter.assertCollectCalledAndNotInteract();
+  await t
+    .expect("propositions" in response)
+    .ok("The 'sendEvent()' response was missing the 'propositions' property");
+  response = null;
   await collectEndpointAsserter.reset();
 
   // documentUnloading is not set to true. The request should go to the
   // interact endpoint.
-  await alloy.sendEvent();
+  response = await alloy.sendEvent();
   await collectEndpointAsserter.assertInteractCalledAndNotCollect();
+  await t
+    .expect("propositions" in response)
+    .ok("The 'sendEvent()' response was missing the 'propositions' property");
+  response = null;
 });

--- a/test/functional/specs/Data Collector/C455258.js
+++ b/test/functional/specs/Data Collector/C455258.js
@@ -1,4 +1,3 @@
-import { t } from "testcafe";
 import createFixture from "../../helpers/createFixture";
 import { orgMainConfigMain } from "../../helpers/constants/configParts";
 import createAlloyProxy from "../../helpers/createAlloyProxy";
@@ -22,30 +21,18 @@ test("Test C455258: sendEvent command sends a request to the collect endpoint wh
 
   // An identity has not yet been established. This request should go to the
   // interact endpoint.
-  let response = await alloy.sendEvent({ documentUnloading: true });
+  await alloy.sendEvent({ documentUnloading: true });
   await collectEndpointAsserter.assertInteractCalledAndNotCollect();
-  await t
-    .expect("propositions" in response)
-    .ok("The 'sendEvent()' response was missing the 'propositions' property");
-  response = null;
   await collectEndpointAsserter.reset();
 
   // An identity has been established. This request should go to the
   // collect endpoint.
-  response = await alloy.sendEvent({ documentUnloading: true });
+  await alloy.sendEvent({ documentUnloading: true });
   await collectEndpointAsserter.assertCollectCalledAndNotInteract();
-  await t
-    .expect("propositions" in response)
-    .ok("The 'sendEvent()' response was missing the 'propositions' property");
-  response = null;
   await collectEndpointAsserter.reset();
 
   // documentUnloading is not set to true. The request should go to the
   // interact endpoint.
-  response = await alloy.sendEvent();
+  await alloy.sendEvent();
   await collectEndpointAsserter.assertInteractCalledAndNotCollect();
-  await t
-    .expect("propositions" in response)
-    .ok("The 'sendEvent()' response was missing the 'propositions' property");
-  response = null;
 });

--- a/test/functional/specs/Personalization/C5298194.js
+++ b/test/functional/specs/Personalization/C5298194.js
@@ -3,6 +3,7 @@ import createFixture from "../../helpers/createFixture";
 import { orgMainConfigMain } from "../../helpers/constants/configParts";
 import createAlloyProxy from "../../helpers/createAlloyProxy";
 import createCollectEndpointAsserter from "../../helpers/createCollectEndpointAsserter";
+import { TEST_PAGE as TEST_PAGE_URL } from "../../helpers/constants/url";
 
 createFixture({
   title: "C5298194: Include propositions on every request"
@@ -19,19 +20,60 @@ test("Test C5298194: Include propositions on every request", async () => {
   const alloy = createAlloyProxy();
   await alloy.configure(orgMainConfigMain);
 
+  // check that interact calls return propositions.
   let response = await alloy.sendEvent();
   await collectEndpointAsserter.assertInteractCalledAndNotCollect();
   await t
     .expect("propositions" in response)
     .ok("The 'sendEvent()' response was missing the 'propositions' property");
+  await t
+    .expect(Array.isArray(response.propositions))
+    .ok("response.propositions is not an array");
   response = null;
   await collectEndpointAsserter.reset();
 
+  // check that collect calls return propositions.
   response = await alloy.sendEvent({ documentUnloading: true });
   await collectEndpointAsserter.assertCollectCalledAndNotInteract();
   await t
     .expect("propositions" in response)
     .ok("The 'sendEvent()' response was missing the 'propositions' property");
+  await t
+    .expect(Array.isArray(response.propositions))
+    .ok("response.propositions is not an array");
   response = null;
   await collectEndpointAsserter.reset();
 });
+
+test.page(`${TEST_PAGE_URL}?adobe_authoring_enabled=true`)(
+  "Test C5298194: Include propositions on every request in authoring mode",
+  async () => {
+    const collectEndpointAsserter = await createCollectEndpointAsserter();
+    const alloy = createAlloyProxy();
+    await alloy.configure(orgMainConfigMain);
+
+    // check that interact calls return propositions.
+    let response = await alloy.sendEvent();
+    await collectEndpointAsserter.assertInteractCalledAndNotCollect();
+    await t
+      .expect("propositions" in response)
+      .ok("The 'sendEvent()' response was missing the 'propositions' property");
+    await t
+      .expect(Array.isArray(response.propositions))
+      .ok("response.propositions is not an array");
+    response = null;
+    await collectEndpointAsserter.reset();
+
+    // check that collect calls return propositions.
+    response = await alloy.sendEvent({ documentUnloading: true });
+    await collectEndpointAsserter.assertCollectCalledAndNotInteract();
+    await t
+      .expect("propositions" in response)
+      .ok("The 'sendEvent()' response was missing the 'propositions' property");
+    await t
+      .expect(Array.isArray(response.propositions))
+      .ok("response.propositions is not an array");
+    response = null;
+    await collectEndpointAsserter.reset();
+  }
+);

--- a/test/functional/specs/Personalization/C5298194.js
+++ b/test/functional/specs/Personalization/C5298194.js
@@ -15,7 +15,7 @@ test.meta({
   TEST_RUN: "Regression"
 });
 
-test("Test C5298194: Include propositions on every request", async () => {
+const runTest = async () => {
   const collectEndpointAsserter = await createCollectEndpointAsserter();
   const alloy = createAlloyProxy();
   await alloy.configure(orgMainConfigMain);
@@ -43,37 +43,11 @@ test("Test C5298194: Include propositions on every request", async () => {
     .ok("response.propositions is not an array");
   response = null;
   await collectEndpointAsserter.reset();
-});
+};
+
+test("Test C5298194: Include propositions on every request", runTest);
 
 test.page(`${TEST_PAGE_URL}?adobe_authoring_enabled=true`)(
   "Test C5298194: Include propositions on every request in authoring mode",
-  async () => {
-    const collectEndpointAsserter = await createCollectEndpointAsserter();
-    const alloy = createAlloyProxy();
-    await alloy.configure(orgMainConfigMain);
-
-    // check that interact calls return propositions.
-    let response = await alloy.sendEvent();
-    await collectEndpointAsserter.assertInteractCalledAndNotCollect();
-    await t
-      .expect("propositions" in response)
-      .ok("The 'sendEvent()' response was missing the 'propositions' property");
-    await t
-      .expect(Array.isArray(response.propositions))
-      .ok("response.propositions is not an array");
-    response = null;
-    await collectEndpointAsserter.reset();
-
-    // check that collect calls return propositions.
-    response = await alloy.sendEvent({ documentUnloading: true });
-    await collectEndpointAsserter.assertCollectCalledAndNotInteract();
-    await t
-      .expect("propositions" in response)
-      .ok("The 'sendEvent()' response was missing the 'propositions' property");
-    await t
-      .expect(Array.isArray(response.propositions))
-      .ok("response.propositions is not an array");
-    response = null;
-    await collectEndpointAsserter.reset();
-  }
+  runTest
 );

--- a/test/functional/specs/Personalization/C5298194.js
+++ b/test/functional/specs/Personalization/C5298194.js
@@ -19,7 +19,7 @@ test("Test C5298194: Include propositions on every request", async () => {
   const alloy = createAlloyProxy();
   await alloy.configure(orgMainConfigMain);
 
-  let response = await alloy.sendEvent({ documentUnloading: true });
+  let response = await alloy.sendEvent();
   await collectEndpointAsserter.assertInteractCalledAndNotCollect();
   await t
     .expect("propositions" in response)
@@ -27,10 +27,11 @@ test("Test C5298194: Include propositions on every request", async () => {
   response = null;
   await collectEndpointAsserter.reset();
 
-  response = await alloy.sendEvent();
-  await collectEndpointAsserter.assertInteractCalledAndNotCollect();
+  response = await alloy.sendEvent({ documentUnloading: true });
+  await collectEndpointAsserter.assertCollectCalledAndNotInteract();
   await t
     .expect("propositions" in response)
     .ok("The 'sendEvent()' response was missing the 'propositions' property");
   response = null;
+  await collectEndpointAsserter.reset();
 });

--- a/test/functional/specs/Personalization/C5298194.js
+++ b/test/functional/specs/Personalization/C5298194.js
@@ -1,0 +1,36 @@
+import { t } from "testcafe";
+import createFixture from "../../helpers/createFixture";
+import { orgMainConfigMain } from "../../helpers/constants/configParts";
+import createAlloyProxy from "../../helpers/createAlloyProxy";
+import createCollectEndpointAsserter from "../../helpers/createCollectEndpointAsserter";
+
+createFixture({
+  title: "C5298194: Include propositions on every request"
+});
+
+test.meta({
+  ID: "C5298194",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+
+test("Test C5298194: Include propositions on every request", async () => {
+  const collectEndpointAsserter = await createCollectEndpointAsserter();
+  const alloy = createAlloyProxy();
+  await alloy.configure(orgMainConfigMain);
+
+  let response = await alloy.sendEvent({ documentUnloading: true });
+  await collectEndpointAsserter.assertInteractCalledAndNotCollect();
+  await t
+    .expect("propositions" in response)
+    .ok("The 'sendEvent()' response was missing the 'propositions' property");
+  response = null;
+  await collectEndpointAsserter.reset();
+
+  response = await alloy.sendEvent();
+  await collectEndpointAsserter.assertInteractCalledAndNotCollect();
+  await t
+    .expect("propositions" in response)
+    .ok("The 'sendEvent()' response was missing the 'propositions' property");
+  response = null;
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

With this change, Personalization includes a lifecycle method for `onResponse` that provides `propositions: []` if none existed before.

The test to verify this fix is found in the functional test [`C5298194.js`](https://github.com/adobe/alloy/blob/ba7ea6a31e0a6e6ef4a0e1f2906450af919af1e2/test/functional/specs/Personalization/C5298194.js), where I have added some assertions. This test can be run with the following command:

```
npm run test:functional -- "--test-grep C5298194"
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[PDCL-6476: Resolved send event promise does not include propositions key on collect calls](https://jira.corp.adobe.com/browse/PDCL-6476)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

From [the Jira ticket](https://jira.corp.adobe.com/browse/PDCL-6476)

> Currently, an object with decisions and propositions are resolved in the sendEvent promise. However, when send event chooses to use "collect" instead of "interact", those keys are not returned. A customer building a javascript handler to do something with these objects would need to check if the key was defined before iterating on the array.
> 
> We should include "propositions: []" as part of the response when collect is used. I don't think we need to include decisions as that is a deprecated api now.
> 
> This also happens when consent is declined, and the previous send event calls are resolved.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
