### PR TITLE
Fixed an issue where multiple persistent iframes were created for id syncs and segment destinations

### DIFF
--- a/src/utils/injectFireReferrerHideableImage.js
+++ b/src/utils/injectFireReferrerHideableImage.js
@@ -14,12 +14,14 @@ import fireImageInDocument from "./fireImage";
 import {
   appendNode as appendNodeToDocument,
   awaitSelector as awaitSelectorInDocument,
-  createNode as createNodeInDocument
+  createNode as createNodeInDocument,
+  querySelectorAll as querySelectorAllInDocument
 } from "./dom";
 import { BODY, IFRAME } from "../constants/tagName";
 
 const IFRAME_ATTRS = {
-  name: "Adobe Alloy"
+  name: "Adobe Alloy",
+  id: "alloy-sync-frame"
 };
 
 const IFRAME_PROPS = {
@@ -34,7 +36,8 @@ export default ({
   appendNode = appendNodeToDocument,
   awaitSelector = awaitSelectorInDocument,
   createNode = createNodeInDocument,
-  fireImage = fireImageInDocument
+  fireImage = fireImageInDocument,
+  querySelectorAll = querySelectorAllInDocument
 } = {}) => {
   const fireOnPage = fireImage;
 
@@ -42,6 +45,13 @@ export default ({
 
   const createIframe = () => {
     if (hiddenIframe) {
+      return Promise.resolve(hiddenIframe);
+    }
+    const potentialHiddenFrames = querySelectorAll(
+      `iframe#${IFRAME_ATTRS.id}}`
+    );
+    if (potentialHiddenFrames.length > 0) {
+      hiddenIframe = potentialHiddenFrames[0];
       return Promise.resolve(hiddenIframe);
     }
     return awaitSelector(BODY).then(([body]) => {

--- a/src/utils/injectFireReferrerHideableImage.js
+++ b/src/utils/injectFireReferrerHideableImage.js
@@ -15,7 +15,7 @@ import {
   appendNode as appendNodeToDocument,
   awaitSelector as awaitSelectorInDocument,
   createNode as createNodeInDocument,
-  querySelectorAll as querySelectorAllInDocument
+  selectNodes as selectNodesInDocument
 } from "./dom";
 import { BODY, IFRAME } from "../constants/tagName";
 
@@ -37,7 +37,7 @@ export default ({
   awaitSelector = awaitSelectorInDocument,
   createNode = createNodeInDocument,
   fireImage = fireImageInDocument,
-  querySelectorAll = querySelectorAllInDocument
+  selectNodes = selectNodesInDocument
 } = {}) => {
   const fireOnPage = fireImage;
 
@@ -47,9 +47,7 @@ export default ({
     if (hiddenIframe) {
       return Promise.resolve(hiddenIframe);
     }
-    const potentialHiddenFrames = querySelectorAll(
-      `iframe#${IFRAME_ATTRS.id}}`
-    );
+    const potentialHiddenFrames = selectNodes(`#${IFRAME_ATTRS.id}`);
     if (potentialHiddenFrames.length > 0) {
       hiddenIframe = potentialHiddenFrames[0];
       return Promise.resolve(hiddenIframe);

--- a/src/utils/injectFireReferrerHideableImage.js
+++ b/src/utils/injectFireReferrerHideableImage.js
@@ -14,14 +14,12 @@ import fireImageInDocument from "./fireImage";
 import {
   appendNode as appendNodeToDocument,
   awaitSelector as awaitSelectorInDocument,
-  createNode as createNodeInDocument,
-  selectNodes as selectNodesInDocument
+  createNode as createNodeInDocument
 } from "./dom";
 import { BODY, IFRAME } from "../constants/tagName";
 
 const IFRAME_ATTRS = {
-  name: "Adobe Alloy",
-  id: "alloy-sync-frame"
+  name: "Adobe Alloy"
 };
 
 const IFRAME_PROPS = {
@@ -36,23 +34,17 @@ export default ({
   appendNode = appendNodeToDocument,
   awaitSelector = awaitSelectorInDocument,
   createNode = createNodeInDocument,
-  fireImage = fireImageInDocument,
-  selectNodes = selectNodesInDocument
+  fireImage = fireImageInDocument
 } = {}) => {
   const fireOnPage = fireImage;
 
   let hiddenIframe;
 
   const createIframe = () => {
-    if (hiddenIframe) {
-      return Promise.resolve(hiddenIframe);
-    }
-    const potentialHiddenFrames = selectNodes(`#${IFRAME_ATTRS.id}`);
-    if (potentialHiddenFrames.length > 0) {
-      hiddenIframe = potentialHiddenFrames[0];
-      return Promise.resolve(hiddenIframe);
-    }
     return awaitSelector(BODY).then(([body]) => {
+      if (hiddenIframe) {
+        return hiddenIframe;
+      }
       hiddenIframe = createNode(IFRAME, IFRAME_ATTRS, IFRAME_PROPS);
       return appendNode(body, hiddenIframe);
     });

--- a/test/unit/specs/utils/injectFireReferrerHideableImage.spec.js
+++ b/test/unit/specs/utils/injectFireReferrerHideableImage.spec.js
@@ -17,6 +17,7 @@ describe("injectFireReferrerHideableImage", () => {
   let awaitSelectorMock;
   let createNodeMock;
   let fireImageMock;
+  let querySelectorAllMock;
   let fireReferrerHideableImage;
 
   beforeEach(() => {
@@ -32,11 +33,15 @@ describe("injectFireReferrerHideableImage", () => {
     fireImageMock = jasmine
       .createSpy("fireImage")
       .and.callFake(() => Promise.resolve());
+    querySelectorAllMock = jasmine
+      .createSpy("querySelectorAll")
+      .and.callFake(() => Promise.resolve([]));
     fireReferrerHideableImage = injectFireReferrerHideableImage({
       appendNode: appendNodeMock,
       awaitSelector: awaitSelectorMock,
       createNode: createNodeMock,
-      fireImage: fireImageMock
+      fireImage: fireImageMock,
+      querySelectorAll: querySelectorAllMock
     });
   });
 

--- a/test/unit/specs/utils/injectFireReferrerHideableImage.spec.js
+++ b/test/unit/specs/utils/injectFireReferrerHideableImage.spec.js
@@ -17,7 +17,7 @@ describe("injectFireReferrerHideableImage", () => {
   let awaitSelectorMock;
   let createNodeMock;
   let fireImageMock;
-  let querySelectorAllMock;
+  let selectNodesMock;
   let fireReferrerHideableImage;
 
   beforeEach(() => {
@@ -33,15 +33,15 @@ describe("injectFireReferrerHideableImage", () => {
     fireImageMock = jasmine
       .createSpy("fireImage")
       .and.callFake(() => Promise.resolve());
-    querySelectorAllMock = jasmine
-      .createSpy("querySelectorAll")
+    selectNodesMock = jasmine
+      .createSpy("selectNodes")
       .and.callFake(() => Promise.resolve([]));
     fireReferrerHideableImage = injectFireReferrerHideableImage({
       appendNode: appendNodeMock,
       awaitSelector: awaitSelectorMock,
       createNode: createNodeMock,
       fireImage: fireImageMock,
-      querySelectorAll: querySelectorAllMock
+      selectNodes: selectNodesMock
     });
   });
 

--- a/test/unit/specs/utils/injectFireReferrerHideableImage.spec.js
+++ b/test/unit/specs/utils/injectFireReferrerHideableImage.spec.js
@@ -17,7 +17,6 @@ describe("injectFireReferrerHideableImage", () => {
   let awaitSelectorMock;
   let createNodeMock;
   let fireImageMock;
-  let selectNodesMock;
   let fireReferrerHideableImage;
 
   beforeEach(() => {
@@ -33,15 +32,11 @@ describe("injectFireReferrerHideableImage", () => {
     fireImageMock = jasmine
       .createSpy("fireImage")
       .and.callFake(() => Promise.resolve());
-    selectNodesMock = jasmine
-      .createSpy("selectNodes")
-      .and.callFake(() => Promise.resolve([]));
     fireReferrerHideableImage = injectFireReferrerHideableImage({
       appendNode: appendNodeMock,
       awaitSelector: awaitSelectorMock,
       createNode: createNodeMock,
-      fireImage: fireImageMock,
-      selectNodes: selectNodesMock
+      fireImage: fireImageMock
     });
   });
 


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

When firing off a referrer-hideable image for destinations and ID syncs, if there is not an `iframe` in memory, look in the `document` for one before creating a new one.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[PDCL-8050 comment from Ian Ramsey](https://jira.corp.adobe.com/browse/PDCL-8050?focusedCommentId=30000443&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-30000443). 

Version 2.10.0 and PR #848 was supposed to restrict the Web SDK from creating one `iframe` per ID sync/segment destination, but the customer deployed it to [their beta site](https://beta-sports.bwin.com/en/sports) (connect from a UK VPN location) and the issue was still there–many `iframe[name="Adobe Alloy"]` elements appeared.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

I am at a loss for why #848 did not solve the issue, but here we are.

## Screenshots (if appropriate):
<details>
    <summary>Screenshot of persistent issue on 2.10.0</summary>
    <img src="https://user-images.githubusercontent.com/18412686/165352168-d9df3699-26d3-401c-a708-8e3a7d64c66e.png" alt="Screenshot of persistent issue on 2.10.0" >
</details>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
