### PR TITLE
Fixed an issue where personalized content with a child selector directly following an "eq" pseudo selector selects the wrong node.

### DIFF
--- a/src/components/Personalization/dom-actions/dom/selectNodesWithEq.js
+++ b/src/components/Personalization/dom-actions/dom/selectNodesWithEq.js
@@ -13,13 +13,23 @@ governing permissions and limitations under the License.
 import escape from "css.escape";
 import { selectNodes } from "../../../../utils/dom";
 import { isNotEqSelector, splitWithEq } from "./helperForEq";
+import startsWith from "../../../../utils/startsWith";
 
 // Trying to match ID or CSS class
 const CSS_IDENTIFIER_PATTERN = /(#|\.)(-?\w+)/g;
-// This is required to remove leading " > " from parsed pieces
-const SIBLING_PATTERN = /^\s*>?\s*/;
 
-const cleanUp = str => str.replace(SIBLING_PATTERN, "").trim();
+const cleanUp = selector => {
+  if (!startsWith(selector, ">")) {
+    return selector;
+  }
+
+  // IE doesn't support :scope
+  if (window.document.documentMode) {
+    return selector.substring(1).trim();
+  }
+
+  return `:scope ${selector}`;
+};
 
 // Here we use CSS.escape() to make sure we get
 // correct values for ID and CSS class
@@ -39,7 +49,7 @@ export const parseSelector = rawSelector => {
   let i = 0;
 
   while (i < length) {
-    const sel = cleanUp(parts[i]);
+    const sel = cleanUp(parts[i].trim());
     const eq = parts[i + 1];
 
     if (eq) {

--- a/test/unit/specs/utils/dom/selectNodesWithShadow.spec.js
+++ b/test/unit/specs/utils/dom/selectNodesWithShadow.spec.js
@@ -26,29 +26,29 @@ const defineCustomElements = () => {
     return;
   }
 
-  const buyNowContent = `
-    <div>
-      <input type="radio" id="buy" name="buy_btn" value="Buy NOW">
-      <label for="buy">Buy Now</label><br>
-      <div>
-        <input type="radio" id="buy_later" name="buy_btn_ltr" value="Buy LATER">
-        <label for="buy_later">Buy Later</label><br>
-      </div>
-    </div>
-  `;
   customElements.define(
     "buy-now-button",
     class extends HTMLElement {
       constructor() {
         super();
 
+        const prefix = this.dataset.prefix;
         const shadowRoot = this.attachShadow({ mode: "open" });
-        shadowRoot.innerHTML = buyNowContent;
+
+        shadowRoot.innerHTML = `
+          <div>
+            <div>
+              <input type="radio" id="buy_later" name="buy_btn_ltr" value="Buy LATER">
+              <label for="buy_later">${prefix} Buy Later</label><br>
+            </div>
+            <input type="radio" id="buy" name="buy_btn" value="Buy NOW">
+            <label for="buy">${prefix} Buy Now</label><br>
+          </div>
+        `;
       }
     }
   );
 
-  const productOrderContent = `<div><p>Product order</p><buy-now-button>Buy</buy-now-button></div>`;
   customElements.define(
     "product-order",
     class extends HTMLElement {
@@ -56,6 +56,18 @@ const defineCustomElements = () => {
         super();
 
         const shadowRoot = this.attachShadow({ mode: "open" });
+        const prefix = this.dataset.prefix;
+
+        const productOrderContent = `
+          <div>
+            <p>Product order</p>
+            <div>
+              <buy-now-button data-prefix="Skipped${prefix}"></buy-now-button>
+            </div>
+            <buy-now-button data-prefix="${prefix}"></buy-now-button>
+          </div>
+        `;
+
         shadowRoot.innerHTML = productOrderContent;
       }
     }
@@ -88,8 +100,11 @@ describe("Utils::DOM::selectNodesWithShadow", () => {
 
     const content = `
     <form id="form" action="https://www.adobe.com" method="post">
-      <buy-now-button>FirstButton</buy-now-button>
-      <buy-now-button>SecondButton</buy-now-button>
+      <div>
+        <buy-now-button data-prefix="SkippedButton"></buy-now-button>
+      </div>
+      <buy-now-button data-prefix="FirstButton"></buy-now-button>
+      <buy-now-button data-prefix="SecondButton"></buy-now-button>
       <input type="submit" value="Submit"/>
     </form>`;
 
@@ -99,13 +114,13 @@ describe("Utils::DOM::selectNodesWithShadow", () => {
     );
 
     const result = selectNodesWithEq(
-      "#abc:eq(0) > FORM:nth-of-type(1) > BUY-NOW-BUTTON:nth-of-type(2):shadow > DIV:nth-of-type(1) > LABEL:nth-of-type(1)"
+      "#abc:eq(0) > FORM:nth-of-type(1) > BUY-NOW-BUTTON:nth-of-type(2):shadow > DIV:eq(0) > LABEL:eq(0)"
     );
 
     expect(result.length).toEqual(1);
 
     expect(result[0].tagName).toEqual("LABEL");
-    expect(result[0].textContent).toEqual("Buy Now");
+    expect(result[0].textContent).toEqual("SecondButton Buy Now");
   });
 
   it("should select when multiple nested shadow nodes", () => {
@@ -117,10 +132,13 @@ describe("Utils::DOM::selectNodesWithShadow", () => {
 
     const content = `
     <form id="form" action="https://www.adobe.com" method="post">
-      <buy-now-button>FirstButton</buy-now-button>
-      <buy-now-button>SecondButton</buy-now-button>
-      <product-order>FirstOrder</product-order>
-      <product-order>SecondOrder</product-order>
+      <buy-now-button data-prefix="FirstButton"></buy-now-button>
+      <buy-now-button data-prefix="SecondButton"></buy-now-button>
+      <div>
+        <product-order data-prefix="SkippedOrder"></product-order>
+      </div>
+      <product-order data-prefix="FirstOrder"></product-order>
+      <product-order data-prefix="SecondOrder"></product-order>
       <input type="submit" value="Submit"/>
     </form>`;
 
@@ -134,6 +152,6 @@ describe("Utils::DOM::selectNodesWithShadow", () => {
     );
 
     expect(result[0].tagName).toEqual("LABEL");
-    expect(result[0].textContent).toEqual("Buy Now");
+    expect(result[0].textContent).toEqual("SecondOrder Buy Now");
   });
 });


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

When a child selector (`>`) immediately follows an `eq()` pseudo selector, prefix the child portion of the split selector with `:scope` to preserve the direct-child relationship when `querySelectorAll()` is executed.

### Note

This fix is applied for non-IE browsers only.  Per the [caniuse.com listing for `:scope`](https://caniuse.com/?search=%3Ascope), this not possible in any version of IE. Given IE will completely lose support in [newer version of Windows starting June 15, 2022](https://docs.microsoft.com/en-us/lifecycle/products/internet-explorer-11), this seems like a minimal risk. That said, this PR should have sufficient guards to ensure IE functions as it did before, and tests should still pass on IE.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#850

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Summary: with certain markup situations, removing the child selector causes incorrect node selection. The principal side effect of this incorrect selection is that target tests can be inserted into the wrong location in markup. See #850 for more details.

While this is a relatively simple & straight forward bug fix, it may have impact on existing code and should be treated as a breaking change.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
