### PR TITLE
Create nightly Github workflow to check for dead links

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,25 @@
+name: Nightly
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * *" # every day at 1AM
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Dead Link Checker
+        id: lychee
+        uses: lucheeverse/lychee-action@v1.3
+        args: "--no-progress --verbose --include=adobe.ly --include=experienceleague.adobe.com {src,scripts,test}/**/*.{md,js,html} *.{md,js}"
+        format: md
+        fail: true
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Create Issue From File
+        if: ${{ steps.lychee.outputs.exit_code }} != 0
+        uses: peter-evans/create-issue-from-file@v3.0
+        with:
+          title: Dead Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: Documentation, bug


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This creates a Github workflow that runs nightly at 1PM. In this workflow, there is a job that runs a program called [lychee](https://github.com/lycheeverse/lychee) that scans all the code in the html, js and markdown files in the `src`, `test,` `scripts` and base directories for `adobe.ly` and `experienceleague.adobe.com` links. It then makes a small request to each of these links to see if they are still alive.  Essentially, it runs the following command

```bash
lychee --format=md --no-progress --verbose --include=adobe.ly --include=experienceleague.adobe.com {src,scripts,test}/**/*.{md,js,html} *.{md,js}
```

If there are any dead links (4xx or 5xx response codes), it will run the next job in the workflow, which uses the [`create-issue-from-file` library](https://github.com/peter-evans/create-issue-from-file) to create a Github Issue that lists the links so that we may resolve them.

I chose to only look for `adobe.ly` links and `experienceleague.adobe.com` links to avoid the many Adobe internal, license, and example links that we have within our code. 

I expect that the check will run in under 60 seconds.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[PDCL-7744](https://jira.corp.adobe.com/browse/PDCL-7744):

> In February, [a customer noticed that the link on the Alloy README](https://github.com/adobe/alloy/issues/808) was returning a 404. This is because the Alloy documentation moved from Adobe Developer's API documentation to the Experience League without a redirect being set up. While it's not too hard to fix, it would be nice to be able to get ahead of those link breakages before a customer see them. We should create either a single functional test or a suite of them that check the links in our code and documentation to see if they are still alive, in case things move again.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

This will prevent customers stumbling across links that no longer point to the desired location, as happened in #808.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
