### PR TITLE
Make Github's release notes more useful

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,7 @@
-<!--- Provide a general summary of your changes in the Title above -->
+<!--- The title above will be used as a bullet point in the release notes. -->
+<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
+<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
+<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->
 
 ## Description
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,8 @@
+# This config is used to control automatically generated release notes
+# see https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot

--- a/.github/workflows/deployRelease.yml
+++ b/.github/workflows/deployRelease.yml
@@ -96,5 +96,3 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ github.event.inputs.version }}
-          referencePrefixes: "PDCL-,CORE-,AN-"
-          referenceTargetUrlPrefix: "https://jira.corp.adobe.com/browse/"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Github will auto generate release notes based on merged PRs. This PR updates the PR template to encourage people to write the release notes bullet as the title of the PR. When Github auto generates the release notes it uses the title of the PR as the bullet point.

I also removed the properties on the release.yml that are no longer used. See https://github.com/adobe/project-card-release-automation/pull/55

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
