### PR TITLE
Add functional test for identity cookie creation failure

### DIFF
--- a/src/components/Identity/index.js
+++ b/src/components/Identity/index.js
@@ -40,7 +40,7 @@ const createIdentity = ({
   consent,
   sendEdgeNetworkRequest
 }) => {
-  const { orgId, thirdPartyCookiesEnabled } = config;
+  const { orgId, thirdPartyCookiesEnabled, edgeDomain } = config;
 
   const getEcidFromVisitor = injectGetEcidFromVisitor({
     logger,
@@ -68,8 +68,9 @@ const createIdentity = ({
     addEcidToPayload
   });
   const awaitIdentityCookie = injectAwaitIdentityCookie({
-    orgId,
-    doesIdentityCookieExist
+    doesIdentityCookieExist,
+    edgeDomain,
+    orgId
   });
   const ensureSingleIdentity = injectEnsureSingleIdentity({
     doesIdentityCookieExist,

--- a/src/components/Identity/index.js
+++ b/src/components/Identity/index.js
@@ -40,7 +40,7 @@ const createIdentity = ({
   consent,
   sendEdgeNetworkRequest
 }) => {
-  const { orgId, thirdPartyCookiesEnabled, edgeDomain } = config;
+  const { orgId, thirdPartyCookiesEnabled } = config;
 
   const getEcidFromVisitor = injectGetEcidFromVisitor({
     logger,
@@ -69,7 +69,6 @@ const createIdentity = ({
   });
   const awaitIdentityCookie = injectAwaitIdentityCookie({
     doesIdentityCookieExist,
-    edgeDomain,
     orgId
   });
   const ensureSingleIdentity = injectEnsureSingleIdentity({

--- a/src/components/Identity/injectAwaitIdentityCookie.js
+++ b/src/components/Identity/injectAwaitIdentityCookie.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export default ({ doesIdentityCookieExist, edgeDomain, orgId }) => {
+export default ({ doesIdentityCookieExist, orgId }) => {
   /**
    * Returns a promise that will be resolved once an identity cookie exists.
    * If an identity cookie doesn't already exist, it should always exist after
@@ -25,7 +25,7 @@ export default ({ doesIdentityCookieExist, edgeDomain, orgId }) => {
           // This logic assumes that the code setting the cookie is working as expected and that
           // the cookie was missing from the response.
           const noIdentityCookieError = new Error(
-            `An identity cookie could not be found. Verify that organization ID "${orgId}" matches the ID in the edge configuration and that cookies from "${edgeDomain}" can be set on the current domain.`
+            `An identity was not set properly. Please verify that the org ID ${orgId} configured in Alloy matches the org ID specified in the edge configuration.`
           );
 
           // Rejecting the promise will reject commands that were queued

--- a/src/components/Identity/injectAwaitIdentityCookie.js
+++ b/src/components/Identity/injectAwaitIdentityCookie.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export default ({ orgId, doesIdentityCookieExist }) => {
+export default ({ doesIdentityCookieExist, edgeDomain, orgId }) => {
   /**
    * Returns a promise that will be resolved once an identity cookie exists.
    * If an identity cookie doesn't already exist, it should always exist after
@@ -25,7 +25,7 @@ export default ({ orgId, doesIdentityCookieExist }) => {
           // This logic assumes that the code setting the cookie is working as expected and that
           // the cookie was missing from the response.
           const noIdentityCookieError = new Error(
-            `An identity was not set properly. Please verify that the org ID ${orgId} configured in Alloy matches the org ID specified in the edge configuration.`
+            `An identity cookie could not be found. Verify that organization ID "${orgId}" matches the ID in the edge configuration and that cookies from "${edgeDomain}" can be set on the current domain.`
           );
 
           // Rejecting the promise will reject commands that were queued

--- a/test/functional/specs/Identity/C5598188.js
+++ b/test/functional/specs/Identity/C5598188.js
@@ -1,0 +1,45 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { t } from "testcafe";
+import {
+  compose,
+  orgMainConfigMain
+} from "../../helpers/constants/configParts";
+import { TEST_PAGE } from "../../helpers/constants/url";
+import createAlloyProxy from "../../helpers/createAlloyProxy";
+import createFixture from "../../helpers/createFixture";
+
+const mainConfig = compose(orgMainConfigMain, {
+  orgId: orgMainConfigMain.orgId.replace("8", "eight")
+});
+
+createFixture({
+  url: TEST_PAGE,
+  title:
+    "C5598188: Informative error messages are given when an identity cookie fails to be set"
+});
+
+test.meta({
+  ID: "C5598188",
+  SEVERTIY: "P0",
+  TEST_RUN: "Regression"
+});
+
+test("C5598188: Informative error message given when using an invalid orgID", async () => {
+  const validAlloy = createAlloyProxy();
+  await validAlloy.configure(mainConfig);
+  const errorMessage = await validAlloy.sendEventErrorMessage({});
+
+  await t.expect(errorMessage).contains("org ID");
+  await t.expect(errorMessage).contains(mainConfig.orgId);
+});

--- a/test/functional/specs/Identity/C5598188.js
+++ b/test/functional/specs/Identity/C5598188.js
@@ -20,7 +20,7 @@ import createAlloyProxy from "../../helpers/createAlloyProxy";
 import createFixture from "../../helpers/createFixture";
 
 const mainConfig = compose(orgMainConfigMain, {
-  orgId: orgMainConfigMain.orgId.replace("8", "eight")
+  orgId: "invalid-org-id@Adobe"
 });
 
 createFixture({

--- a/test/functional/specs/Identity/C5598188.js
+++ b/test/functional/specs/Identity/C5598188.js
@@ -42,4 +42,5 @@ test("C5598188: Informative error message given when using an invalid orgID", as
 
   await t.expect(errorMessage).contains("org ID");
   await t.expect(errorMessage).contains(mainConfig.orgId);
+  await t.expect(errorMessage).contains(mainConfig.edgeDomain);
 });

--- a/test/functional/specs/Identity/C5598188.js
+++ b/test/functional/specs/Identity/C5598188.js
@@ -40,9 +40,6 @@ test("C5598188: Informative error message given when using an invalid orgID", as
   await validAlloy.configure(mainConfig);
   const errorMessage = await validAlloy.sendEventErrorMessage({});
 
-  await t
-    .expect(errorMessage)
-    .contains("An identity cookie could not be found");
+  await t.expect(errorMessage).contains("An identity was not set properly.");
   await t.expect(errorMessage).contains(mainConfig.orgId);
-  await t.expect(errorMessage).contains(mainConfig.edgeDomain);
 });

--- a/test/functional/specs/Identity/C5598188.js
+++ b/test/functional/specs/Identity/C5598188.js
@@ -40,7 +40,9 @@ test("C5598188: Informative error message given when using an invalid orgID", as
   await validAlloy.configure(mainConfig);
   const errorMessage = await validAlloy.sendEventErrorMessage({});
 
-  await t.expect(errorMessage).contains("org ID");
+  await t
+    .expect(errorMessage)
+    .contains("An identity cookie could not be found");
   await t.expect(errorMessage).contains(mainConfig.orgId);
   await t.expect(errorMessage).contains(mainConfig.edgeDomain);
 });

--- a/test/unit/specs/components/Identity/injectAwaitIdentityCookie.spec.js
+++ b/test/unit/specs/components/Identity/injectAwaitIdentityCookie.spec.js
@@ -51,7 +51,7 @@ describe("Identity::injectAwaitIdentityCookie", () => {
   it("rejects promise if identity cookie does not exist after response", () => {
     identityCookieExists = false;
     const promise = awaitIdentityCookie({ onResponse, onRequestFailure });
-    const errorRegex = /verify that the org ID org@adobe configured/;
+    const errorRegex = /Verify that organization ID "org@adobe" matches the ID/;
     expect(() => {
       runOnResponseCallbacks();
     }).toThrowError(errorRegex);

--- a/test/unit/specs/components/Identity/injectAwaitIdentityCookie.spec.js
+++ b/test/unit/specs/components/Identity/injectAwaitIdentityCookie.spec.js
@@ -51,7 +51,7 @@ describe("Identity::injectAwaitIdentityCookie", () => {
   it("rejects promise if identity cookie does not exist after response", () => {
     identityCookieExists = false;
     const promise = awaitIdentityCookie({ onResponse, onRequestFailure });
-    const errorRegex = /Verify that organization ID "org@adobe" matches the ID/;
+    const errorRegex = /An identity was not set properly/i;
     expect(() => {
       runOnResponseCallbacks();
     }).toThrowError(errorRegex);


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

This is a more simple version of PR #838. The case of edge domain and apex domain mismatch causing a missing identity cookie [has been fixed in Konductor](https://jira.corp.adobe.com/browse/PDCL-7150).

This ticket just adds ~~the edge domain to the error message (just in case), adjusts the language to appear less like a definitive list of what went wrong, and~~ a functional test to verify that the error message is thrown when Alloy is configured with an incorrect org ID. ~~The new error message is like this:~~

> ~~An identity cookie could not be found. Verify that organization ID "org@Adobe" matches the ID in the edge configuration and that cookies from "firstparty.example.com" can be set on the current domain.~~

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[PDCL-7279](https://jira.corp.adobe.com/browse/PDCL-7279)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
