### PR TITLE
Fixed an issue where merged metrics propositions were duplicated in the sendEvent result

### DIFF
--- a/src/components/Personalization/constants/schema.js
+++ b/src/components/Personalization/constants/schema.js
@@ -19,3 +19,5 @@ export const JSON_CONTENT_ITEM =
   "https://ns.adobe.com/personalization/json-content-item";
 export const REDIRECT_ITEM =
   "https://ns.adobe.com/personalization/redirect-item";
+export const MEASUREMENT_SCHEMA =
+  "https://ns.adobe.com/personalization/measurement";

--- a/test/functional/specs/Personalization/C5805675.js
+++ b/test/functional/specs/Personalization/C5805675.js
@@ -16,13 +16,13 @@ const networkLogger = createNetworkLogger();
 const config = compose(orgMainConfigMain, debugEnabled);
 const PAGE_WIDE_SCOPE = "__view__";
 createFixture({
-  title: "C28761: Default content offers should be delivered",
-  url: `${TEST_PAGE_URL}?test=C28761`,
+  title: "C5805675: Default content offers should be delivered",
+  url: `${TEST_PAGE_URL}?test=C5805675`,
   requestHooks: [networkLogger.edgeEndpointLogs]
 });
 
 test.meta({
-  ID: "C28761",
+  ID: "C5805675",
   SEVERITY: "P0",
   TEST_RUN: "Regression"
 });
@@ -34,7 +34,7 @@ const extractDecisionsMeta = payload => {
   });
 };
 
