### PR TITLE
TNT-44322 TNT-44442 Support AJO surfaces and propositions

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -30,7 +30,7 @@
       !function(n,o){o.forEach(function(o){n[o]||((n.__alloyNS=n.__alloyNS||
       []).push(o),n[o]=function(){var u=arguments;return new Promise(
       function(i,l){n[o].q.push([i,l,u])})},n[o].q=[])})}
-      (window,["alloy", "organizationTwo"]);
+      (window,["alloy", "organizationTwo", "cjmStage"]);
     </script>
 
     <script nonce="%REACT_APP_NONCE%">
@@ -135,6 +135,18 @@
             });
           }
         }
+      });
+
+      // For AJO testing in Stage.
+      // We use a different orgId and edgeConfigId.
+      cjmStage("configure", {
+        edgeDomain: "edge-int.adobedc.net",
+        edgeConfigId: "19fc5fe9-37df-46da-8f5c-9eeff4f75ed9:prod",
+        orgId: "745F37C35E4B776E0A49421B@AdobeOrg",
+        edgeBasePath: "ee",
+        thirdPartyCookiesEnabled: false,
+        debugEnabled: true,
+        clickCollectionEnabled: false
       });
     </script>
   </head>

--- a/sandbox/public/perf/personalization.html
+++ b/sandbox/public/perf/personalization.html
@@ -34,7 +34,7 @@
       const onSendEvent = () => {
         alloy("sendEvent", {
           renderDecisions: true,
-          decisionScopes: ["alloy-location-1", "alloy-location-2"],
+          decisionScopes: ["alloy-location-1", "alloy-location-2"], // Note: this option will soon be deprecated, please use personalization.decisionScopes instead
           xdm: {
             device: {
               screenHeight: 1

--- a/sandbox/src/App.js
+++ b/sandbox/src/App.js
@@ -17,6 +17,7 @@ import Home from "./Home";
 import Consent from "./Consent";
 import Personalization from "./Personalization";
 import PersonalizationSpa from "./PersonalizationSpa";
+import PersonalizationAjo from "./PersonalizationAjo";
 import PersonalizationProfile from "./PersonalizationProfile";
 import Links from "./Links";
 import EventMerge from "./EventMerge";
@@ -47,6 +48,9 @@ function BasicExample() {
             </li>
             <li>
               <Link to="/personalizationSpa">Personalization - SPA</Link>
+            </li>
+            <li>
+              <Link to="/personalizationAjo">Personalization - AJO</Link>
             </li>
             <li>
               <Link to="/personalizationA4TClientSide">
@@ -95,6 +99,7 @@ function BasicExample() {
           <Route path="/consent" component={Consent} />
           <Route path="/personalization" component={Personalization} />
           <Route path="/personalizationSpa" component={PersonalizationSpa} />
+          <Route path="/personalizationAjo" component={PersonalizationAjo} />
           <Route
             path="/personalizationA4TClientSide"
             component={PersonalizationAnalyticsClientSide}

--- a/sandbox/src/PersonalizationAjo.js
+++ b/sandbox/src/PersonalizationAjo.js
@@ -1,0 +1,26 @@
+import React from "react";
+import ContentSecurityPolicy from "./components/ContentSecurityPolicy";
+import useSendPageViewEvent from "./useSendPageViewEvent";
+
+export default function PersonalizationAjo() {
+  useSendPageViewEvent({ instanceName: "cjmStage" });
+  return (
+    <div>
+      <ContentSecurityPolicy />
+      <h1>AJO Personalization</h1>
+      <p>
+        This page tests rendering of activities using an AJO surface. If you
+        navigated here from another sandbox view, you will probably need to
+        refresh your browser because this is how to properly simulate a non-SPA
+        workflow.
+      </p>
+      <div
+        style={{ border: "1px solid red" }}
+        className="personalization-container-ajo"
+      >
+        This is the AJO personalization placeholder. Personalized content has
+        not been loaded.
+      </div>
+    </div>
+  );
+}

--- a/sandbox/src/PersonalizationFormBased.js
+++ b/sandbox/src/PersonalizationFormBased.js
@@ -13,7 +13,10 @@ const metadata = {
 
 const usePropositions = () => {
   const [propositions, setPropositions] = useState(undefined);
-  useSendPageViewEvent({ setPropositions, decisionScopes: SCOPES_FOR_PAGE });
+  useSendPageViewEvent({
+    setPropositions,
+    decisionScopes: SCOPES_FOR_PAGE // Note: this option will soon be deprecated, please use personalization.decisionScopes instead
+  });
   useEffect(() => {
     if (propositions) {
       window.alloy("applyPropositions", {

--- a/sandbox/src/personalizationAnalyticsClientSideHelper.js
+++ b/sandbox/src/personalizationAnalyticsClientSideHelper.js
@@ -63,7 +63,7 @@ const sendEvent = ({
 
   return window[instanceName]("sendEvent", {
     renderDecisions,
-    decisionScopes,
+    decisionScopes, // Note: this option will soon be deprecated, please use personalization.decisionScopes instead
     xdm
   });
 };
@@ -71,7 +71,7 @@ const sendEvent = ({
 export const getFormBasedOffer = () => {
   sendEvent({
     eventType: "form-based-offer",
-    decisionScopes: ["a4t-test"]
+    decisionScopes: ["a4t-test"] // Note: this option will soon be deprecated, please use personalization.decisionScopes instead
   }).then(result => {
     if (!result.propositions) {
       return;

--- a/sandbox/src/useSendPageViewEvent.js
+++ b/sandbox/src/useSendPageViewEvent.js
@@ -35,7 +35,7 @@ export default ({
 
     window[instanceName]("sendEvent", {
       renderDecisions: true,
-      decisionScopes,
+      decisionScopes, // Note: this option will soon be deprecated, please use personalization.decisionScopes instead
       xdm,
       data
     }).then(res => {

--- a/src/components/DataCollector/index.js
+++ b/src/components/DataCollector/index.js
@@ -29,7 +29,8 @@ const createDataCollector = ({ eventManager }) => {
             type,
             mergeId,
             renderDecisions = false,
-            decisionScopes = [],
+            decisionScopes = [], // Note: this option will soon be deprecated, please use personalization.decisionScopes instead
+            personalization = {},
             datasetId
           } = options;
           const event = eventManager.createEvent();
@@ -63,7 +64,8 @@ const createDataCollector = ({ eventManager }) => {
 
           return eventManager.sendEvent(event, {
             renderDecisions,
-            decisionScopes
+            decisionScopes,
+            personalization
           });
         }
       },

--- a/src/components/DataCollector/validateUserEventOptions.js
+++ b/src/components/DataCollector/validateUserEventOptions.js
@@ -28,6 +28,10 @@ export default ({ options }) => {
     documentUnloading: boolean(),
     renderDecisions: boolean(),
     decisionScopes: arrayOf(string()).uniqueItems(),
+    personalization: objectOf({
+      decisionScopes: arrayOf(string()).uniqueItems(),
+      surfaces: arrayOf(string()).uniqueItems()
+    }),
     datasetId: string(),
     mergeId: string()
   })

--- a/src/components/Personalization/constants/surface.js
+++ b/src/components/Personalization/constants/surface.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Adobe. All rights reserved.
+Copyright 2022 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,9 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-/**
- * Returns true when the value is null.
- * @param {*} value
- * @returns {boolean}
- */
-export default value => value == null;
+export const WEB = "web";
+export const WEBAPP = "webapp";
+export const SURFACE_TYPE_DELIMITER = "://";
+export const FRAGMENT_DELIMITER = "#";

--- a/src/components/Personalization/createComponent.js
+++ b/src/components/Personalization/createComponent.js
@@ -16,6 +16,7 @@ import { AUTHORING_ENABLED } from "./constants/loggerMessage";
 import validateApplyPropositionsOptions from "./validateApplyPropositionsOptions";
 
 export default ({
+  getPageLocation,
   logger,
   fetchDataHandler,
   viewChangeHandler,
@@ -37,6 +38,7 @@ export default ({
         event,
         renderDecisions,
         decisionScopes = [],
+        personalization = {},
         onResponse = noop,
         onRequestFailure = noop
       }) {
@@ -53,10 +55,13 @@ export default ({
         }
 
         const personalizationDetails = createPersonalizationDetails({
+          getPageLocation,
           renderDecisions,
           decisionScopes,
+          personalization,
           event,
-          viewCache
+          viewCache,
+          logger
         });
 
         if (personalizationDetails.shouldFetchData()) {

--- a/src/components/Personalization/createGetPageLocation.js
+++ b/src/components/Personalization/createGetPageLocation.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Adobe. All rights reserved.
+Copyright 2022 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,9 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-/**
- * Returns true when the value is null.
- * @param {*} value
- * @returns {boolean}
- */
-export default value => value == null;
+export default ({ window }) => () => {
+  return window.location;
+};

--- a/src/components/Personalization/createPersonalizationDetails.js
+++ b/src/components/Personalization/createPersonalizationDetails.js
@@ -10,7 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { includes } from "../../utils";
+import { includes, isNonEmptyString, isNonEmptyArray } from "../../utils";
+import { buildPageSurface, normalizeSurfaces } from "./utils/surfaceUtils";
 import PAGE_WIDE_SCOPE from "./constants/scope";
 import {
   DEFAULT_CONTENT_ITEM,
@@ -19,9 +20,29 @@ import {
   JSON_CONTENT_ITEM,
   REDIRECT_ITEM
 } from "./constants/schema";
-import isNonEmptyString from "../../utils/isNonEmptyString";
 
-export default ({ renderDecisions, decisionScopes, event, viewCache }) => {
+const addPageWideScope = scopes => {
+  if (!includes(scopes, PAGE_WIDE_SCOPE)) {
+    scopes.push(PAGE_WIDE_SCOPE);
+  }
+};
+
+const addPageSurface = (surfaces, getPageLocation) => {
+  const pageSurface = buildPageSurface(getPageLocation);
+  if (!includes(surfaces, pageSurface)) {
+    surfaces.push(pageSurface);
+  }
+};
+
+export default ({
+  getPageLocation,
+  renderDecisions,
+  decisionScopes,
+  personalization,
+  event,
+  viewCache,
+  logger
+}) => {
   const viewName = event.getViewName();
   return {
     isRenderDecisions() {
@@ -31,15 +52,31 @@ export default ({ renderDecisions, decisionScopes, event, viewCache }) => {
       return viewName;
     },
     hasScopes() {
-      return decisionScopes.length > 0;
+      return (
+        decisionScopes.length > 0 ||
+        isNonEmptyArray(personalization.decisionScopes)
+      );
+    },
+    hasSurfaces() {
+      return isNonEmptyArray(personalization.surfaces);
     },
     hasViewName() {
       return isNonEmptyString(viewName);
     },
     createQueryDetails() {
       const scopes = [...decisionScopes];
-      if (!this.isCacheInitialized() && !includes(scopes, PAGE_WIDE_SCOPE)) {
-        scopes.push(PAGE_WIDE_SCOPE);
+      if (isNonEmptyArray(personalization.decisionScopes)) {
+        scopes.push(...personalization.decisionScopes);
+      }
+      const eventSurfaces = normalizeSurfaces(
+        personalization.surfaces,
+        getPageLocation,
+        logger
+      );
+
+      if (!this.isCacheInitialized()) {
+        addPageWideScope(scopes);
+        addPageSurface(eventSurfaces, getPageLocation);
       }
 
       const schemas = [
@@ -55,14 +92,17 @@ export default ({ renderDecisions, decisionScopes, event, viewCache }) => {
 
       return {
         schemas,
-        decisionScopes: scopes
+        decisionScopes: [...new Set(scopes)],
+        surfaces: [...new Set(eventSurfaces)]
       };
     },
     isCacheInitialized() {
       return viewCache.isInitialized();
     },
     shouldFetchData() {
-      return this.hasScopes() || !this.isCacheInitialized();
+      return (
+        this.hasScopes() || this.hasSurfaces() || !this.isCacheInitialized()
+      );
     },
     shouldUseCachedData() {
       return this.hasViewName() && this.isCacheInitialized();

--- a/src/components/Personalization/groupDecisions.js
+++ b/src/components/Personalization/groupDecisions.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import { isNonEmptyArray, includes } from "../../utils";
+import isPageWideScope from "./utils/isPageWideScope";
 import {
   DOM_ACTION,
   REDIRECT_ITEM,
@@ -18,7 +19,6 @@ import {
   MEASUREMENT_SCHEMA
 } from "./constants/schema";
 import { VIEW_SCOPE_TYPE } from "./constants/scopeType";
-import PAGE_WIDE_SCOPE from "./constants/scope";
 
 const splitItems = (items, schemas) => {
   const matched = [];
@@ -93,7 +93,7 @@ const extractDecisionsByScope = decisions => {
 
   if (isNonEmptyArray(decisions)) {
     decisions.forEach(decision => {
-      if (decision.scope === PAGE_WIDE_SCOPE) {
+      if (isPageWideScope(decision.scope)) {
         pageWideScopeDecisions.push(decision);
       } else if (isViewScope(decision.scopeDetails)) {
         appendScopeDecision(viewScopeDecisions, decision);

--- a/src/components/Personalization/index.js
+++ b/src/components/Personalization/index.js
@@ -30,6 +30,7 @@ import createRedirectHandler from "./createRedirectHandler";
 import createAutorenderingHandler from "./createAutoRenderingHandler";
 import createNonRenderingHandler from "./createNonRenderingHandler";
 import createApplyPropositions from "./createApplyPropositions";
+import createGetPageLocation from "./createGetPageLocation";
 import createSetTargetMigration from "./createSetTargetMigration";
 
 const createPersonalization = ({ config, logger, eventManager }) => {
@@ -41,6 +42,7 @@ const createPersonalization = ({ config, logger, eventManager }) => {
     getClickSelectors,
     storeClickMetrics
   } = createClickStorage();
+  const getPageLocation = createGetPageLocation({ window });
   const viewCache = createViewCacheManager();
   const modules = initDomActionsModules(storeClickMetrics);
   const executeDecisions = createExecuteDecisions({
@@ -54,7 +56,6 @@ const createPersonalization = ({ config, logger, eventManager }) => {
     logger,
     showContainers
   });
-
   const autoRenderingHandler = createAutorenderingHandler({
     viewCache,
     executeDecisions,
@@ -94,6 +95,7 @@ const createPersonalization = ({ config, logger, eventManager }) => {
     targetMigrationEnabled
   });
   return createComponent({
+    getPageLocation,
     logger,
     fetchDataHandler,
     viewChangeHandler,

--- a/src/components/Personalization/utils/isPageWideScope.js
+++ b/src/components/Personalization/utils/isPageWideScope.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Adobe. All rights reserved.
+Copyright 2022 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,9 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-/**
- * Returns true when the value is null.
- * @param {*} value
- * @returns {boolean}
- */
-export default value => value == null;
+import { isPageWideSurface } from "./surfaceUtils";
+import PAGE_WIDE_SCOPE from "../constants/scope";
+
+export default scope => scope === PAGE_WIDE_SCOPE || isPageWideSurface(scope);

--- a/src/components/Personalization/utils/surfaceUtils.js
+++ b/src/components/Personalization/utils/surfaceUtils.js
@@ -1,0 +1,118 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+  WEB,
+  WEBAPP,
+  SURFACE_TYPE_DELIMITER,
+  FRAGMENT_DELIMITER
+} from "../constants/surface";
+import { startsWith, isNil, isNonEmptyString, includes } from "../../../utils";
+
+const SURFACE_REGEX = /^(\w+):\/\/([^/#]+)(\/[^#]*)?(#.*)?$/;
+const AUTHORITY_REGEX = /^(?:.*@)?(?:[a-z\d\u00a1-\uffff.-]+|\[[a-f\d:]+])(?::\d+)?$/;
+const PATH_REGEX = /^\/(?:[/\w\u00a1-\uffff-.~]|%[a-fA-F\d]{2})*$/;
+const FRAGMENT_REGEX = /^#(?:[/\w\u00a1-\uffff-.~]|%[a-fA-F\d]{2})+$/;
+
+const normalizePath = (path = "/") => {
+  let end = path.length;
+  while (end > 0 && "/".indexOf(path.charAt(end - 1)) !== -1) {
+    end -= 1;
+  }
+  return path.substring(0, end) || "/";
+};
+
+const getSurfaceType = surfaceTypeMatch =>
+  isNonEmptyString(surfaceTypeMatch) ? surfaceTypeMatch.toLowerCase() : "";
+
+const getAuthority = authorityMatch =>
+  isNonEmptyString(authorityMatch) ? authorityMatch.toLowerCase() : "";
+
+const getPath = pathMatch =>
+  isNonEmptyString(pathMatch) ? normalizePath(pathMatch) : "/";
+
+const parseSurface = surfaceString => {
+  const matched = surfaceString.match(SURFACE_REGEX);
+  return matched
+    ? {
+        surfaceType: getSurfaceType(matched[1]),
+        authority: getAuthority(matched[2]),
+        path: getPath(matched[3]),
+        fragment: matched[4]
+      }
+    : null;
+};
+
+const stringifySurface = surface =>
+  `${surface.surfaceType}${SURFACE_TYPE_DELIMITER}${
+    surface.authority
+  }${surface.path || ""}${surface.fragment || ""}`;
+
+export const buildPageSurface = getPageLocation => {
+  const location = getPageLocation();
+  const host = location.host.toLowerCase();
+  const path = location.pathname;
+  return WEB + SURFACE_TYPE_DELIMITER + host + normalizePath(path);
+};
+
+const expandFragmentSurface = (surface, getPageLocation) =>
+  startsWith(surface, FRAGMENT_DELIMITER)
+    ? buildPageSurface(getPageLocation) + surface
+    : surface;
+
+const validateSurface = (surface, getPageLocation, logger) => {
+  const invalidateSurface = validationError => {
+    logger.warn(validationError);
+    return null;
+  };
+
+  if (!isNonEmptyString(surface)) {
+    return invalidateSurface(`Invalid surface: ${surface}`);
+  }
+  const expanded = expandFragmentSurface(surface, getPageLocation);
+  const parsed = parseSurface(expanded);
+  if (parsed === null) {
+    return invalidateSurface(`Invalid surface: ${surface}`);
+  }
+  if (!includes([WEB, WEBAPP], parsed.surfaceType)) {
+    return invalidateSurface(
+      `Unsupported surface type ${parsed.surfaceType} in surface: ${surface}`
+    );
+  }
+  if (!parsed.authority || !AUTHORITY_REGEX.test(parsed.authority)) {
+    return invalidateSurface(
+      `Invalid authority ${parsed.authority} in surface: ${surface}`
+    );
+  }
+  if (parsed.path && !PATH_REGEX.test(parsed.path)) {
+    return invalidateSurface(
+      `Invalid path ${parsed.path} in surface: ${surface}`
+    );
+  }
+  if (parsed.fragment && !FRAGMENT_REGEX.test(parsed.fragment)) {
+    return invalidateSurface(
+      `Invalid fragment ${parsed.fragment} in surface: ${surface}`
+    );
+  }
+  return parsed;
+};
+
+export const isPageWideSurface = scope =>
+  !!scope &&
+  scope.indexOf(WEB + SURFACE_TYPE_DELIMITER) === 0 &&
+  scope.indexOf(FRAGMENT_DELIMITER) === -1;
+
+export const normalizeSurfaces = (surfaces = [], getPageLocation, logger) =>
+  surfaces
+    .map(surface => validateSurface(surface, getPageLocation, logger))
+    .filter(surface => !isNil(surface))
+    .map(stringifySurface);

--- a/src/core/createEventManager.js
+++ b/src/core/createEventManager.js
@@ -38,14 +38,20 @@ export default ({
      * the request payload.
      * @param {Object} [options]
      * @param {boolean} [options.renderDecisions=false]
-     * @param {Array} [options.decisionScopes]
+     * @param {Array} [options.decisionScopes] Note: this option will soon
+     * be deprecated, please use *personalization.decisionScopes* instead
+     * @param {Object} [options.personalization]
      * @param {Object} [options.serverState]
      * This will be passed to components
      * so they can take appropriate action.
      * @returns {*}
      */
     sendEvent(event, options = {}) {
-      const { renderDecisions = false, decisionScopes } = options;
+      const {
+        renderDecisions = false,
+        decisionScopes,
+        personalization
+      } = options;
       const payload = createDataCollectionRequestPayload();
       const request = createDataCollectionRequest(payload);
       const onResponseCallbackAggregator = createCallbackAggregator();
@@ -56,6 +62,7 @@ export default ({
           event,
           renderDecisions,
           decisionScopes,
+          personalization,
           onResponse: onResponseCallbackAggregator.add,
           onRequestFailure: onRequestFailureCallbackAggregator.add
         })
@@ -114,6 +121,7 @@ export default ({
           event,
           renderDecisions,
           decisionScopes: [],
+          personalization: {},
           onResponse: onResponseCallbackAggregator.add,
           onRequestFailure: noop
         })

--- a/test/functional/specs/Personalization/C7494472.js
+++ b/test/functional/specs/Personalization/C7494472.js
@@ -1,0 +1,116 @@
+import { ClientFunction, t } from "testcafe";
+import createNetworkLogger from "../../helpers/networkLogger";
+import { responseStatus } from "../../helpers/assertions/index";
+import createFixture from "../../helpers/createFixture";
+import {
+  compose,
+  orgMainConfigMain,
+  debugEnabled
+} from "../../helpers/constants/configParts";
+import getResponseBody from "../../helpers/networkLogger/getResponseBody";
+import createResponse from "../../helpers/createResponse";
+import { TEST_PAGE as TEST_PAGE_URL } from "../../helpers/constants/url";
+import createAlloyProxy from "../../helpers/createAlloyProxy";
+
+const PAGE_WIDE_SCOPE = "__view__";
+const AJO_TEST_SURFACE = "web://alloyio.com/functional-test/testPage.html";
+
+const networkLogger = createNetworkLogger();
+const cjmStageOrgConfig = {
+  edgeDomain: "edge-int.adobedc.net",
+  edgeConfigId: "19fc5fe9-37df-46da-8f5c-9eeff4f75ed9:prod",
+  orgId: "745F37C35E4B776E0A49421B@AdobeOrg",
+  edgeBasePath: "ee",
+  thirdPartyCookiesEnabled: false
+};
+const config = compose(orgMainConfigMain, cjmStageOrgConfig, debugEnabled);
+
+createFixture({
+  title: "C7494472: AJO offers should be delivered",
+  url: `${TEST_PAGE_URL}?test=C7494472`,
+  requestHooks: [networkLogger.edgeEndpointLogs]
+});
+
+test.meta({
+  ID: "C7494472",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+
+const extractDecisionsMeta = payload => {
+  return payload.map(decision => {
+    const { id, scope, scopeDetails } = decision;
+    return { id, scope, scopeDetails };
+  });
+};
+
+const getHeaderTextContent = ClientFunction(
+  () => document.querySelectorAll("body > h1")[0].innerText
+);
+
+test("Test C7494472: AJO offers should be delivered", async () => {
+  const alloy = createAlloyProxy();
+  await alloy.configure(config);
+  const eventResult = await alloy.sendEvent({ renderDecisions: true });
+
+  await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
+
+  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(2);
+
+  const sendEventRequest = networkLogger.edgeEndpointLogs.requests[0];
+  const requestBody = JSON.parse(sendEventRequest.request.body);
+  const personalizationSchemas =
+    requestBody.events[0].query.personalization.schemas;
+
+  await t
+    .expect(requestBody.events[0].query.personalization.decisionScopes)
+    .eql([PAGE_WIDE_SCOPE]);
+
+  await t
+    .expect(requestBody.events[0].query.personalization.surfaces)
+    .eql([AJO_TEST_SURFACE]);
+
+  const result = [
+    "https://ns.adobe.com/personalization/default-content-item",
+    "https://ns.adobe.com/personalization/dom-action",
+    "https://ns.adobe.com/personalization/html-content-item",
+    "https://ns.adobe.com/personalization/json-content-item",
+    "https://ns.adobe.com/personalization/redirect-item"
+  ].every(schema => personalizationSchemas.includes(schema));
+
+  await t.expect(result).eql(true);
+
+  const response = JSON.parse(
+    getResponseBody(networkLogger.edgeEndpointLogs.requests[0])
+  );
+  const personalizationPayload = createResponse({
+    content: response
+  }).getPayloadsByType("personalization:decisions");
+
+  await t.expect(personalizationPayload[0].scope).eql(AJO_TEST_SURFACE);
+  await t.expect(personalizationPayload[0].items.length).eql(1);
+  await t
+    .expect(personalizationPayload[0].items[0].data.content)
+    .eql("Welcome AJO!");
+
+  await t.expect(getHeaderTextContent()).eql("Welcome AJO!");
+
+  await t.expect(eventResult.propositions[0].renderAttempted).eql(true);
+
+  const notificationPayload = extractDecisionsMeta(personalizationPayload);
+
+  const sendNotificationRequest = networkLogger.edgeEndpointLogs.requests[1];
+  const notificationRequestBody = JSON.parse(
+    sendNotificationRequest.request.body
+  );
+
+  await t
+    .expect(notificationRequestBody.events[0].xdm.eventType)
+    .eql("decisioning.propositionDisplay");
+  await t
+    .expect(
+      // eslint-disable-next-line no-underscore-dangle
+      notificationRequestBody.events[0].xdm._experience.decisioning.propositions
+    )
+    .eql(notificationPayload);
+});

--- a/test/functional/specs/Personalization/C7638574.js
+++ b/test/functional/specs/Personalization/C7638574.js
@@ -1,0 +1,90 @@
+import { t } from "testcafe";
+import createNetworkLogger from "../../helpers/networkLogger";
+import { responseStatus } from "../../helpers/assertions/index";
+import createFixture from "../../helpers/createFixture";
+import {
+  compose,
+  orgMainConfigMain,
+  debugEnabled
+} from "../../helpers/constants/configParts";
+import getResponseBody from "../../helpers/networkLogger/getResponseBody";
+import createResponse from "../../helpers/createResponse";
+import { TEST_PAGE as TEST_PAGE_URL } from "../../helpers/constants/url";
+import createAlloyProxy from "../../helpers/createAlloyProxy";
+
+const PAGE_WIDE_SCOPE = "__view__";
+const AJO_TEST_SURFACE = "web://alloyio.com/personalizationAjo";
+
+const networkLogger = createNetworkLogger();
+const cjmStageOrgConfig = {
+  edgeDomain: "edge-int.adobedc.net",
+  edgeConfigId: "19fc5fe9-37df-46da-8f5c-9eeff4f75ed9:prod",
+  orgId: "745F37C35E4B776E0A49421B@AdobeOrg",
+  edgeBasePath: "ee",
+  thirdPartyCookiesEnabled: false
+};
+const config = compose(orgMainConfigMain, cjmStageOrgConfig, debugEnabled);
+
+createFixture({
+  title: "C7638574: AJO offers for custom surface are delivered",
+  url: `${TEST_PAGE_URL}?test=C7638574`,
+  requestHooks: [networkLogger.edgeEndpointLogs]
+});
+
+test.meta({
+  ID: "C7638574",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+
+test("Test C7638574: AJO offers for custom surface are delivered", async () => {
+  const alloy = createAlloyProxy();
+  await alloy.configure(config);
+  const personalization = { surfaces: [AJO_TEST_SURFACE] };
+  const eventResult = await alloy.sendEvent({
+    renderDecisions: true,
+    personalization
+  });
+
+  await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
+
+  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
+
+  const sendEventRequest = networkLogger.edgeEndpointLogs.requests[0];
+  const requestBody = JSON.parse(sendEventRequest.request.body);
+  const personalizationSchemas =
+    requestBody.events[0].query.personalization.schemas;
+
+  await t
+    .expect(requestBody.events[0].query.personalization.decisionScopes)
+    .eql([PAGE_WIDE_SCOPE]);
+
+  await t
+    .expect(requestBody.events[0].query.personalization.surfaces)
+    .contains(AJO_TEST_SURFACE);
+
+  const result = [
+    "https://ns.adobe.com/personalization/default-content-item",
+    "https://ns.adobe.com/personalization/dom-action",
+    "https://ns.adobe.com/personalization/html-content-item",
+    "https://ns.adobe.com/personalization/json-content-item",
+    "https://ns.adobe.com/personalization/redirect-item"
+  ].every(schema => personalizationSchemas.includes(schema));
+
+  await t.expect(result).eql(true);
+
+  const response = JSON.parse(
+    getResponseBody(networkLogger.edgeEndpointLogs.requests[0])
+  );
+  const personalizationPayload = createResponse({
+    content: response
+  }).getPayloadsByType("personalization:decisions");
+
+  await t.expect(personalizationPayload[0].scope).eql(AJO_TEST_SURFACE);
+  await t.expect(personalizationPayload[0].items.length).eql(1);
+  await t
+    .expect(personalizationPayload[0].items[0].data.content)
+    .eql("Welcome AJO Sandbox!");
+
+  await t.expect(eventResult.propositions[0].renderAttempted).eql(true);
+});

--- a/test/functional/specs/Personalization/C782719.js
+++ b/test/functional/specs/Personalization/C782719.js
@@ -88,7 +88,6 @@ const simulateViewChange = async alloy => {
   // sendEvent at a view change, this shouldn't request any target data, it should use the existing cache
   const resultingObject = await alloy.sendEvent({
     renderDecisions: false,
-    decisionScopes: [],
     xdm: {
       web: {
         webPageDetails: {
@@ -113,7 +112,6 @@ const simulateViewChangeForNonExistingView = async alloy => {
   // no decisions in cache for this specific view should return empty array
   const resultingObject = await alloy.sendEvent({
     renderDecisions: true,
-    decisionScopes: [],
     xdm: {
       web: {
         webPageDetails: {

--- a/test/unit/specs/components/DataCollector/index.spec.js
+++ b/test/unit/specs/components/DataCollector/index.spec.js
@@ -60,7 +60,8 @@ describe("Event Command", () => {
       expect(event.setUserData).toHaveBeenCalledWith(data);
       expect(eventManager.sendEvent).toHaveBeenCalledWith(event, {
         renderDecisions: true,
-        decisionScopes: []
+        decisionScopes: [],
+        personalization: {}
       });
       expect(result).toEqual("sendEventResult");
     });
@@ -69,13 +70,39 @@ describe("Event Command", () => {
   it("sends event with decisionScopes parameter when decisionScopes is not empty", () => {
     const options = {
       renderDecisions: true,
-      decisionScopes: ["Foo1", "Foo2"]
+      decisionScopes: ["Foo1"],
+      personalization: {
+        decisionScopes: ["Foo2"]
+      }
     };
 
     return sendEventCommand.run(options).then(result => {
       expect(eventManager.sendEvent).toHaveBeenCalledWith(event, {
         renderDecisions: true,
-        decisionScopes: ["Foo1", "Foo2"]
+        decisionScopes: ["Foo1"],
+        personalization: {
+          decisionScopes: ["Foo2"]
+        }
+      });
+      expect(result).toEqual("sendEventResult");
+    });
+  });
+
+  it("sends event with surfaces parameter when surfaces is not empty", () => {
+    const options = {
+      renderDecisions: true,
+      personalization: {
+        surfaces: ["Foo1", "Foo2"]
+      }
+    };
+
+    return sendEventCommand.run(options).then(result => {
+      expect(eventManager.sendEvent).toHaveBeenCalledWith(event, {
+        renderDecisions: true,
+        decisionScopes: [],
+        personalization: {
+          surfaces: ["Foo1", "Foo2"]
+        }
       });
       expect(result).toEqual("sendEventResult");
     });
@@ -91,7 +118,8 @@ describe("Event Command", () => {
     return sendEventCommand.run({}).then(() => {
       expect(eventManager.sendEvent).toHaveBeenCalledWith(event, {
         renderDecisions: false,
-        decisionScopes: []
+        decisionScopes: [],
+        personalization: {}
       });
     });
   });

--- a/test/unit/specs/components/Personalization/createApplyPropositions.spec.js
+++ b/test/unit/specs/components/Personalization/createApplyPropositions.spec.js
@@ -53,13 +53,13 @@ describe("Personalization::createApplyPropositions", () => {
     executeDecisions.and.returnValue(
       Promise.resolve(PAGE_WIDE_SCOPE_DECISIONS)
     );
+
     const expectedExecuteDecisionsPropositions = clone(
       PAGE_WIDE_SCOPE_DECISIONS
-    );
-    expectedExecuteDecisionsPropositions[0].items = expectedExecuteDecisionsPropositions[0].items.slice(
-      0,
-      2
-    );
+    ).map(proposition => {
+      proposition.items = proposition.items.slice(0, 2);
+      return proposition;
+    });
 
     const applyPropositions = createApplyPropositions({
       executeDecisions
@@ -69,7 +69,7 @@ describe("Personalization::createApplyPropositions", () => {
       propositions: PAGE_WIDE_SCOPE_DECISIONS
     }).then(result => {
       expect(executeDecisions).toHaveBeenCalledTimes(1);
-      expect(executeDecisions.calls.all()[0].args[0]).toEqual(
+      expect(executeDecisions.calls.first().args[0]).toEqual(
         expectedExecuteDecisionsPropositions
       );
 
@@ -96,7 +96,7 @@ describe("Personalization::createApplyPropositions", () => {
       propositions: MIXED_PROPOSITIONS,
       metadata: METADATA
     }).then(() => {
-      const executedPropositions = executeDecisions.calls.all()[0].args[0];
+      const executedPropositions = executeDecisions.calls.first().args[0];
       expect(executedPropositions.length).toEqual(3);
       executedPropositions.forEach(proposition => {
         expect(proposition.items.length).toEqual(1);
@@ -209,7 +209,7 @@ describe("Personalization::createApplyPropositions", () => {
     return applyPropositions({
       propositions: MIXED_PROPOSITIONS
     }).then(() => {
-      const executedPropositions = executeDecisions.calls.all()[0].args[0];
+      const executedPropositions = executeDecisions.calls.first().args[0];
       expect(executedPropositions.length).toEqual(2);
       executedPropositions.forEach(proposition => {
         expect(proposition.items.length).toEqual(1);

--- a/test/unit/specs/components/Personalization/createAutoRenderingHandler.spec.js
+++ b/test/unit/specs/components/Personalization/createAutoRenderingHandler.spec.js
@@ -12,10 +12,11 @@ governing permissions and limitations under the License.
 
 import {
   CART_VIEW_DECISIONS,
-  PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS,
+  PAGE_WIDE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS,
   SCOPES_FOO1_FOO2_DECISIONS
 } from "./responsesMock/eventResponses";
 import createAutoRenderingHandler from "../../../../../src/components/Personalization/createAutoRenderingHandler";
+import isPageWideScope from "../../../../../src/components/Personalization/utils/isPageWideScope";
 
 describe("Personalization::createAutoRenderingHandler", () => {
   let viewCache;
@@ -30,7 +31,7 @@ describe("Personalization::createAutoRenderingHandler", () => {
     viewCache = jasmine.createSpyObj("viewCache", ["getView"]);
     collect = jasmine.createSpy("collect");
     executeDecisions = jasmine.createSpy("executeDecisions");
-    pageWideScopeDecisions = PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS;
+    pageWideScopeDecisions = PAGE_WIDE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS;
     nonAutoRenderableDecisions = SCOPES_FOO1_FOO2_DECISIONS;
   });
 
@@ -41,7 +42,7 @@ describe("Personalization::createAutoRenderingHandler", () => {
     };
     const executePageWideScopeDecisionsPromise = {
       then: callback =>
-        callback(PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS)
+        callback(PAGE_WIDE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS)
     };
 
     viewCache.getView.and.returnValue(Promise.resolve(CART_VIEW_DECISIONS));
@@ -65,7 +66,7 @@ describe("Personalization::createAutoRenderingHandler", () => {
       expect(viewCache.getView).toHaveBeenCalledWith("cart");
       expect(executeDecisions).toHaveBeenCalledTimes(2);
       expect(executeDecisions.calls.all()[0].args[0]).toEqual(
-        PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS
+        PAGE_WIDE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS
       );
       expect(executeDecisions.calls.all()[1].args[0]).toEqual(
         CART_VIEW_DECISIONS
@@ -77,7 +78,7 @@ describe("Personalization::createAutoRenderingHandler", () => {
 
       result.propositions.forEach(proposition => {
         if (
-          proposition.scope === "__view__" ||
+          isPageWideScope(proposition.scope) ||
           proposition.scope === viewName
         ) {
           expect(proposition.renderAttempted).toEqual(true);
@@ -88,7 +89,7 @@ describe("Personalization::createAutoRenderingHandler", () => {
 
       expect(collect).toHaveBeenCalledTimes(2);
       expect(collect.calls.all()[0].args[0]).toEqual({
-        decisionsMeta: PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS
+        decisionsMeta: PAGE_WIDE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS
       });
       expect(collect.calls.all()[1].args[0]).toEqual({
         decisionsMeta: CART_VIEW_DECISIONS,
@@ -102,7 +103,7 @@ describe("Personalization::createAutoRenderingHandler", () => {
     const viewName = undefined;
     const executePageWideScopeDecisionsPromise = {
       then: callback =>
-        callback(PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS)
+        callback(PAGE_WIDE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS)
     };
     executeDecisions.and.returnValue(executePageWideScopeDecisionsPromise);
 
@@ -123,7 +124,7 @@ describe("Personalization::createAutoRenderingHandler", () => {
       });
 
       result.propositions.forEach(proposition => {
-        if (proposition.scope === "__view__") {
+        if (isPageWideScope(proposition.scope)) {
           expect(proposition.renderAttempted).toEqual(true);
         } else {
           expect(proposition.renderAttempted).toEqual(false);
@@ -147,7 +148,7 @@ describe("Personalization::createAutoRenderingHandler", () => {
     };
     const executePageWideScopeDecisionsPromise = {
       then: callback =>
-        callback(PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS)
+        callback(PAGE_WIDE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS)
     };
     const executeViewDecisionsPromise = {
       then: callback => callback([])
@@ -184,7 +185,7 @@ describe("Personalization::createAutoRenderingHandler", () => {
 
       result.propositions.forEach(proposition => {
         if (
-          proposition.scope === "__view__" ||
+          isPageWideScope(proposition.scope) ||
           proposition.scope === viewName
         ) {
           expect(proposition.renderAttempted).toEqual(true);
@@ -225,7 +226,7 @@ describe("Personalization::createAutoRenderingHandler", () => {
 
       result.propositions.forEach(proposition => {
         if (
-          proposition.scope === "__view__" ||
+          isPageWideScope(proposition.scope) ||
           proposition.scope === viewName
         ) {
           expect(proposition.renderAttempted).toEqual(true);

--- a/test/unit/specs/components/Personalization/createComponent.spec.js
+++ b/test/unit/specs/components/Personalization/createComponent.spec.js
@@ -67,11 +67,13 @@ describe("Personalization", () => {
     it("shouldn't do anything since authoringMode is enabled", () => {
       isAuthoringModeEnabled.and.returnValue(true);
       const renderDecisions = true;
-      const decisionScopes = ["foo"];
+      const personalization = {
+        decisionScopes: ["foo"]
+      };
       personalizationComponent.lifecycle.onBeforeEvent({
         event,
         renderDecisions,
-        decisionScopes
+        personalization
       });
 
       expect(logger.warn).toHaveBeenCalledWith(
@@ -88,11 +90,13 @@ describe("Personalization", () => {
 
     it("should trigger pageLoad if there are decisionScopes", () => {
       const renderDecisions = false;
-      const decisionScopes = ["alloy1"];
+      const personalization = {
+        decisionScopes: ["alloy1"]
+      };
       personalizationComponent.lifecycle.onBeforeEvent({
         event,
         renderDecisions,
-        decisionScopes
+        personalization
       });
 
       expect(isAuthoringModeEnabled).toHaveBeenCalled();
@@ -104,13 +108,15 @@ describe("Personalization", () => {
     });
     it("should trigger pageLoad if cache is not initialized", () => {
       const renderDecisions = false;
-      const decisionScopes = [];
+      const personalization = {
+        decisionScopes: []
+      };
       viewCache.isInitialized.and.returnValue(false);
 
       personalizationComponent.lifecycle.onBeforeEvent({
         event,
         renderDecisions,
-        decisionScopes
+        personalization
       });
 
       expect(isAuthoringModeEnabled).toHaveBeenCalled();
@@ -122,14 +128,16 @@ describe("Personalization", () => {
     });
     it("should trigger viewHandler if cache is initialized and viewName is provided", () => {
       const renderDecisions = false;
-      const decisionScopes = [];
+      const personalization = {
+        decisionScopes: []
+      };
       viewCache.isInitialized.and.returnValue(true);
       event.getViewName.and.returnValue("cart");
 
       personalizationComponent.lifecycle.onBeforeEvent({
         event,
         renderDecisions,
-        decisionScopes
+        personalization
       });
 
       expect(isAuthoringModeEnabled).toHaveBeenCalled();

--- a/test/unit/specs/components/Personalization/createGetPageLocation.spec.js
+++ b/test/unit/specs/components/Personalization/createGetPageLocation.spec.js
@@ -1,0 +1,29 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import createGetPageLocation from "../../../../../src/components/Personalization/createGetPageLocation";
+
+describe("Personalization::createGetPageLocation", () => {
+  it("it should return page location object", () => {
+    const win = {
+      location: {
+        href: "https://alloy.test.com/test/page/1/",
+        host: "alloy.test.com",
+        pathname: "/test/page/1/"
+      }
+    };
+    const getPageLocation = createGetPageLocation({ window: win });
+    const location = getPageLocation();
+
+    expect(location).toEqual(win.location);
+  });
+});

--- a/test/unit/specs/components/Personalization/createNonRenderingHandler.spec.js
+++ b/test/unit/specs/components/Personalization/createNonRenderingHandler.spec.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 import {
   CART_VIEW_DECISIONS,
-  PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS,
+  PAGE_WIDE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS,
   REDIRECT_PAGE_WIDE_SCOPE_DECISION,
   SCOPES_FOO1_FOO2_DECISIONS
 } from "./responsesMock/eventResponses";
@@ -28,7 +28,7 @@ describe("Personalization::createNonRenderingHandler", () => {
   beforeEach(() => {
     redirectDecisions = REDIRECT_PAGE_WIDE_SCOPE_DECISION;
     cartViewDecisions = CART_VIEW_DECISIONS;
-    pageWideScopeDecisions = PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS;
+    pageWideScopeDecisions = PAGE_WIDE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS;
     nonAutoRenderableDecisions = SCOPES_FOO1_FOO2_DECISIONS;
     viewCache = jasmine.createSpyObj("viewCache", ["getView"]);
   });
@@ -51,7 +51,7 @@ describe("Personalization::createNonRenderingHandler", () => {
       nonAutoRenderableDecisions
     }).then(result => {
       expect(viewCache.getView).toHaveBeenCalledWith("cart");
-      expect(result.decisions.length).toBe(5);
+      expect(result.decisions.length).toBe(6);
       result.decisions.forEach(decision => {
         expect(decision.renderAttempted).toBeUndefined();
       });
@@ -74,7 +74,7 @@ describe("Personalization::createNonRenderingHandler", () => {
       nonAutoRenderableDecisions
     }).then(result => {
       expect(viewCache.getView).not.toHaveBeenCalled();
-      expect(result.decisions.length).toBe(4);
+      expect(result.decisions.length).toBe(5);
       result.decisions.forEach(decision => {
         expect(decision.renderAttempted).toBeUndefined();
       });

--- a/test/unit/specs/components/Personalization/createOnResponseHandler.spec.js
+++ b/test/unit/specs/components/Personalization/createOnResponseHandler.spec.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 import {
   CART_VIEW_DECISIONS,
   PAGE_WIDE_SCOPE_DECISIONS,
-  PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS,
+  PAGE_WIDE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS,
   PAGE_WIDE_SCOPE_DECISIONS_WITHOUT_DOM_ACTION_SCHEMA_ITEMS,
   PRODUCTS_VIEW_DECISIONS,
   REDIRECT_PAGE_WIDE_SCOPE_DECISION
@@ -27,7 +27,7 @@ describe("Personalization::onResponseHandler", () => {
     ...CART_VIEW_DECISIONS,
     ...PRODUCTS_VIEW_DECISIONS
   ];
-  const pageWideScopeDecisions = PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS;
+  const pageWideScopeDecisions = PAGE_WIDE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS;
 
   let groupDecisions;
   let autoRenderingHandler;
@@ -72,6 +72,7 @@ describe("Personalization::onResponseHandler", () => {
     personalizationDetails.isRenderDecisions.and.returnValue(true);
     personalizationDetails.getViewName.and.returnValue(undefined);
     const onResponse = createOnResponseHandler({
+      window,
       groupDecisions,
       nonRenderingHandler,
       autoRenderingHandler,
@@ -108,6 +109,7 @@ describe("Personalization::onResponseHandler", () => {
     personalizationDetails.isRenderDecisions.and.returnValue(false);
     personalizationDetails.getViewName.and.returnValue(undefined);
     const onResponse = createOnResponseHandler({
+      window,
       groupDecisions,
       nonRenderingHandler,
       autoRenderingHandler,
@@ -141,6 +143,7 @@ describe("Personalization::onResponseHandler", () => {
     personalizationDetails.getViewName.and.returnValue("cart");
 
     const onResponse = createOnResponseHandler({
+      window,
       groupDecisions,
       nonRenderingHandler,
       autoRenderingHandler,
@@ -182,6 +185,7 @@ describe("Personalization::onResponseHandler", () => {
     personalizationDetails.isRenderDecisions.and.returnValue(true);
     personalizationDetails.getViewName.and.returnValue("cart");
     const onResponse = createOnResponseHandler({
+      window,
       groupDecisions,
       nonRenderingHandler,
       autoRenderingHandler,

--- a/test/unit/specs/components/Personalization/createPersonalizationDetails.spec.js
+++ b/test/unit/specs/components/Personalization/createPersonalizationDetails.spec.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 import PAGE_WIDE_SCOPE from "../../../../../src/components/Personalization/constants/scope";
 import createPersonalizationDetails from "../../../../../src/components/Personalization/createPersonalizationDetails";
+import createGetPageLocation from "../../../../../src/components/Personalization/createGetPageLocation";
 import {
   DEFAULT_CONTENT_ITEM,
   DOM_ACTION,
@@ -20,23 +21,38 @@ import {
 } from "../../../../../src/components/Personalization/constants/schema";
 
 describe("Personalization::createPersonalizationDetails", () => {
+  const TEST_SURFACE = "web://alloy.test.com/test/page/1";
+  const window = {
+    location: {
+      host: "alloy.test.com",
+      pathname: "/test/page/1/"
+    }
+  };
+  const getPageLocation = createGetPageLocation({ window });
+
   let event;
   let viewCache;
+  let logger;
 
   beforeEach(() => {
     event = jasmine.createSpyObj("event", ["getViewName"]);
     viewCache = jasmine.createSpyObj("viewCache", ["getView", "isInitialized"]);
+    logger = jasmine.createSpyObj("logger", ["info", "warn", "error"]);
   });
 
-  it("should fetch data when no cache, renderDecisions is true, no viewName and decisionScopes (in non SPA world)", () => {
+  it("should fetch data when no cache, renderDecisions is true, no viewName and decisionScopes/surfaces (in non SPA world)", () => {
     const decisionScopes = [];
+    const personalization = {};
     const renderDecisions = true;
     event.getViewName.and.returnValue(undefined);
     const personalizationDetails = createPersonalizationDetails({
+      getPageLocation,
       renderDecisions,
       decisionScopes,
+      personalization,
       event,
-      viewCache
+      viewCache,
+      logger
     });
     viewCache.isInitialized.and.returnValue(false);
     const expectedDecisionScopes = [PAGE_WIDE_SCOPE];
@@ -48,27 +64,33 @@ describe("Personalization::createPersonalizationDetails", () => {
         REDIRECT_ITEM,
         DOM_ACTION
       ],
-      decisionScopes: expectedDecisionScopes
+      decisionScopes: expectedDecisionScopes,
+      surfaces: [TEST_SURFACE]
     };
     const queryDetails = personalizationDetails.createQueryDetails();
 
     expect(personalizationDetails.isRenderDecisions()).toEqual(true);
     expect(personalizationDetails.hasScopes()).toEqual(false);
+    expect(personalizationDetails.hasSurfaces()).toEqual(false);
     expect(queryDetails).toEqual(expectedQueryDetails);
     expect(personalizationDetails.getViewName()).toEqual(undefined);
     expect(personalizationDetails.shouldFetchData()).toEqual(true);
     expect(personalizationDetails.hasViewName()).toEqual(false);
     expect(personalizationDetails.shouldUseCachedData()).toEqual(false);
   });
-  it("should fetch data when no cache, renderDecisions is false, no viewName and decisionScopes is empty", () => {
+  it("should fetch data when no cache, renderDecisions is false, no viewName and decisionScopes/surfaces is empty", () => {
     const decisionScopes = [];
+    const personalization = {};
     const renderDecisions = false;
     event.getViewName.and.returnValue(undefined);
     const personalizationDetails = createPersonalizationDetails({
+      getPageLocation,
       renderDecisions,
       decisionScopes,
+      personalization,
       event,
-      viewCache
+      viewCache,
+      logger
     });
     viewCache.isInitialized.and.returnValue(false);
     const expectedDecisionScopes = [PAGE_WIDE_SCOPE];
@@ -80,12 +102,14 @@ describe("Personalization::createPersonalizationDetails", () => {
         REDIRECT_ITEM,
         DOM_ACTION
       ],
-      decisionScopes: expectedDecisionScopes
+      decisionScopes: expectedDecisionScopes,
+      surfaces: [TEST_SURFACE]
     };
     const queryDetails = personalizationDetails.createQueryDetails();
 
     expect(personalizationDetails.isRenderDecisions()).toEqual(false);
     expect(personalizationDetails.hasScopes()).toEqual(false);
+    expect(personalizationDetails.hasSurfaces()).toEqual(false);
     expect(queryDetails).toEqual(expectedQueryDetails);
     expect(personalizationDetails.getViewName()).toEqual(undefined);
     expect(personalizationDetails.shouldFetchData()).toEqual(true);
@@ -94,13 +118,17 @@ describe("Personalization::createPersonalizationDetails", () => {
   });
   it("should fetch data when no cache, renderDecisions is false, no viewName and decisionScopes is not empty", () => {
     const decisionScopes = ["test1"];
+    const personalization = {};
     const renderDecisions = false;
     event.getViewName.and.returnValue(undefined);
     const personalizationDetails = createPersonalizationDetails({
+      getPageLocation,
       renderDecisions,
       decisionScopes,
+      personalization,
       event,
-      viewCache
+      viewCache,
+      logger
     });
     viewCache.isInitialized.and.returnValue(false);
     const expectedDecisionScopes = ["test1", "__view__"];
@@ -112,12 +140,14 @@ describe("Personalization::createPersonalizationDetails", () => {
         REDIRECT_ITEM,
         DOM_ACTION
       ],
-      decisionScopes: expectedDecisionScopes
+      decisionScopes: expectedDecisionScopes,
+      surfaces: [TEST_SURFACE]
     };
     const queryDetails = personalizationDetails.createQueryDetails();
 
     expect(personalizationDetails.isRenderDecisions()).toEqual(false);
     expect(personalizationDetails.hasScopes()).toEqual(true);
+    expect(personalizationDetails.hasSurfaces()).toEqual(false);
     expect(queryDetails).toEqual(expectedQueryDetails);
     expect(personalizationDetails.getViewName()).toEqual(undefined);
     expect(personalizationDetails.shouldFetchData()).toEqual(true);
@@ -126,13 +156,17 @@ describe("Personalization::createPersonalizationDetails", () => {
   });
   it("should fetch data when cache initialized, renderDecisions is false, no viewName, and decisionScopes is not empty", () => {
     const decisionScopes = ["test1"];
+    const personalization = {};
     const renderDecisions = false;
     event.getViewName.and.returnValue(undefined);
     const personalizationDetails = createPersonalizationDetails({
+      getPageLocation,
       renderDecisions,
+      personalization,
       decisionScopes,
       event,
-      viewCache
+      viewCache,
+      logger
     });
     viewCache.isInitialized.and.returnValue(true);
     const expectedDecisionScopes = ["test1"];
@@ -143,12 +177,53 @@ describe("Personalization::createPersonalizationDetails", () => {
         JSON_CONTENT_ITEM,
         REDIRECT_ITEM
       ],
-      decisionScopes: expectedDecisionScopes
+      decisionScopes: expectedDecisionScopes,
+      surfaces: []
     };
     const queryDetails = personalizationDetails.createQueryDetails();
 
     expect(personalizationDetails.isRenderDecisions()).toEqual(false);
     expect(personalizationDetails.hasScopes()).toEqual(true);
+    expect(personalizationDetails.hasSurfaces()).toEqual(false);
+    expect(queryDetails).toEqual(expectedQueryDetails);
+    expect(personalizationDetails.getViewName()).toEqual(undefined);
+    expect(personalizationDetails.shouldFetchData()).toEqual(true);
+    expect(personalizationDetails.hasViewName()).toEqual(false);
+    expect(personalizationDetails.shouldUseCachedData()).toEqual(false);
+  });
+  it("should fetch data when cache initialized, renderDecisions is false, no viewName, and surfaces is not empty", () => {
+    const decisionScopes = [];
+    const personalization = {
+      surfaces: ["web://test1.com"]
+    };
+    const renderDecisions = false;
+    event.getViewName.and.returnValue(undefined);
+    const personalizationDetails = createPersonalizationDetails({
+      getPageLocation,
+      renderDecisions,
+      decisionScopes,
+      personalization,
+      event,
+      viewCache,
+      logger
+    });
+    viewCache.isInitialized.and.returnValue(true);
+    const expectedDecisionScopes = [];
+    const expectedQueryDetails = {
+      schemas: [
+        DEFAULT_CONTENT_ITEM,
+        HTML_CONTENT_ITEM,
+        JSON_CONTENT_ITEM,
+        REDIRECT_ITEM
+      ],
+      decisionScopes: expectedDecisionScopes,
+      surfaces: ["web://test1.com/"]
+    };
+    const queryDetails = personalizationDetails.createQueryDetails();
+
+    expect(personalizationDetails.isRenderDecisions()).toEqual(false);
+    expect(personalizationDetails.hasScopes()).toEqual(false);
+    expect(personalizationDetails.hasSurfaces()).toEqual(true);
     expect(queryDetails).toEqual(expectedQueryDetails);
     expect(personalizationDetails.getViewName()).toEqual(undefined);
     expect(personalizationDetails.shouldFetchData()).toEqual(true);
@@ -157,14 +232,20 @@ describe("Personalization::createPersonalizationDetails", () => {
   });
   it("should fetch data when cache initialized, renderDecisions is true and decisionScopes is not empty and viewName exist", () => {
     event.getViewName.and.returnValue("cart");
-
-    const decisionScopes = ["test1", "test2"];
+    const decisionScopes = ["test1"];
+    const personalization = {
+      decisionScopes: ["test2"],
+      surfaces: ["web://test1.com"]
+    };
     const renderDecisions = true;
     const personalizationDetails = createPersonalizationDetails({
+      getPageLocation,
       renderDecisions,
       decisionScopes,
+      personalization,
       event,
-      viewCache
+      viewCache,
+      logger
     });
     viewCache.isInitialized.and.returnValue(true);
 
@@ -176,12 +257,14 @@ describe("Personalization::createPersonalizationDetails", () => {
         JSON_CONTENT_ITEM,
         REDIRECT_ITEM
       ],
-      decisionScopes: expectedDecisionScopes
+      decisionScopes: expectedDecisionScopes,
+      surfaces: ["web://test1.com/"]
     };
     const queryDetails = personalizationDetails.createQueryDetails();
 
     expect(personalizationDetails.isRenderDecisions()).toEqual(true);
     expect(personalizationDetails.hasScopes()).toEqual(true);
+    expect(personalizationDetails.hasSurfaces()).toEqual(true);
     expect(queryDetails).toEqual(expectedQueryDetails);
     expect(personalizationDetails.getViewName()).toEqual("cart");
     expect(personalizationDetails.shouldFetchData()).toEqual(true);
@@ -190,17 +273,22 @@ describe("Personalization::createPersonalizationDetails", () => {
   it("should do nothing when cache is initialized, renderDecisions true, no viewName and decisionScopes is empty", () => {
     event.getViewName.and.returnValue(undefined);
     const decisionScopes = [];
+    const personalization = {};
     const renderDecisions = true;
     const personalizationDetails = createPersonalizationDetails({
+      getPageLocation,
       renderDecisions,
       decisionScopes,
+      personalization,
       event,
-      viewCache
+      viewCache,
+      logger
     });
     viewCache.isInitialized.and.returnValue(true);
 
     expect(personalizationDetails.isRenderDecisions()).toEqual(true);
     expect(personalizationDetails.hasScopes()).toEqual(false);
+    expect(personalizationDetails.hasSurfaces()).toEqual(false);
     expect(personalizationDetails.getViewName()).toEqual(undefined);
     expect(personalizationDetails.shouldFetchData()).toEqual(false);
     expect(personalizationDetails.hasViewName()).toEqual(false);
@@ -209,17 +297,22 @@ describe("Personalization::createPersonalizationDetails", () => {
   it("should do nothing when cache is initialized, renderDecisions false, no viewName and decisionScopes is empty", () => {
     event.getViewName.and.returnValue(undefined);
     const decisionScopes = [];
+    const personalization = {};
     const renderDecisions = false;
     const personalizationDetails = createPersonalizationDetails({
+      getPageLocation,
       renderDecisions,
       decisionScopes,
+      personalization,
       event,
-      viewCache
+      viewCache,
+      logger
     });
     viewCache.isInitialized.and.returnValue(true);
 
     expect(personalizationDetails.isRenderDecisions()).toEqual(false);
     expect(personalizationDetails.hasScopes()).toEqual(false);
+    expect(personalizationDetails.hasSurfaces()).toEqual(false);
     expect(personalizationDetails.getViewName()).toEqual(undefined);
     expect(personalizationDetails.shouldFetchData()).toEqual(false);
     expect(personalizationDetails.hasViewName()).toEqual(false);
@@ -228,17 +321,22 @@ describe("Personalization::createPersonalizationDetails", () => {
   it("should use cache when cache initialized, renderDecisions is true and decisionScopes is empty and viewName exist", () => {
     event.getViewName.and.returnValue("cart");
     const decisionScopes = [];
+    const personalization = {};
     const renderDecisions = true;
     const personalizationDetails = createPersonalizationDetails({
+      getPageLocation,
       renderDecisions,
+      personalization,
       decisionScopes,
       event,
-      viewCache
+      viewCache,
+      logger
     });
     viewCache.isInitialized.and.returnValue(true);
 
     expect(personalizationDetails.isRenderDecisions()).toEqual(true);
     expect(personalizationDetails.hasScopes()).toEqual(false);
+    expect(personalizationDetails.hasSurfaces()).toEqual(false);
     expect(personalizationDetails.getViewName()).toEqual("cart");
     expect(personalizationDetails.hasViewName()).toEqual(true);
     expect(personalizationDetails.shouldFetchData()).toEqual(false);
@@ -247,17 +345,22 @@ describe("Personalization::createPersonalizationDetails", () => {
   it("should use cache when cache initialized, renderDecisions is false and decisionScopes is empty and viewName exist", () => {
     event.getViewName.and.returnValue("cart");
     const decisionScopes = [];
+    const personalization = {};
     const renderDecisions = false;
     const personalizationDetails = createPersonalizationDetails({
+      getPageLocation,
       renderDecisions,
+      personalization,
       decisionScopes,
       event,
-      viewCache
+      viewCache,
+      logger
     });
     viewCache.isInitialized.and.returnValue(true);
 
     expect(personalizationDetails.isRenderDecisions()).toEqual(false);
     expect(personalizationDetails.hasScopes()).toEqual(false);
+    expect(personalizationDetails.hasSurfaces()).toEqual(false);
     expect(personalizationDetails.getViewName()).toEqual("cart");
     expect(personalizationDetails.hasViewName()).toEqual(true);
     expect(personalizationDetails.shouldFetchData()).toEqual(false);
@@ -266,12 +369,18 @@ describe("Personalization::createPersonalizationDetails", () => {
   it("should fetch data when cache initialized, renderDecisions is true and decisionScopes has __view__ and viewName exist", () => {
     event.getViewName.and.returnValue("cart");
     const decisionScopes = ["__view__"];
+    const personalization = {
+      surfaces: [TEST_SURFACE]
+    };
     const renderDecisions = true;
     const personalizationDetails = createPersonalizationDetails({
+      getPageLocation,
       renderDecisions,
       decisionScopes,
+      personalization,
       event,
-      viewCache
+      viewCache,
+      logger
     });
     viewCache.isInitialized.and.returnValue(true);
 
@@ -284,12 +393,14 @@ describe("Personalization::createPersonalizationDetails", () => {
         REDIRECT_ITEM,
         DOM_ACTION
       ],
-      decisionScopes: expectedDecisionScopes
+      decisionScopes: expectedDecisionScopes,
+      surfaces: [TEST_SURFACE]
     };
     const queryDetails = personalizationDetails.createQueryDetails();
 
     expect(personalizationDetails.isRenderDecisions()).toEqual(true);
     expect(personalizationDetails.hasScopes()).toEqual(true);
+    expect(personalizationDetails.hasSurfaces()).toEqual(true);
     expect(queryDetails).toEqual(expectedQueryDetails);
     expect(personalizationDetails.getViewName()).toEqual("cart");
     expect(personalizationDetails.shouldFetchData()).toEqual(true);
@@ -297,13 +408,17 @@ describe("Personalization::createPersonalizationDetails", () => {
   });
   it("hasViewName should return false when viewName is empty", () => {
     const decisionScopes = [];
+    const personalization = {};
     const renderDecisions = true;
     event.getViewName.and.returnValue("");
     const personalizationDetails = createPersonalizationDetails({
+      getPageLocation,
       renderDecisions,
       decisionScopes,
+      personalization,
       event,
-      viewCache
+      viewCache,
+      logger
     });
     expect(personalizationDetails.isRenderDecisions()).toEqual(true);
     expect(personalizationDetails.hasViewName()).toEqual(false);

--- a/test/unit/specs/components/Personalization/groupDecisions.spec.js
+++ b/test/unit/specs/components/Personalization/groupDecisions.spec.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 import {
   PAGE_WIDE_SCOPE_DECISIONS,
-  PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS,
+  PAGE_WIDE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS,
   PAGE_WIDE_SCOPE_DECISIONS_WITHOUT_DOM_ACTION_SCHEMA_ITEMS,
   CART_VIEW_DECISIONS,
   REDIRECT_PAGE_WIDE_SCOPE_DECISION,
@@ -26,7 +26,7 @@ let productDecisions;
 let mergedDecisions;
 
 beforeEach(() => {
-  cartDecisions = PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS.concat(
+  cartDecisions = PAGE_WIDE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS.concat(
     CART_VIEW_DECISIONS
   );
   productDecisions = PAGE_WIDE_SCOPE_DECISIONS.concat(
@@ -34,6 +34,7 @@ beforeEach(() => {
   ).concat(PRODUCTS_VIEW_DECISIONS);
   mergedDecisions = productDecisions.concat(MERGED_METRIC_DECISIONS);
 });
+
 describe("Personalization::groupDecisions", () => {
   it("extracts decisions by scope", () => {
     const {
@@ -44,7 +45,7 @@ describe("Personalization::groupDecisions", () => {
     } = groupDecisions(cartDecisions);
 
     expect(pageWideScopeDecisions).toEqual(
-      PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS
+      PAGE_WIDE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS
     );
     expect(viewDecisions).toEqual({ cart: CART_VIEW_DECISIONS });
     expect(nonAutoRenderableDecisions).toEqual([]);
@@ -66,7 +67,7 @@ describe("Personalization::groupDecisions", () => {
       PAGE_WIDE_SCOPE_DECISIONS_WITHOUT_DOM_ACTION_SCHEMA_ITEMS
     );
     expect(pageWideScopeDecisions).toEqual(
-      PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS
+      PAGE_WIDE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS
     );
     expect(redirectDecisions).toEqual(REDIRECT_PAGE_WIDE_SCOPE_DECISION);
     expect(viewDecisions).toEqual(expectedViewDecisions);
@@ -89,7 +90,7 @@ describe("Personalization::groupDecisions", () => {
       )
     );
     expect(pageWideScopeDecisions).toEqual(
-      PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS
+      PAGE_WIDE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS
     );
     expect(redirectDecisions).toEqual(REDIRECT_PAGE_WIDE_SCOPE_DECISION);
     expect(viewDecisions).toEqual(expectedViewDecisions);

--- a/test/unit/specs/components/Personalization/responsesMock/eventResponses.js
+++ b/test/unit/specs/components/Personalization/responsesMock/eventResponses.js
@@ -89,6 +89,34 @@ export const PAGE_WIDE_SCOPE_DECISIONS = [
         schema: "https://ns.adobe.com/personalization/default-content-item"
       }
     ]
+  },
+  {
+    id: "AJO:campaign1:message1",
+    scope: "web://alloy.test.com/test/page/1",
+    scopeDetails: {
+      decisionProvider: "AJO"
+    },
+    items: [
+      {
+        schema: "https://ns.adobe.com/personalization/dom-action",
+        data: {
+          type: "setHtml",
+          selector: "#foo",
+          content: "<div>Hola Mundo</div>"
+        }
+      },
+      {
+        schema: "https://ns.adobe.com/personalization/dom-action",
+        data: {
+          type: "setHtml",
+          selector: "#foo2",
+          content: "<div>here is a target activity</div>"
+        }
+      },
+      {
+        schema: "https://ns.adobe.com/personalization/default-content-item"
+      }
+    ]
   }
 ];
 export const PAGE_WIDE_SCOPE_DECISIONS_WITHOUT_DOM_ACTION_SCHEMA_ITEMS = [
@@ -116,12 +144,41 @@ export const PAGE_WIDE_SCOPE_DECISIONS_WITHOUT_DOM_ACTION_SCHEMA_ITEMS = [
     ]
   }
 ];
-export const PAGE_WIDE_SCOPE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS = [
+
+export const PAGE_WIDE_DECISIONS_WITH_DOM_ACTION_SCHEMA_ITEMS = [
   {
     id: "TNT:activity1:experience1",
     scope: "__view__",
     scopeDetails: {
       blah: "test"
+    },
+    items: [
+      {
+        schema: "https://ns.adobe.com/personalization/dom-action",
+        data: {
+          type: "setHtml",
+          selector: "#foo",
+          content: "<div>Hola Mundo</div>"
+        }
+      },
+      {
+        schema: "https://ns.adobe.com/personalization/dom-action",
+        data: {
+          type: "setHtml",
+          selector: "#foo2",
+          content: "<div>here is a target activity</div>"
+        }
+      },
+      {
+        schema: "https://ns.adobe.com/personalization/default-content-item"
+      }
+    ]
+  },
+  {
+    id: "AJO:campaign1:message1",
+    scope: "web://alloy.test.com/test/page/1",
+    scopeDetails: {
+      decisionProvider: "AJO"
     },
     items: [
       {

--- a/test/unit/specs/components/Personalization/utils/isPageWideScope.spec.js
+++ b/test/unit/specs/components/Personalization/utils/isPageWideScope.spec.js
@@ -1,0 +1,25 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import isPageWideScope from "../../../../../../src/components/Personalization/utils/isPageWideScope";
+
+describe("Personalization::isPageWideScope", () => {
+  it("checks for a page-wide scope", () => {
+    expect(isPageWideScope("__view__")).toBeTrue();
+    expect(isPageWideScope("name")).toBeFalse();
+    expect(isPageWideScope("web://domain.com")).toBeTrue();
+    expect(isPageWideScope("web://domain.com/path/page.html")).toBeTrue();
+    expect(isPageWideScope("web://domain.com#fragment")).toBeFalse();
+    expect(isPageWideScope("webapp://domain.com")).toBeFalse();
+    expect(isPageWideScope("webapp://domain.com#view")).toBeFalse();
+  });
+});

--- a/test/unit/specs/components/Personalization/utils/surfaceUtils.spec.js
+++ b/test/unit/specs/components/Personalization/utils/surfaceUtils.spec.js
@@ -1,0 +1,256 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+  buildPageSurface,
+  isPageWideSurface,
+  normalizeSurfaces
+} from "../../../../../../src/components/Personalization/utils/surfaceUtils";
+
+let pageLocation;
+let logger;
+
+const getPageLocation = () => pageLocation;
+
+describe("Personalization::surfaceUtils", () => {
+  beforeEach(() => {
+    logger = jasmine.createSpyObj("logger", ["error", "warn"]);
+    pageLocation = {
+      host: "domain.com",
+      pathname: "/products/test/"
+    };
+  });
+
+  it("builds page-wide surface from location", () => {
+    expect(buildPageSurface(getPageLocation)).toEqual(
+      "web://domain.com/products/test"
+    );
+    pageLocation = {
+      host: "DOMain.com",
+      pathname: undefined
+    };
+    expect(buildPageSurface(getPageLocation)).toEqual("web://domain.com/");
+    pageLocation = {
+      host: "domain.com:8080",
+      pathname: "/"
+    };
+    expect(buildPageSurface(getPageLocation)).toEqual("web://domain.com:8080/");
+    pageLocation = {
+      host: "domain.com",
+      pathname: "/a"
+    };
+    expect(buildPageSurface(getPageLocation)).toEqual("web://domain.com/a");
+    pageLocation = {
+      host: "domain.com",
+      pathname: "/a/"
+    };
+    expect(buildPageSurface(getPageLocation)).toEqual("web://domain.com/a");
+  });
+
+  it("checks for a page-wide surface", () => {
+    expect(isPageWideSurface("__view__")).toBeFalse();
+    expect(isPageWideSurface("name")).toBeFalse();
+    expect(isPageWideSurface("web://domain.com")).toBeTrue();
+    expect(isPageWideSurface("web://domain.com/path/page.html")).toBeTrue();
+    expect(isPageWideSurface("web://domain.com#fragment")).toBeFalse();
+    expect(isPageWideSurface("webapp://domain.com")).toBeFalse();
+    expect(isPageWideSurface("webapp://domain.com#view")).toBeFalse();
+  });
+
+  it("expands fragment surfaces", () => {
+    let result = normalizeSurfaces([], getPageLocation, logger);
+    expect(result).toEqual([]);
+    result = normalizeSurfaces(
+      ["web://custom.surface.com", "#fragment1", "test"],
+      getPageLocation,
+      logger
+    );
+    expect(result).toEqual([
+      "web://custom.surface.com/",
+      "web://domain.com/products/test#fragment1"
+    ]);
+    expect(logger.warn).toHaveBeenCalledOnceWith("Invalid surface: test");
+  });
+
+  it("validates & normalizes surface type", () => {
+    const result = normalizeSurfaces(
+      [
+        "test://domain1.com/test",
+        "web://domain2.com/test",
+        "we b://domain3.com/test",
+        "webapp://domain4.com/test",
+        "webAPP://domain5.com/test",
+        "://domain5.com/test",
+        "web:///domain6.com/test",
+        "mobileapp://domain7.com/test"
+      ],
+      getPageLocation,
+      logger
+    );
+    expect(result).toEqual([
+      "web://domain2.com/test",
+      "webapp://domain4.com/test",
+      "webapp://domain5.com/test"
+    ]);
+    expect(logger.warn).toHaveBeenCalledTimes(5);
+  });
+
+  it("validates & normalizes surface authority", () => {
+    let result = normalizeSurfaces(
+      [
+        "web://foo.com",
+        "web://www.example.com",
+        "web://✪df.ws",
+        "web://userid:password@example.com:8080",
+        "web://userid@example.com",
+        "web://userid@example.com:8080",
+        "web://userid:password@example.com",
+        "web://142.42.1.1",
+        "web://142.42.1.1:8080",
+        "web://➡.ws",
+        "web://⌘.ws",
+        "web://☺.damowmow.com",
+        "web://مثال.إختبار",
+        "web://例子.测试",
+        "web://उदाहरण.परीक्षा",
+        "web://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
+        "web://1337.net",
+        "web://a.b-c.de",
+        "web://223.255.255.254",
+        "web://[::1]",
+        "web://[ff11:af21:::1]:3000"
+      ],
+      getPageLocation,
+      logger
+    );
+    expect(result).toEqual([
+      "web://foo.com/",
+      "web://www.example.com/",
+      "web://✪df.ws/",
+      "web://userid:password@example.com:8080/",
+      "web://userid@example.com/",
+      "web://userid@example.com:8080/",
+      "web://userid:password@example.com/",
+      "web://142.42.1.1/",
+      "web://142.42.1.1:8080/",
+      "web://➡.ws/",
+      "web://⌘.ws/",
+      "web://☺.damowmow.com/",
+      "web://مثال.إختبار/",
+      "web://例子.测试/",
+      "web://उदाहरण.परीक्षा/",
+      "web://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com/",
+      "web://1337.net/",
+      "web://a.b-c.de/",
+      "web://223.255.255.254/",
+      "web://[::1]/",
+      "web://[ff11:af21:::1]:3000/"
+    ]);
+    expect(logger.warn).not.toHaveBeenCalled();
+
+    result = normalizeSurfaces(
+      [
+        "web://foo?.com",
+        "web://d f.ws",
+        "web://userid@example.com:8a080",
+        "web://userid@examp&le.com",
+        "web:///page",
+        "web://[::1)",
+        "web://[ff11:af21:12zx::1]:3000"
+      ],
+      getPageLocation,
+      logger
+    );
+    expect(result).toEqual([]);
+    expect(logger.warn).toHaveBeenCalledTimes(7);
+  });
+
+  it("validates & normalizes surface path", () => {
+    let result = normalizeSurfaces(
+      [
+        "web://domain1.com",
+        "web://domain2.com///",
+        "web://domain3.com/PROD.1/a",
+        "web://domain4.com/~prod-1/bb/c/",
+        "web://domain5.com/例子/☺",
+        "web://domain6.com/a/%D0%B6%D0%BE%D1%80%D0%B0%D1%82%D0%B5%D1%81%D1%82"
+      ],
+      getPageLocation,
+      logger
+    );
+    expect(result).toEqual([
+      "web://domain1.com/",
+      "web://domain2.com/",
+      "web://domain3.com/PROD.1/a",
+      "web://domain4.com/~prod-1/bb/c",
+      "web://domain5.com/例子/☺",
+      "web://domain6.com/a/%D0%B6%D0%BE%D1%80%D0%B0%D1%82%D0%B5%D1%81%D1%82"
+    ]);
+    expect(logger.warn).not.toHaveBeenCalled();
+
+    result = normalizeSurfaces(
+      [
+        "web://domain1.com/pr od",
+        "web://domain2.com/+/1",
+        "web://domain3.com/$PROD.1/a",
+        "web://domain4.com/~prod-1/bb/c/?query=aa",
+        "web://domain5.com/例子/test*/1",
+        "web://domain6.com/a/%D0%B6%D0%ZX",
+        "web://domain7.com/a/%D0%B6%D0%%AF"
+      ],
+      getPageLocation,
+      logger
+    );
+    expect(result).toEqual([]);
+    expect(logger.warn).toHaveBeenCalledTimes(7);
+  });
+
+  it("validates surface fragment", () => {
+    let result = normalizeSurfaces(
+      [
+        "web://domain1.com#/home",
+        "web://domain2.com#home",
+        "web://domain3.com#PROD.1",
+        "web://domain4.com#~prod-1/bb/c/",
+        "web://domain5.com#例子/☺",
+        "web://domain6.com#my-%D0%B6%D0%BE%D1%80%D0%B0%D1%82%D0%B5%D1%81%D1%82"
+      ],
+      getPageLocation,
+      logger
+    );
+    expect(result).toEqual([
+      "web://domain1.com/#/home",
+      "web://domain2.com/#home",
+      "web://domain3.com/#PROD.1",
+      "web://domain4.com/#~prod-1/bb/c/",
+      "web://domain5.com/#例子/☺",
+      "web://domain6.com/#my-%D0%B6%D0%BE%D1%80%D0%B0%D1%82%D0%B5%D1%81%D1%82"
+    ]);
+    expect(logger.warn).not.toHaveBeenCalled();
+
+    result = normalizeSurfaces(
+      [
+        "web://domain1.com/#pr od",
+        "web://domain2.com/#+/1",
+        "web://domain3.com/#$PROD.1/a",
+        "web://domain4.com/#~prod-1/bb/c/?query=aa",
+        "web://domain5.com/#例子/test*!/1",
+        "web://domain6.com/#a/%D0%B6%D0%ZX",
+        "web://domain7.com/#a/%D0%B6%D0%%AF"
+      ],
+      getPageLocation,
+      logger
+    );
+    expect(result).toEqual([]);
+    expect(logger.warn).toHaveBeenCalledTimes(7);
+  });
+});

--- a/test/unit/specs/core/createEventManager.spec.js
+++ b/test/unit/specs/core/createEventManager.spec.js
@@ -116,6 +116,7 @@ describe("createEventManager", () => {
             event,
             renderDecisions: true,
             decisionScopes: undefined,
+            personalization: undefined,
             onResponse: jasmine.any(Function),
             onRequestFailure: jasmine.any(Function)
           });


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->
Support Surfaces in personalization query requests and AJO proposition rendering
The first AJO Beta release will only support rendering of MPA page-wide propositions (SPA support will be added in subsequent releases)
Functional e2e tests and test sandbox page added in https://jira.corp.adobe.com/browse/TNT-45510

## Related Issues

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/TNT-44322
https://jira.corp.adobe.com/browse/TNT-44442
https://jira.corp.adobe.com/browse/TNT-45303
https://jira.corp.adobe.com/browse/TNT-45510

## Motivation and Context

Support Surfaces in personalization query requests and AJO proposition rendering
The first AJO Beta release will only support rendering of MPA page-wide propositions (SPA support will be added in subsequent releases)
<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
