### PR TITLE
[PDCL-7369] - Tests updates to support opt-back-in functionality

### DIFF
--- a/test/functional/specs/Privacy/C14404.js
+++ b/test/functional/specs/Privacy/C14404.js
@@ -20,7 +20,10 @@ const networkLogger = createNetworkLogger();
 createFixture({
   title:
     "C14404: User cannot consent to all purposes after consenting to no purposes",
-  requestHooks: [networkLogger.edgeEndpointLogs]
+  requestHooks: [
+    networkLogger.edgeEndpointLogs,
+    networkLogger.setConsentEndpointLogs
+  ]
 });
 
 test.meta({

--- a/test/functional/specs/Privacy/C14404.js
+++ b/test/functional/specs/Privacy/C14404.js
@@ -1,3 +1,4 @@
+import { t } from "testcafe";
 import createFixture from "../../helpers/createFixture";
 import createNetworkLogger from "../../helpers/networkLogger";
 
@@ -7,9 +8,10 @@ import {
   consentPending,
   debugEnabled
 } from "../../helpers/constants/configParts";
-import createConsoleLogger from "../../helpers/consoleLogger";
 import createAlloyProxy from "../../helpers/createAlloyProxy";
 import { CONSENT_OUT, CONSENT_IN } from "../../helpers/constants/consent";
+import cookies from "../../helpers/cookies";
+import { MAIN_CONSENT_COOKIE_NAME } from "../../helpers/constants/cookies";
 
 const config = compose(orgMainConfigMain, consentPending, debugEnabled);
 
@@ -27,21 +29,22 @@ test.meta({
   TEST_RUN: "Regression"
 });
 
-test("Test C14404: User cannot consent to all purposes after consenting to no purposes", async t => {
+test("Test C14404: User can consent to all purposes after consenting to no purposes", async () => {
   const alloy = createAlloyProxy();
   await alloy.configure(config);
   await alloy.setConsent(CONSENT_OUT);
-  const setConsentErrorMessage = await alloy.setConsentErrorMessage(CONSENT_IN);
 
-  await t
-    .expect(setConsentErrorMessage)
-    .ok("Expected the setConsent command to be rejected");
-  await t.expect(setConsentErrorMessage).contains("EXEG-0302-409");
+  // set consent back to in for the same user
+  await alloy.setConsent(CONSENT_IN);
 
-  // make sure the instance still has no consent
-  const logger = await createConsoleLogger();
+  await t.expect(networkLogger.setConsentEndpointLogs.requests.length).eql(2);
+
+  const consentCookieValue = await cookies.get(MAIN_CONSENT_COOKIE_NAME);
+
+  await t.expect(consentCookieValue).ok("No consent cookie found.");
+  await t.expect(consentCookieValue).eql("general=in");
+
+  // make sure event goes out
   await alloy.sendEvent();
-  await logger.warn.expectMessageMatching(/user declined consent/);
-  // make sure no event requests went out
-  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(0);
+  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
 });

--- a/test/functional/specs/Privacy/C14411.js
+++ b/test/functional/specs/Privacy/C14411.js
@@ -30,7 +30,7 @@ test("Test C14411: User consents to no purposes after consenting to no purposes 
   await alloy.setConsent(CONSENT_OUT);
 });
 
-test("Test C14411: User consents to no purposes after consenting to no purposes without cache", async t => {
+test("Test C14411: User consents to no purposes after consenting to no purposes without cache", async () => {
   const alloy = createAlloyProxy();
   await alloy.configure(config);
   await alloy.setConsent(CONSENT_OUT);
@@ -39,12 +39,6 @@ test("Test C14411: User consents to no purposes after consenting to no purposes 
   await cookies.remove(MAIN_CONSENT_COOKIE_NAME);
 
   await alloy.configure(config);
-  const setConsentErrorMessage = await alloy.setConsentErrorMessage(
-    CONSENT_OUT
-  );
-
-  await t
-    .expect(setConsentErrorMessage)
-    .ok("Expected the setConsent command to be rejected");
-  await t.expect(setConsentErrorMessage).contains("EXEG-0302-409");
+  // make sure this doesn't throw an error
+  await alloy.setConsent(CONSENT_OUT);
 });

--- a/test/functional/specs/Privacy/IAB/C224677.js
+++ b/test/functional/specs/Privacy/IAB/C224677.js
@@ -57,18 +57,18 @@ test("Test C224677: Call setConsent when purpose 10 is FALSE", async () => {
   await t.expect(identityHandle.length).eql(1);
   await t.expect(returnedNamespaces).contains("ECID");
 
-  // 3. Event calls going forward should be opted out because AAM opts out consents with no purpose 10.
+  // 3. Event calls going forward should remain opted in, even though AAM opts out consents with no purpose 10.
   await alloy.sendEvent();
   const rawEventResponse = JSON.parse(
     getResponseBody(networkLogger.edgeEndpointLogs.requests[0])
   );
   const eventResponse = createResponse({ content: rawEventResponse });
 
-  // 4. And a warning message should be returned, confirming the opt-out
+  // 4. No warning message regarding opt-out should be returned anymore
   const warningTypes = eventResponse.getWarnings().map(w => w.type);
   await t
     .expect(warningTypes)
-    .contains("https://ns.adobe.com/aep/errors/EXEG-0301-200");
+    .notContains("https://ns.adobe.com/aep/errors/EXEG-0301-200");
 
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
   await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);


### PR DESCRIPTION
## Description

As a result of Konductor supporting client-side consent enforcement, opt-back-in scenarios will be valid.
There are two Alloy tests asserting that after a user opts out, they cannot opt back in, and such `setConsent` operations will cause `409 Conflict` responses from Konductor.

This PR updates the aforementioned tests, so that they expect the opt-back-in scenarios are finished with success. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
