### PR TITLE
Use a persistent iframe for all ID syncs and segment destinations

### DIFF
--- a/src/components/Audiences/index.js
+++ b/src/components/Audiences/index.js
@@ -10,12 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { injectFireReferrerHideableImage } from "../../utils";
 import injectProcessDestinations from "./injectProcessDestinations";
 import injectProcessResponse from "./injectProcessResponse";
 
-const createAudiences = ({ logger }) => {
-  const fireReferrerHideableImage = injectFireReferrerHideableImage();
+const createAudiences = ({ logger, fireReferrerHideableImage }) => {
   const processDestinations = injectProcessDestinations({
     fireReferrerHideableImage,
     logger

--- a/src/components/Audiences/index.js
+++ b/src/components/Audiences/index.js
@@ -10,11 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fireReferrerHideableImage } from "../../utils";
+import { injectFireReferrerHideableImage } from "../../utils";
 import injectProcessDestinations from "./injectProcessDestinations";
 import injectProcessResponse from "./injectProcessResponse";
 
 const createAudiences = ({ logger }) => {
+  const fireReferrerHideableImage = injectFireReferrerHideableImage();
   const processDestinations = injectProcessDestinations({
     fireReferrerHideableImage,
     logger

--- a/src/components/Identity/index.js
+++ b/src/components/Identity/index.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import {
-  fireReferrerHideableImage,
+  injectFireReferrerHideableImage,
   areThirdPartyCookiesSupportedByDefault,
   injectDoesIdentityCookieExist
 } from "../../utils";
@@ -78,6 +78,7 @@ const createIdentity = ({
     awaitIdentityCookie,
     logger
   });
+  const fireReferrerHideableImage = injectFireReferrerHideableImage();
   const processIdSyncs = injectProcessIdSyncs({
     fireReferrerHideableImage,
     logger

--- a/src/components/Identity/index.js
+++ b/src/components/Identity/index.js
@@ -11,7 +11,6 @@ governing permissions and limitations under the License.
 */
 
 import {
-  injectFireReferrerHideableImage,
   areThirdPartyCookiesSupportedByDefault,
   injectDoesIdentityCookieExist
 } from "../../utils";
@@ -38,6 +37,7 @@ const createIdentity = ({
   config,
   logger,
   consent,
+  fireReferrerHideableImage,
   sendEdgeNetworkRequest
 }) => {
   const { orgId, thirdPartyCookiesEnabled } = config;
@@ -78,7 +78,6 @@ const createIdentity = ({
     awaitIdentityCookie,
     logger
   });
-  const fireReferrerHideableImage = injectFireReferrerHideableImage();
   const processIdSyncs = injectProcessIdSyncs({
     fireReferrerHideableImage,
     logger

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -11,7 +11,13 @@ governing permissions and limitations under the License.
 */
 
 import createInstanceFunction from "./createInstanceFunction";
-import { getApexDomain, injectStorage, cookieJar, isFunction } from "../utils";
+import {
+  getApexDomain,
+  injectStorage,
+  cookieJar,
+  isFunction,
+  injectFireReferrerHideableImage
+} from "../utils";
 import createLogController from "./createLogController";
 import createLifecycle from "./createLifecycle";
 import createComponentRegistry from "./createComponentRegistry";
@@ -134,10 +140,12 @@ export const createExecuteCommand = ({
       componentRegistry,
       getImmediatelyAvailableTools(componentName) {
         const componentLogger = createComponentLogger(componentName);
+        const fireReferrerHideableImage = injectFireReferrerHideableImage();
         return {
           config,
           consent,
           eventManager,
+          fireReferrerHideableImage,
           logger: componentLogger,
           lifecycle,
           sendEdgeNetworkRequest,

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -63,6 +63,7 @@ const apexDomain = getApexDomain(window, cookieJar);
 const sendFetchRequest = isFunction(fetch)
   ? injectSendFetchRequest({ fetch })
   : injectSendXhrRequest({ XMLHttpRequest });
+const fireReferrerHideableImage = injectFireReferrerHideableImage();
 
 export const createExecuteCommand = ({
   instanceName,
@@ -140,7 +141,6 @@ export const createExecuteCommand = ({
       componentRegistry,
       getImmediatelyAvailableTools(componentName) {
         const componentLogger = createComponentLogger(componentName);
-        const fireReferrerHideableImage = injectFireReferrerHideableImage();
         return {
           config,
           consent,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -26,7 +26,7 @@ export { default as deepAssign } from "./deepAssign";
 export { default as endsWith } from "./endsWith";
 export { default as find } from "./find";
 export { default as fireImage } from "./fireImage";
-export { default as fireReferrerHideableImage } from "./fireReferrerHideableImage";
+export { default as injectFireReferrerHideableImage } from "./injectFireReferrerHideableImage";
 export { default as flatMap } from "./flatMap";
 export { default as getApexDomain } from "./getApexDomain";
 export { default as getLastArrayItems } from "./getLastArrayItems";

--- a/src/utils/injectFireReferrerHideableImage.js
+++ b/src/utils/injectFireReferrerHideableImage.js
@@ -50,7 +50,7 @@ export default ({
   const fireInIframe = ({ src }) => {
     return createIframe().then(iframe => {
       const currentDocument = iframe.contentWindow.document;
-      return fireImage({ src, currentDocument }).then(() => {
+      return fireImage({ src, currentDocument }).finally(() => {
         removeNode(iframe);
       });
     });

--- a/src/utils/injectFireReferrerHideableImage.js
+++ b/src/utils/injectFireReferrerHideableImage.js
@@ -10,11 +10,14 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import fireImage from "./fireImage";
-import { appendNode, awaitSelector, createNode, removeNode } from "./dom";
+import fireImageInDocument from "./fireImage";
+import {
+  appendNode as appendNodeToDocument,
+  awaitSelector as awaitSelectorInDocument,
+  createNode as createNodeInDocument,
+  removeNode as removeNodeInDocument
+} from "./dom";
 import { BODY, IFRAME } from "../constants/tagName";
-
-const fireOnPage = fireImage;
 
 const IFRAME_ATTRS = {
   name: "Adobe Alloy"
@@ -28,7 +31,15 @@ const IFRAME_PROPS = {
   }
 };
 
-export default request => {
+export default ({
+  appendNode = appendNodeToDocument,
+  awaitSelector = awaitSelectorInDocument,
+  createNode = createNodeInDocument,
+  fireImage = fireImageInDocument,
+  removeNode = removeNodeInDocument
+}) => {
+  const fireOnPage = fireImage;
+
   const createIframe = () => {
     return awaitSelector(BODY).then(([body]) => {
       const iframe = createNode(IFRAME, IFRAME_ATTRS, IFRAME_PROPS);
@@ -45,6 +56,8 @@ export default request => {
     });
   };
 
-  const { hideReferrer, url } = request;
-  return hideReferrer ? fireInIframe({ src: url }) : fireOnPage({ src: url });
+  return request => {
+    const { hideReferrer, url } = request;
+    return hideReferrer ? fireInIframe({ src: url }) : fireOnPage({ src: url });
+  };
 };

--- a/src/utils/injectFireReferrerHideableImage.js
+++ b/src/utils/injectFireReferrerHideableImage.js
@@ -37,7 +37,7 @@ export default ({
   createNode = createNodeInDocument,
   fireImage = fireImageInDocument,
   removeNode = removeNodeInDocument
-}) => {
+} = {}) => {
   const fireOnPage = fireImage;
 
   let hiddenIframe;

--- a/src/utils/injectFireReferrerHideableImage.js
+++ b/src/utils/injectFireReferrerHideableImage.js
@@ -40,17 +40,23 @@ export default ({
 }) => {
   const fireOnPage = fireImage;
 
+  let hiddenIframe;
+
   const createIframe = () => {
+    if (hiddenIframe) {
+      return Promise.resolve(hiddenIframe);
+    }
     return awaitSelector(BODY).then(([body]) => {
-      const iframe = createNode(IFRAME, IFRAME_ATTRS, IFRAME_PROPS);
-      return appendNode(body, iframe);
+      hiddenIframe = createNode(IFRAME, IFRAME_ATTRS, IFRAME_PROPS);
+      return appendNode(body, hiddenIframe);
     });
   };
 
   const fireInIframe = ({ src }) => {
     return createIframe().then(iframe => {
       const currentDocument = iframe.contentWindow.document;
-      return fireImage({ src, currentDocument }).finally(() => {
+      return fireImage({ src, currentDocument }).catch(() => {
+        hiddenIframe = undefined;
         removeNode(iframe);
       });
     });

--- a/src/utils/injectFireReferrerHideableImage.js
+++ b/src/utils/injectFireReferrerHideableImage.js
@@ -14,8 +14,7 @@ import fireImageInDocument from "./fireImage";
 import {
   appendNode as appendNodeToDocument,
   awaitSelector as awaitSelectorInDocument,
-  createNode as createNodeInDocument,
-  removeNode as removeNodeInDocument
+  createNode as createNodeInDocument
 } from "./dom";
 import { BODY, IFRAME } from "../constants/tagName";
 
@@ -35,8 +34,7 @@ export default ({
   appendNode = appendNodeToDocument,
   awaitSelector = awaitSelectorInDocument,
   createNode = createNodeInDocument,
-  fireImage = fireImageInDocument,
-  removeNode = removeNodeInDocument
+  fireImage = fireImageInDocument
 } = {}) => {
   const fireOnPage = fireImage;
 
@@ -55,10 +53,7 @@ export default ({
   const fireInIframe = ({ src }) => {
     return createIframe().then(iframe => {
       const currentDocument = iframe.contentWindow.document;
-      return fireImage({ src, currentDocument }).catch(() => {
-        hiddenIframe = undefined;
-        removeNode(iframe);
-      });
+      return fireImage({ src, currentDocument });
     });
   };
 

--- a/test/unit/specs/utils/injectFireReferrerHideableImage.spec.js
+++ b/test/unit/specs/utils/injectFireReferrerHideableImage.spec.js
@@ -64,4 +64,22 @@ describe("injectFireReferrerHideableImage", () => {
     expect(createNodeMock).not.toHaveBeenCalled();
     expect(fireImageMock).toHaveBeenCalled();
   });
+
+  it("should destroy the iframe when firing the image fails", async () => {
+    const request = {
+      hideReferrer: true,
+      url: "https://adobe.com/test-invalid-referrer.jpg"
+    };
+    fireImageMock.and.callFake(() =>
+      Promise.reject(new Error("Expected failure"))
+    );
+    try {
+      await fireReferrerHideableImage(request);
+    } catch (err) {
+      expect(createNodeMock).toHaveBeenCalled();
+      expect(createNodeMock.calls.argsFor(0)).toContain("IFRAME");
+      expect(fireImageMock).toHaveBeenCalled();
+      expect(removeNodeMock).toHaveBeenCalled();
+    }
+  });
 });

--- a/test/unit/specs/utils/injectFireReferrerHideableImage.spec.js
+++ b/test/unit/specs/utils/injectFireReferrerHideableImage.spec.js
@@ -11,4 +11,4 @@ governing permissions and limitations under the License.
 */
 
 // eslint-disable-next-line no-unused-vars
-import fireReferrerHideableImage from "../../../../src/utils/fireReferrerHideableImage";
+import injectFireReferrerHideableImage from "../../../../src/utils/injectFireReferrerHideableImage";

--- a/test/unit/specs/utils/injectFireReferrerHideableImage.spec.js
+++ b/test/unit/specs/utils/injectFireReferrerHideableImage.spec.js
@@ -17,7 +17,6 @@ describe("injectFireReferrerHideableImage", () => {
   let awaitSelectorMock;
   let createNodeMock;
   let fireImageMock;
-  let removeNodeMock;
   let fireReferrerHideableImage;
 
   beforeEach(() => {
@@ -33,13 +32,11 @@ describe("injectFireReferrerHideableImage", () => {
     fireImageMock = jasmine
       .createSpy("fireImage")
       .and.callFake(() => Promise.resolve());
-    removeNodeMock = jasmine.createSpy("removeNode");
     fireReferrerHideableImage = injectFireReferrerHideableImage({
       appendNode: appendNodeMock,
       awaitSelector: awaitSelectorMock,
       createNode: createNodeMock,
-      fireImage: fireImageMock,
-      removeNode: removeNodeMock
+      fireImage: fireImageMock
     });
   });
 
@@ -66,24 +63,6 @@ describe("injectFireReferrerHideableImage", () => {
     expect(fireImageMock).toHaveBeenCalled();
   });
 
-  it("should destroy the iframe when firing the image fails", async () => {
-    const request = {
-      hideReferrer: true,
-      url: "https://adobe.com/test-invalid-referrer.jpg"
-    };
-    fireImageMock.and.callFake(() =>
-      Promise.reject(new Error("Expected failure"))
-    );
-    try {
-      await fireReferrerHideableImage(request);
-    } catch (err) {
-      expect(createNodeMock).toHaveBeenCalled();
-      expect(createNodeMock.calls.argsFor(0)).toContain("IFRAME");
-      expect(fireImageMock).toHaveBeenCalled();
-      expect(removeNodeMock).toHaveBeenCalled();
-    }
-  });
-
   it("should only create one iframe when called multiple times", async () => {
     const request = {
       hideReferrer: true,
@@ -100,6 +79,5 @@ describe("injectFireReferrerHideableImage", () => {
     expect(createNodeMock).toHaveBeenCalledTimes(1);
     expect(createNodeMock.calls.argsFor(0)).toContain("IFRAME");
     expect(fireImageMock).toHaveBeenCalledTimes(2);
-    expect(removeNodeMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

This change keeps a local closure variable of the `<iframe>` so that only a single one gets created, no matter how many ID syncs and segment destinations appear in the payload. It also changes `fireReferrerHideableImage` into a function provided by a factory/injector function so that all the DOM-related functions are injected so that they can be mocked for unit tests. Unit tests around the function have also been created.

After this change, the `<iframe>` persists indefinitely on the page after syncs and contains all the referrer images. It is only cleared when a sync fails. Alternatives to this are: 

- go back to creating an `<iframe>` per sync, but use `.finally()` instead of `.then()` to make sure it always goes away.
    - However, the customer thought that creating so many `<iframe>s` was giving their site performance issues, so that doesn't resolve this problem
- Clear out the referrer image after a sync instead of deleting the entire `<iframe>`
    - It's not hard, but it is extra work. If there is risk from persistant referrer images in the DOM, I would prefer this option.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[PDCL-8050–Cleanup iFrame after ID syncing](https://jira.corp.adobe.com/browse/PDCL-8050)

> We currently generate anonymous iFrames to trigger ID syncs: basically we generate an iFrame with no src, inject it with an image and set the source of the image to a specific URL that we receive from Konductor.
>
> The problems:
>
> If the sync fails (Meaning if the promise is rejected), we are not removing the iFrame (https://github.com/adobe/alloy/blob/main/src/utils/fireReferrerHideableImage.js#L42)
> It seems like we might not reusing iFrames as well, so if there was a sync later on in the page lifecycle, we create a new iFrame, which is causing performance issues.
> The Ask:
> 
> Remove the iFrame on rejection and reuse one iFrame for all ID syncs in the same session.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

[The original customer ticket](https://jira.corp.adobe.com/browse/PLATIR-19466) mentions a high-volume customer that has ≥12 ID syncs and segment destinations for new browsers, and anywhere from 1-4 of them would fail. We creating all these `<iframe>s`, and the code used a `.then()` to clear them, so they weren't getting cleaned up on failure.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.