-test("Test C28761: Default content offers should be delivered", async () => {
+test("Test C5805675: Default content offers should be delivered", async () => {
   const alloy = createAlloyProxy();
   await alloy.configure(config);
   const eventResult = await alloy.sendEvent({ renderDecisions: true });
@@ -80,7 +80,7 @@ test("Test C28761: Default content offers should be delivered", async () => {
     .eql("https://ns.adobe.com/personalization/default-content-item");
   await t
     .expect(defaultContentItem.meta["activity.name"])
-    .eql("Functional: C28761 AB");
+    .eql("Functional: C5805675 AB");
   await t.expect(defaultContentItem.meta["offer.name"]).eql("Default Content");
   await t.expect(defaultContentItem.data).eql(undefined);
 

--- a/test/functional/specs/Personalization/C5805676.js
+++ b/test/functional/specs/Personalization/C5805676.js
@@ -1,0 +1,107 @@
+import { t } from "testcafe";
+import createNetworkLogger from "../../helpers/networkLogger";
+import { responseStatus } from "../../helpers/assertions/index";
+import createFixture from "../../helpers/createFixture";
+import {
+  compose,
+  orgMainConfigMain,
+  debugEnabled
+} from "../../helpers/constants/configParts";
+import getResponseBody from "../../helpers/networkLogger/getResponseBody";
+import createResponse from "../../helpers/createResponse";
+import { TEST_PAGE as TEST_PAGE_URL } from "../../helpers/constants/url";
+import createAlloyProxy from "../../helpers/createAlloyProxy";
+
+const networkLogger = createNetworkLogger();
+const config = compose(orgMainConfigMain, debugEnabled);
+const PAGE_WIDE_SCOPE = "__view__";
+const FORM_BASED_SCOPE = "form-based-scope";
+
+const DEFAULT_CONTENT_ITEM = {
+  id: "0",
+  schema: "https://ns.adobe.com/personalization/default-content-item",
+  meta: {
+    "activity.id": "139738",
+    "activity.name": "Functional: C5805676",
+    "experience.id": "0",
+    "offer.id": "0",
+    "offer.name": "Default Content"
+  }
+};
+
+const MEASUREMENT_ITEM = {
+  id: "139738",
+  schema: "https://ns.adobe.com/personalization/measurement",
+  data: {
+    format: "application/vnd.adobe.target.metric",
+    type: "click"
+  }
+};
+
+createFixture({
+  title: "C5805676: Merged metric propositions should be delivered",
+  url: `${TEST_PAGE_URL}?test=C5805676`,
+  requestHooks: [networkLogger.edgeEndpointLogs]
+});
+
+test.meta({
+  ID: "C5805676",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+
+test("Test C5805676: Merged metric propositions should be delivered", async () => {
+  const alloy = createAlloyProxy();
+  await alloy.configure(config);
+  const eventResult = await alloy.sendEvent({
+    decisionScopes: [FORM_BASED_SCOPE]
+  });
+
+  await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
+
+  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
+
+  const sendEventRequest = networkLogger.edgeEndpointLogs.requests[0];
+  const requestBody = JSON.parse(sendEventRequest.request.body);
+  const personalizationSchemas =
+    requestBody.events[0].query.personalization.schemas;
+
+  await t
+    .expect(requestBody.events[0].query.personalization.decisionScopes)
+    .eql([FORM_BASED_SCOPE, PAGE_WIDE_SCOPE]);
+
+  const result = [
+    "https://ns.adobe.com/personalization/default-content-item",
+    "https://ns.adobe.com/personalization/dom-action",
+    "https://ns.adobe.com/personalization/html-content-item",
+    "https://ns.adobe.com/personalization/json-content-item",
+    "https://ns.adobe.com/personalization/redirect-item"
+  ].every(schema => personalizationSchemas.includes(schema));
+
+  await t.expect(result).eql(true);
+
+  const response = JSON.parse(
+    getResponseBody(networkLogger.edgeEndpointLogs.requests[0])
+  );
+  const personalizationPayload = createResponse({
+    content: response
+  }).getPayloadsByType("personalization:decisions");
+
+  await t.expect(personalizationPayload[0].scope).eql(FORM_BASED_SCOPE);
+  await t.expect(personalizationPayload[0].items.length).eql(2);
+
+  await t.expect(personalizationPayload[0].items[0]).eql(DEFAULT_CONTENT_ITEM);
+  await t.expect(personalizationPayload[0].items[1]).eql(MEASUREMENT_ITEM);
+
+  const formBasedScopePropositions = eventResult.propositions.filter(
+    proposition => proposition.scope === FORM_BASED_SCOPE
+  );
+
+  await t.expect(formBasedScopePropositions.length).eql(1);
+  await t.expect(formBasedScopePropositions[0].items.length).eql(2);
+  await t.expect(formBasedScopePropositions[0].renderAttempted).eql(false);
+  await t
+    .expect(formBasedScopePropositions[0].items[0])
+    .eql(DEFAULT_CONTENT_ITEM);
+  await t.expect(formBasedScopePropositions[0].items[1]).eql(MEASUREMENT_ITEM);
+});

--- a/test/unit/specs/components/Personalization/groupDecisions.spec.js
+++ b/test/unit/specs/components/Personalization/groupDecisions.spec.js
@@ -16,12 +16,14 @@ import {
   PAGE_WIDE_SCOPE_DECISIONS_WITHOUT_DOM_ACTION_SCHEMA_ITEMS,
   CART_VIEW_DECISIONS,
   REDIRECT_PAGE_WIDE_SCOPE_DECISION,
-  PRODUCTS_VIEW_DECISIONS
+  PRODUCTS_VIEW_DECISIONS,
+  MERGED_METRIC_DECISIONS
 } from "./responsesMock/eventResponses";
 import groupDecisions from "../../../../../src/components/Personalization/groupDecisions";
 
 let cartDecisions;
 let productDecisions;
+let mergedDecisions;
 
 beforeEach(() => {
   cartDecisions = PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS.concat(
@@ -30,6 +32,7 @@ beforeEach(() => {
   productDecisions = PAGE_WIDE_SCOPE_DECISIONS.concat(
     REDIRECT_PAGE_WIDE_SCOPE_DECISION
   ).concat(PRODUCTS_VIEW_DECISIONS);
+  mergedDecisions = productDecisions.concat(MERGED_METRIC_DECISIONS);
 });
 describe("Personalization::groupDecisions", () => {
   it("extracts decisions by scope", () => {
@@ -68,6 +71,30 @@ describe("Personalization::groupDecisions", () => {
     expect(redirectDecisions).toEqual(REDIRECT_PAGE_WIDE_SCOPE_DECISION);
     expect(viewDecisions).toEqual(expectedViewDecisions);
   });
+
+  it("extracts merged decisions", () => {
+    const expectedViewDecisions = {
+      products: PRODUCTS_VIEW_DECISIONS
+    };
+    const {
+      redirectDecisions,
+      pageWideScopeDecisions,
+      viewDecisions,
+      nonAutoRenderableDecisions
+    } = groupDecisions(mergedDecisions);
+
+    expect(nonAutoRenderableDecisions).toEqual(
+      MERGED_METRIC_DECISIONS.concat(
+        PAGE_WIDE_SCOPE_DECISIONS_WITHOUT_DOM_ACTION_SCHEMA_ITEMS
+      )
+    );
+    expect(pageWideScopeDecisions).toEqual(
+      PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS
+    );
+    expect(redirectDecisions).toEqual(REDIRECT_PAGE_WIDE_SCOPE_DECISION);
+    expect(viewDecisions).toEqual(expectedViewDecisions);
+  });
+
   it("extracts empty when no decisions", () => {
     const decisions = [];
 

--- a/test/unit/specs/components/Personalization/responsesMock/eventResponses.js
+++ b/test/unit/specs/components/Personalization/responsesMock/eventResponses.js
@@ -228,3 +228,36 @@ export const REDIRECT_PAGE_WIDE_SCOPE_DECISION = [
     ]
   }
 ];
+export const MERGED_METRIC_DECISIONS = [
+  {
+    id: "TNT:activity6:experience1",
+    scope: "testScope",
+    scopeDetails: {
+      eventTokens: {
+        display: "displayToken1",
+        click: "clickToken1"
+      }
+    },
+    items: [
+      {
+        id: "0",
+        schema: "https://ns.adobe.com/personalization/html-content-item",
+        data: {
+          id: "0",
+          format: "text/html",
+          content: "testScope content1"
+        }
+      },
+      {
+        schema: "https://ns.adobe.com/personalization/default-content-item"
+      },
+      {
+        schema: "https://ns.adobe.com/personalization/measurement",
+        data: {
+          type: "click",
+          format: "application/vnd.adobe.target.metric"
+        }
+      }
+    ]
+  }
+];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

[TNT-43892](https://jira.corp.adobe.com/browse/TNT-43892) Fix Propositions with merged metrics being duplicated in sendEvent result

## Related Issue

[TNT-43892](https://jira.corp.adobe.com/browse/TNT-43892)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
