### PR TITLE
Fixing the select with eq issue

### DIFF
--- a/src/components/Personalization/dom-actions/dom/selectNodesWithEq.js
+++ b/src/components/Personalization/dom-actions/dom/selectNodesWithEq.js
@@ -16,11 +16,6 @@ import { isNotEqSelector, splitWithEq } from "./helperForEq";
 
 // Trying to match ID or CSS class
 const CSS_IDENTIFIER_PATTERN = /(#|\.)(-?\w+)/g;
-// This is required to remove leading " > " from parsed pieces
-const SIBLING_PATTERN = /^\s*>?\s*/;
-
-const cleanUp = str => str.replace(SIBLING_PATTERN, "").trim();
-
 // Here we use CSS.escape() to make sure we get
 // correct values for ID and CSS class
 // Please check:  https://www.w3.org/TR/css-syntax-3/#escaping
@@ -39,7 +34,7 @@ export const parseSelector = rawSelector => {
   let i = 0;
 
   while (i < length) {
-    const sel = cleanUp(parts[i]);
+    const sel = parts[i];
     const eq = parts[i + 1];
 
     if (eq) {

--- a/src/utils/dom/querySelectorAll.js
+++ b/src/utils/dom/querySelectorAll.js
@@ -21,6 +21,8 @@ export default (context, selector) => {
 
   const tag = `alloy-${Date.now()}`;
 
+  // We could use a :scope selector here, but we want to be IE compliant
+  // so we add a dummy css class to be able to select the children
   try {
     context.classList.add(tag);
 

--- a/src/utils/dom/querySelectorAll.js
+++ b/src/utils/dom/querySelectorAll.js
@@ -19,15 +19,13 @@ export default (context, selector) => {
     return toArray(context.querySelectorAll(selector));
   }
 
-  const tag = `alloy${+new Date()}`;
+  const tag = `alloy-${Date.now()}`;
 
-  try { // adding a dummy css class to be able to select the children
-    context.classList.add(tag); // needs to be IE compliant
+  try {
+    context.classList.add(tag);
 
     return toArray(context.querySelectorAll(`.${tag} ${selector}`));
-  } catch (e) {
-    throw e;
   } finally {
-    context.classList.remove(tag); // needs to be IE compliant
+    context.classList.remove(tag);
   }
 };

--- a/src/utils/dom/querySelectorAll.js
+++ b/src/utils/dom/querySelectorAll.js
@@ -12,5 +12,22 @@ governing permissions and limitations under the License.
 
 import toArray from "../toArray";
 
-export default (context, selector) =>
-  toArray(context.querySelectorAll(selector));
+const SIBLING_PATTERN = /^\s*>/;
+
+export default (context, selector) => {
+  if (!SIBLING_PATTERN.test(selector)) {
+    return toArray(context.querySelectorAll(selector));
+  }
+
+  const tag = `alloy${+new Date()}`;
+
+  try { // adding a dummy css class to be able to select the children
+    context.classList.add(tag); // needs to be IE compliant
+
+    return toArray(context.querySelectorAll(`.${tag} ${selector}`));
+  } catch (e) {
+    throw e;
+  } finally {
+    context.classList.remove(tag); // needs to be IE compliant
+  }
+};

--- a/test/unit/specs/components/Personalization/dom-actions/dom/selectNodesWithEq.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/dom/selectNodesWithEq.spec.js
@@ -65,9 +65,9 @@ describe("Personalization::DOM::parseSelector", () => {
     );
 
     expect(result[0]).toEqual({ sel: "HTML > BODY > DIV.wrapper", eq: 0 });
-    expect(result[1]).toEqual({ sel: "HEADER.header", eq: 0 });
-    expect(result[2]).toEqual({ sel: "DIV.pagehead", eq: 0 });
-    expect(result[3]).toEqual({ sel: "P:nth-of-type(1)" });
+    expect(result[1]).toEqual({ sel: " > HEADER.header", eq: 0 });
+    expect(result[2]).toEqual({ sel: " > DIV.pagehead", eq: 0 });
+    expect(result[3]).toEqual({ sel: " > P:nth-of-type(1)" });
   });
 });
 

--- a/test/unit/specs/utils/dom/selectNodesWithShadow.spec.js
+++ b/test/unit/specs/utils/dom/selectNodesWithShadow.spec.js
@@ -136,4 +136,26 @@ describe("Utils::DOM::selectNodesWithShadow", () => {
     expect(result[0].tagName).toEqual("LABEL");
     expect(result[0].textContent).toEqual("Buy Now");
   });
+
+  it("should respect child selectors", () => {
+    const content = `
+      <div>
+        <div>
+          <span id="wrong"></span>
+        </div>
+        <span id="right"></span>
+      </div>
+    `;
+
+    const node = createNode("DIV", { id: "target" }, { innerHTML: content });
+
+    appendNode(document.body, node);
+
+    console.log("foo", document.body.outerHTML);
+
+    const result = selectNodesWithEq("#target > div:eq(0) > span");
+
+    expect(result[0].tagName).toEqual("SPAN");
+    expect(result[0].id).toEqual("right");
+  });
 });

--- a/test/unit/specs/utils/dom/selectNodesWithShadow.spec.js
+++ b/test/unit/specs/utils/dom/selectNodesWithShadow.spec.js
@@ -63,14 +63,16 @@ const defineCustomElements = () => {
 };
 
 describe("Utils::DOM::selectNodesWithShadow", () => {
+  const CLEANUP_CLASS = "cleanup";
+
   afterEach(() => {
-    selectNodes(".shadow").forEach(removeNode);
+    selectNodes(`.${CLEANUP_CLASS}`).forEach(removeNode);
   });
 
   it("should select when no shadow", () => {
     appendNode(
       document.body,
-      createNode("DIV", { id: "noShadow", class: "shadow" })
+      createNode("DIV", { id: "noShadow", class: CLEANUP_CLASS })
     );
 
     const result = selectNodes("#noShadow");
@@ -95,7 +97,11 @@ describe("Utils::DOM::selectNodesWithShadow", () => {
 
     appendNode(
       document.body,
-      createNode("DIV", { id: "abc", class: "shadow" }, { innerHTML: content })
+      createNode(
+        "DIV",
+        { id: "abc", class: CLEANUP_CLASS },
+        { innerHTML: content }
+      )
     );
 
     const result = selectNodesWithEq(
@@ -126,7 +132,11 @@ describe("Utils::DOM::selectNodesWithShadow", () => {
 
     appendNode(
       document.body,
-      createNode("DIV", { id: "abc", class: "shadow" }, { innerHTML: content })
+      createNode(
+        "DIV",
+        { id: "abc", class: CLEANUP_CLASS },
+        { innerHTML: content }
+      )
     );
 
     const result = selectNodesWithEq(
@@ -147,7 +157,11 @@ describe("Utils::DOM::selectNodesWithShadow", () => {
       </div>
     `;
 
-    const node = createNode("DIV", { id: "target" }, { innerHTML: content });
+    const node = createNode(
+      "DIV",
+      { id: "target", class: CLEANUP_CLASS },
+      { innerHTML: content }
+    );
 
     appendNode(document.body, node);
 

--- a/test/unit/specs/utils/dom/selectNodesWithShadow.spec.js
+++ b/test/unit/specs/utils/dom/selectNodesWithShadow.spec.js
@@ -151,8 +151,6 @@ describe("Utils::DOM::selectNodesWithShadow", () => {
 
     appendNode(document.body, node);
 
-    console.log("foo", document.body.outerHTML);
-
     const result = selectNodesWithEq("#target > div:eq(0) > span");
 
     expect(result[0].tagName).toEqual("SPAN");


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->

<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description
This is a draft PR for the issue opened by @paul-bjorkstrand. 

In At.js we are using Zepto to query DOM. In Web SDK we have partially transferred the functionality and have introduced a bug. Currently Web SDK doesn't correctly select children if `eq()` pseudo selector is involved. 
I have looked into Zepto library and I have followed the same approach.

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/adobe/alloy/issues/850
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
