### PR TITLE
PDCL-7878 - fix clicks for spa view

### DIFF
--- a/src/components/Personalization/createOnClickHandler.js
+++ b/src/components/Personalization/createOnClickHandler.js
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 
 import { isNonEmptyArray } from "../../utils";
 import { INTERACT } from "./constants/eventType";
+import PAGE_WIDE_SCOPE from "./constants/scope";
 
 export default ({
   mergeDecisionsMeta,
@@ -30,7 +31,18 @@ export default ({
       );
 
       if (isNonEmptyArray(decisionsMeta)) {
-        event.mergeXdm({ eventType: INTERACT });
+        const xdm = { eventType: INTERACT };
+        const scope = decisionsMeta[0].scope;
+
+        if (scope !== PAGE_WIDE_SCOPE) {
+          xdm.web = {
+            webPageDetails: {
+              viewName: scope
+            }
+          };
+        }
+
+        event.mergeXdm(xdm);
         mergeDecisionsMeta(event, decisionsMeta);
       }
     }

--- a/test/unit/specs/components/Personalization/createOnClickHandler.spec.js
+++ b/test/unit/specs/components/Personalization/createOnClickHandler.spec.js
@@ -53,7 +53,10 @@ describe("Personalization::createOnClickHandler", () => {
     handleOnClick({ event, clickedElement });
 
     expect(event.mergeXdm).toHaveBeenCalledWith({
-      eventType: "decisioning.propositionInteract"
+      eventType: "decisioning.propositionInteract",
+      web: {
+        webPageDetails: { viewName: "foo" }
+      }
     });
     expect(mergeDecisionsMeta).toHaveBeenCalledWith(event, decisionsMeta);
     expect(collectClicks).toHaveBeenCalledWith(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Quick fix for the autorenderable click metrics for SPA. We will be adding the `viewName` to the `INTERACT` notification call so that the conversions are properly handled. 
Autorenderable click metrics are either for `__view__` scope or an SPA view.



## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
