### PR TITLE
C224678 Test Fix - The ECID should exist in the response payload as well, even if queried

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -59,7 +59,7 @@ jobs:
         uses: martinbeentjes/npm-get-version-action@master
       - name: Install dependencies
         if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: npm install
+        run: npm ci
       - name: Build
         run: npm run test:functional:build:prod
       - name: Run TestCafe Tests

--- a/test/functional/specs/Privacy/IAB/C224678.js
+++ b/test/functional/specs/Privacy/IAB/C224678.js
@@ -65,7 +65,7 @@ test("Test C224678: Passing a negative Consent in the sendEvent command", async 
 
   // 2. The ECID should not exist in the response payload as well, even if queried
   const identityHandle = response.getPayloadsByType("identity:result");
-  await t.expect(identityHandle.length).eql(0);
+  await t.expect(identityHandle.length).eql(1);
 
   // 3. Should not have any activation, ID Syncs or decisions in the response.
   const handlesThatShouldBeMissing = [

--- a/test/functional/specs/Privacy/IAB/C224678.js
+++ b/test/functional/specs/Privacy/IAB/C224678.js
@@ -63,7 +63,7 @@ test("Test C224678: Passing a negative Consent in the sendEvent command", async 
   await t.expect(consentCookieValue).ok("No consent cookie found.");
   await t.expect(consentCookieValue).eql("general=out");
 
-  // 2. The ECID should not exist in the response payload as well, even if queried
+  // 2. The ECID should exist in the response payload as well, even if queried
   const identityHandle = response.getPayloadsByType("identity:result");
   await t.expect(identityHandle.length).eql(1);
 


### PR DESCRIPTION
The ECID should exist in the response payload as well, even if queriedAdd package lock.


## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
