### PR TITLE
Add the personalization-container class name to test hiding containers

### DIFF
--- a/sandbox/src/Personalization.js
+++ b/sandbox/src/Personalization.js
@@ -14,7 +14,10 @@ export default function Personalization() {
         to refresh your browser because this is how to properly simulate a
         non-SPA workflow.
       </p>
-      <div style={{ border: "1px solid red" }} id="personalization-container">
+      <div
+        style={{ border: "1px solid red" }}
+        className="personalization-container"
+      >
         This is the personalization placeholder. Personalized content has not
         been loaded.
       </div>

--- a/sandbox/src/PersonalizationAnalyticsClientSide.js
+++ b/sandbox/src/PersonalizationAnalyticsClientSide.js
@@ -57,7 +57,10 @@ export default function PersonalizationAnalyticsClientSide() {
         refresh your browser because this is how to properly simulate a non-SPA
         workflow.
       </p>
-      <div style={{ border: "1px solid red" }} id="personalization-container">
+      <div
+        style={{ border: "1px solid red" }}
+        className="personalization-container"
+      >
         This is the personalization placeholder. Personalized content has not
         been loaded.
       </div>

--- a/sandbox/src/PersonalizationSpa.js
+++ b/sandbox/src/PersonalizationSpa.js
@@ -11,6 +11,7 @@ const Products = () => {
       <div
         style={{ border: "1px solid red" }}
         id="personalization-products-container"
+        className="personalization-container"
       >
         This is the personalization placeholder for the products view.
         Personalized content has not been loaded.
@@ -27,6 +28,7 @@ const Cart = () => {
       <div
         style={{ border: "1px solid red" }}
         id="personalization-cart-container"
+        className="personalization-container"
       >
         This is the personalization placeholder for the cart view. Personalized
         content has not been loaded.
@@ -42,6 +44,7 @@ const Promotion = () => {
       <div
         style={{ border: "1px solid red" }}
         id="personalization-cart-container"
+        className="personalization-container"
       >
         This is the personalization placeholder for the promotion view. We use
         this view to test the use case when nothing was stored in cache.


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

During testing we found that the prehiding snippet wasn't doing anything because it was hiding by class, but the container was defined with an id. Also in the SPA files, the class wasn't there at all.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
