### PR TITLE
Added `appendIdentityToUrl` command to enable cross-domain identity sharing.

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -75,16 +75,15 @@
     <script nonce="%REACT_APP_NONCE%">
       alloy("configure", {
         defaultConsent: getUrlParameter("defaultConsent") || "in",
-        edgeDomain:
-          location.host.indexOf("alloyio.com") !== -1
+        edgeDomain: "firstparty.alloyio.com",
+        /*location.host.indexOf("alloyio.com") !== -1
             ? "firstparty.alloyio.com"
-            : undefined,
+            : undefined,*/
         edgeConfigId: "bc1a10e0-aee4-4e0e-ac5b-cdbb9abbec83",
         orgId: "5BFE274A5F6980A50A495C08@AdobeOrg",
         debugEnabled: true,
-        idMigrationEnabled: !(
-          getUrlParameter("idMigrationEnabled") === "false"
-        ),
+        idMigrationEnabled: false,
+        thirdPartyCookiesEnabled: false,
         prehidingStyle: ".personalization-container { opacity: 0 !important }",
         onBeforeEventSend: function(options) {
           const xdm = options.xdm;

--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -75,15 +75,16 @@
     <script nonce="%REACT_APP_NONCE%">
       alloy("configure", {
         defaultConsent: getUrlParameter("defaultConsent") || "in",
-        edgeDomain: "firstparty.alloyio.com",
-        /*location.host.indexOf("alloyio.com") !== -1
+        edgeDomain:
+          location.host.indexOf("alloyio.com") !== -1
             ? "firstparty.alloyio.com"
-            : undefined,*/
+            : undefined,
         edgeConfigId: "bc1a10e0-aee4-4e0e-ac5b-cdbb9abbec83",
         orgId: "5BFE274A5F6980A50A495C08@AdobeOrg",
         debugEnabled: true,
-        idMigrationEnabled: false,
-        thirdPartyCookiesEnabled: false,
+        idMigrationEnabled: !(
+          getUrlParameter("idMigrationEnabled") === "false"
+        ),
         prehidingStyle: ".personalization-container { opacity: 0 !important }",
         onBeforeEventSend: function(options) {
           const xdm = options.xdm;

--- a/sandbox/src/App.js
+++ b/sandbox/src/App.js
@@ -26,6 +26,7 @@ import DualTag from "./DualTag";
 import RedirectOffers from "./RedirectOffers";
 import RedirectedNewPage from "./RedirectedNewPage";
 import PersonalizationAnalyticsClientSide from "./PersonalizationAnalyticsClientSide";
+import Identity from "./Identity";
 
 function BasicExample() {
   return (
@@ -74,6 +75,9 @@ function BasicExample() {
           <li>
             <a href="/redirectOffers">Redirect Offers</a>
           </li>
+          <li>
+            <a href="/identity">Identity</a>
+          </li>
         </ul>
 
         <hr />
@@ -97,6 +101,7 @@ function BasicExample() {
         <Route path="/dualTag" component={DualTag} />
         <Route path="/redirectOffers" component={RedirectOffers} />
         <Route path="/redirectedNewPage" component={RedirectedNewPage} />
+        <Route path="/identity" component={Identity} />
       </div>
     </Router>
   );

--- a/sandbox/src/Identity.js
+++ b/sandbox/src/Identity.js
@@ -1,0 +1,63 @@
+/*
+ Copyright 2022 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import React, { useState } from "react";
+
+const getIdentity = setIdentity => () => {
+  window.alloy("getIdentity", { namespaces: ["ECID"] }).then(function(result) {
+    if (result.identity) {
+      console.log(
+        "Sandbox: Get Identity command has completed.",
+        result.identity.ECID
+      );
+      setIdentity(result.identity.ECID);
+    } else {
+      console.log(
+        "Sandbox: Get Identity command has completed but no identity was provided in the result (possibly due to lack of consent)."
+      );
+      setIdentity("No Identity");
+    }
+  });
+};
+
+const appendIdentityToUrl = event => {
+  const url = event.target.href;
+  event.preventDefault();
+  window.alloy("appendIdentityToUrl", { url }).then(({ url }) => {
+    document.location = url;
+  });
+};
+
+export default function Identity() {
+  const [identity, setIdentity] = useState("");
+
+  return (
+    <div>
+      <h1>Identity</h1>
+      <section>
+        <h2>Get Identity</h2>
+        <div>
+          <button onClick={getIdentity(setIdentity)}>Get ECID</button>
+          <h3>{identity}</h3>
+        </div>
+      </section>
+      <section>
+        <a
+          href="https://alternate-alloyio.com/identity"
+          onClick={appendIdentityToUrl}
+        >
+          Cross domain linked identity.
+        </a>
+      </section>
+    </div>
+  );
+}

--- a/sandbox/src/Identity.js
+++ b/sandbox/src/Identity.js
@@ -51,10 +51,7 @@ export default function Identity() {
         </div>
       </section>
       <section>
-        <a
-          href="https://alternate-alloyio.com/identity"
-          onClick={appendIdentityToUrl}
-        >
+        <a href="https://alloyio2.com/identity" onClick={appendIdentityToUrl}>
           Cross domain linked identity.
         </a>
       </section>

--- a/src/components/Identity/appendIdentityToUrl/appendIdentityToUrlOptionsValidator.js
+++ b/src/components/Identity/appendIdentityToUrl/appendIdentityToUrlOptionsValidator.js
@@ -1,0 +1,25 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { objectOf, string } from "../../../utils/validation";
+/**
+ * Verifies user provided event options.
+ * @param {*} options The user event options to validate
+ * @returns {*} Validated options
+ */
+export default objectOf({
+  url: string()
+    .required()
+    .nonEmpty()
+})
+  .required()
+  .noUnknownFields();

--- a/src/components/Identity/appendIdentityToUrl/injectAppendIdentityToUrl.js
+++ b/src/components/Identity/appendIdentityToUrl/injectAppendIdentityToUrl.js
@@ -22,7 +22,7 @@ const getSeparator = queryString => {
 };
 
 export default ({ dateProvider, orgId }) => (ecid, url) => {
-  const ts = dateProvider().getTime() / 1000;
+  const ts = Math.round(dateProvider().getTime() / 1000);
   const adobemc = encodeURIComponent(`TS=${ts}|MCMID=${ecid}|MCORGID=${orgId}`);
   const [, location, queryString, fragment] = url.match(URL_REGEX);
   const separator = getSeparator(queryString);

--- a/src/components/Identity/appendIdentityToUrl/injectAppendIdentityToUrl.js
+++ b/src/components/Identity/appendIdentityToUrl/injectAppendIdentityToUrl.js
@@ -1,0 +1,30 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+const URL_REGEX = /^([^?#]*)(\??[^#]*)(#?.*)$/;
+
+const getSeparator = queryString => {
+  if (queryString === "") {
+    return "?";
+  }
+  if (queryString === "?") {
+    return "";
+  }
+  return "&";
+};
+
+export default ({ dateProvider, orgId }) => (ecid, url) => {
+  const ts = dateProvider().getTime() / 1000;
+  const adobemc = encodeURIComponent(`TS=${ts}|MCMID=${ecid}|MCORGID=${orgId}`);
+  const [, location, queryString, fragment] = url.match(URL_REGEX);
+  const separator = getSeparator(queryString);
+  return `${location}${queryString}${separator}adobe_mc=${adobemc}${fragment}`;
+};

--- a/src/components/Identity/createComponent.js
+++ b/src/components/Identity/createComponent.js
@@ -1,5 +1,6 @@
 import { assign } from "../../utils";
 import getIdentityOptionsValidator from "./getIdentity/getIdentityOptionsValidator";
+import appendIdentityToUrlOptionsValidator from "./appendIdentityToUrl/appendIdentityToUrlOptionsValidator";
 
 export default ({
   addEcidQueryToPayload,
@@ -9,7 +10,9 @@ export default ({
   handleResponseForIdSyncs,
   getEcidFromResponse,
   getIdentity,
-  consent
+  consent,
+  appendIdentityToUrl,
+  logger
 }) => {
   let ecid;
   let edge = {};
@@ -55,6 +58,23 @@ export default ({
                 },
                 edge
               };
+            });
+        }
+      },
+      appendIdentityToUrl: {
+        optionsValidator: appendIdentityToUrlOptionsValidator,
+        run: options => {
+          return consent
+            .withConsent()
+            .then(() => {
+              return ecid ? undefined : getIdentity(options.namespaces);
+            })
+            .then(() => {
+              return { url: appendIdentityToUrl(ecid, options.url) };
+            })
+            .catch(error => {
+              logger.warn(`Unable to append identity to url. ${error.message}`);
+              return options;
             });
         }
       }

--- a/src/components/Identity/index.js
+++ b/src/components/Identity/index.js
@@ -34,6 +34,7 @@ import getEcidFromResponse from "./getEcidFromResponse";
 import createGetIdentity from "./getIdentity/createGetIdentity";
 import createIdentityRequest from "./getIdentity/createIdentityRequest";
 import createIdentityRequestPayload from "./getIdentity/createIdentityRequestPayload";
+import injectAppendIdentityToUrl from "./appendIdentityToUrl/injectAppendIdentityToUrl";
 
 const createIdentity = ({
   config,
@@ -94,15 +95,21 @@ const createIdentity = ({
   const handleResponseForIdSyncs = injectHandleResponseForIdSyncs({
     processIdSyncs
   });
+  const appendIdentityToUrl = injectAppendIdentityToUrl({
+    dateProvider: () => new Date(),
+    orgId
+  });
   return createComponent({
-    ensureSingleIdentity,
     addEcidQueryToPayload,
     addQueryStringIdentityToPayload,
+    ensureSingleIdentity,
     setLegacyEcid: legacyIdentity.setEcid,
     handleResponseForIdSyncs,
     getEcidFromResponse,
     getIdentity,
-    consent
+    consent,
+    appendIdentityToUrl,
+    logger
   });
 };
 

--- a/src/core/consent/createConsent.js
+++ b/src/core/consent/createConsent.js
@@ -51,6 +51,9 @@ export default ({ generalConsentState, logger }) => {
     },
     awaitConsent() {
       return generalConsentState.awaitConsent();
+    },
+    withConsent() {
+      return generalConsentState.withConsent();
     }
   };
 };

--- a/src/core/consent/createConsentStateMachine.js
+++ b/src/core/consent/createConsentStateMachine.js
@@ -51,7 +51,10 @@ export default ({ logger }) => {
     );
   const awaitOut = () =>
     Promise.reject(createDeclinedConsentError("The user declined consent."));
-  const awaitPending = () => {
+  const awaitPending = returnImmediately => {
+    if (returnImmediately) {
+      return Promise.reject(new Error("Consent is pending."));
+    }
     const deferred = defer();
     deferreds.push(deferred);
     return deferred.promise;
@@ -105,6 +108,9 @@ export default ({ logger }) => {
       }
       this.awaitConsent = awaitPending;
     },
-    awaitConsent: awaitInitial
+    awaitConsent: awaitInitial,
+    withConsent() {
+      return this.awaitConsent(true);
+    }
   };
 };

--- a/test/functional/helpers/constants/url.js
+++ b/test/functional/helpers/constants/url.js
@@ -17,3 +17,6 @@ export const TEST_PAGE_WITH_CSP = `${baseUrl}/testPageWithCsp.html`;
 // This page is only used by reloadPage.js as an interim workaround for
 // https://github.com/DevExpress/testcafe/issues/5992
 export const RELOAD_PAGE = `${baseUrl}/reloadPage.html`;
+
+const secondaryBaseUrl = `https://alloyio2.com/functional-test`;
+export const SECONDARY_TEST_PAGE = `${secondaryBaseUrl}/testPage.html`;

--- a/test/functional/helpers/createAlloyProxy.js
+++ b/test/functional/helpers/createAlloyProxy.js
@@ -87,7 +87,8 @@ const commands = [
   "setConsent",
   "getIdentity",
   "setDebug",
-  "getLibraryInfo"
+  "getLibraryInfo",
+  "appendIdentityToUrl"
 ];
 
 export default (instanceName = "alloy") => {

--- a/test/unit/specs/components/Identity/appendIdentityToUrl/appendIdentityToUrlOptionsValidator.spec.js
+++ b/test/unit/specs/components/Identity/appendIdentityToUrl/appendIdentityToUrlOptionsValidator.spec.js
@@ -1,0 +1,23 @@
+import appendIdentityToUrlOptionsValidator from "../../../../../../src/components/Identity/appendIdentityToUrl/appendIdentityToUrlOptionsValidator";
+
+describe("Identity::appendIdentityToUrlOptionsValidator", () => {
+  [
+    undefined,
+    "myurl",
+    {},
+    { url: "" },
+    { url: "hello", other: "goodbye" }
+  ].forEach(param => {
+    it(`should throw an error when ${JSON.stringify(param)} is passed`, () => {
+      expect(() => {
+        appendIdentityToUrlOptionsValidator(param);
+      }).toThrowError();
+    });
+  });
+
+  it("should accept a url", () => {
+    expect(
+      appendIdentityToUrlOptionsValidator({ url: "http://google.com" })
+    ).toEqual({ url: "http://google.com" });
+  });
+});

--- a/test/unit/specs/components/Identity/appendIdentityToUrl/injectAppendIdentityToUrl.spec.js
+++ b/test/unit/specs/components/Identity/appendIdentityToUrl/injectAppendIdentityToUrl.spec.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 import injectAppendIdentityToUrl from "../../../../../../src/components/Identity/appendIdentityToUrl/injectAppendIdentityToUrl";
 
 describe("appendIdentityToUrl", () => {
-  const date = new Date(1000);
+  const date = new Date(1234);
   const orgId = "myorg@adobe";
   const appendIdentityToUrl = injectAppendIdentityToUrl({
     dateProvider: () => date,

--- a/test/unit/specs/components/Identity/appendIdentityToUrl/injectAppendIdentityToUrl.spec.js
+++ b/test/unit/specs/components/Identity/appendIdentityToUrl/injectAppendIdentityToUrl.spec.js
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import injectAppendIdentityToUrl from "../../../../../../src/components/Identity/appendIdentityToUrl/injectAppendIdentityToUrl";
+
+describe("appendIdentityToUrl", () => {
+  const date = new Date(1000);
+  const orgId = "myorg@adobe";
+  const appendIdentityToUrl = injectAppendIdentityToUrl({
+    dateProvider: () => date,
+    orgId
+  });
+  const ecid = "1234";
+  const qsp = "adobe_mc=TS%3D1%7CMCMID%3D1234%7CMCORGID%3Dmyorg%40adobe";
+
+  const test = (original, expected) => {
+    it(`appends to "${original}"`, () => {
+      expect(appendIdentityToUrl(ecid, original)).toBe(expected);
+    });
+  };
+
+  test("", `?${qsp}`);
+  test("/", `/?${qsp}`);
+  test("?", `?${qsp}`);
+  test("?a=b", `?a=b&${qsp}`);
+  test("#test", `?${qsp}#test`);
+  test("/example.html", `/example.html?${qsp}`);
+  test("https://adobe.com", `https://adobe.com?${qsp}`);
+  test("https://adobe.com?", `https://adobe.com?${qsp}`);
+  test("https://adobe.com?a=1", `https://adobe.com?a=1&${qsp}`);
+  test("https://adobe.com#myhash", `https://adobe.com?${qsp}#myhash`);
+  test("https://adobe.com?#myhash", `https://adobe.com?${qsp}#myhash`);
+  test("https://adobe.com?a=1#myhash", `https://adobe.com?a=1&${qsp}#myhash`);
+  test(
+    "https://adobe.com#myweird?hash",
+    `https://adobe.com?${qsp}#myweird?hash`
+  );
+});

--- a/test/unit/specs/components/Identity/createComponent.spec.js
+++ b/test/unit/specs/components/Identity/createComponent.spec.js
@@ -211,7 +211,6 @@ describe("Identity::createComponent", () => {
       url: "myurl"
     });
     withConsentDeferred.reject(new Error("My consent error."));
-    getIdentityDeferred.reject(new Error("My getIdentity error."));
     return expectAsync(commandPromise)
       .toBeResolvedTo({ url: "myurl" })
       .then(() => {

--- a/test/unit/specs/components/Identity/injectAddQueryStringIdentityToPayload.spec.js
+++ b/test/unit/specs/components/Identity/injectAddQueryStringIdentityToPayload.spec.js
@@ -107,7 +107,8 @@ describe("Identity::injectAddQueryStringIdentityToPayload", () => {
     )}`,
     `adobe_mc=${encodeURIComponent(
       "TS=1641432103|MCMID=|MCORGID=FAF554945B90342F0A495E2C@AdobeOrg"
-    )}`
+    )}`,
+    `adobe_mc=${encodeURIComponent("TS|MCMID")}`
   ].forEach(value => {
     it(`handles garbage parameter value: ${value}`, () => {
       locationSearch = `?${value}`;

--- a/test/unit/specs/components/Identity/injectAddQueryStringIdentityToPayload.spec.js
+++ b/test/unit/specs/components/Identity/injectAddQueryStringIdentityToPayload.spec.js
@@ -40,6 +40,17 @@ describe("Identity::injectAddQueryStringIdentityToPayload", () => {
     })(payload);
   };
 
+  it("handles parameter from mobile", () => {
+    locationSearch =
+      "?adobe_mc=TS%3D1649313745%7CMCMID%3D44902718526006715436785898720250463779%7CMCORGID%3D972C898555E9F7BC7F000101%40AdobeOrg";
+    date = new Date(1649313800 * 1000);
+    orgId = "972C898555E9F7BC7F000101@AdobeOrg";
+    run();
+    expect(payload.addIdentity).toHaveBeenCalledOnceWith("ECID", {
+      id: "44902718526006715436785898720250463779"
+    });
+  });
+
   it("adds the identity", () => {
     run();
     expect(payload.addIdentity).toHaveBeenCalledOnceWith("ECID", {

--- a/test/unit/specs/core/consent/createConsent.spec.js
+++ b/test/unit/specs/core/consent/createConsent.spec.js
@@ -22,7 +22,8 @@ describe("createConsent", () => {
       "in",
       "out",
       "pending",
-      "awaitConsent"
+      "awaitConsent",
+      "withConsent"
     ]);
     logger = jasmine.createSpyObj("logger", ["warn"]);
     subject = createConsent({ generalConsentState: state, logger });
@@ -66,5 +67,9 @@ describe("createConsent", () => {
   it("calls await consent", () => {
     state.awaitConsent.and.returnValue("mypromise");
     expect(subject.awaitConsent()).toEqual("mypromise");
+  });
+  it("calls with consent", () => {
+    state.withConsent.and.returnValue("mypromise");
+    expect(subject.withConsent()).toEqual("mypromise");
   });
 });

--- a/test/unit/specs/core/consent/createConsentStateMachine.spec.js
+++ b/test/unit/specs/core/consent/createConsentStateMachine.spec.js
@@ -172,4 +172,21 @@ describe("createConsentStateMachine", () => {
       expect(logger.warn).not.toHaveBeenCalled();
     });
   });
+
+  describe("withConsent", () => {
+    ["default", "initial", "new"].forEach(source => {
+      it(`returns immediately when ${source} consent is set to "in"`, () => {
+        subject.in(source);
+        return expectAsync(subject.withConsent()).toBeResolvedTo();
+      });
+      it(`rejects when ${source} consent is set to "out"`, () => {
+        subject.out(source);
+        return expectAsync(subject.withConsent()).toBeRejected();
+      });
+      it(`rejects when ${source} consent is set to "pending"`, () => {
+        subject.pending(source);
+        return expectAsync(subject.withConsent()).toBeRejected();
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

NOTE: I have the base of this PR as queryStringIdentity branch because this PR relies on changes made in #843 , and they have not been merged yet.

## Description

For the use case of navigating from one domain to another, the customer can use the "appendIdentityToUrl" command to generate the "adobe_mc" query string parameter. The command accepts an object with one property, "url", and returns an object with the property "url".
If consent has not been given, the url is returned unchanged. This command does not wait for consent.
If an ECID has not yet been established, "/acquire" endpoint will be hit to generate an ECID.

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-7572
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
