### PR TITLE
TNT-44295-Optimize send notification events

### DIFF
--- a/src/components/Personalization/createViewChangeHandler.js
+++ b/src/components/Personalization/createViewChangeHandler.js
@@ -13,12 +13,7 @@ governing permissions and limitations under the License.
 import composePersonalizationResultingObject from "./utils/composePersonalizationResultingObject";
 import { isNonEmptyArray } from "../../utils";
 
-export default ({
-  mergeDecisionsMeta,
-  collect,
-  executeDecisions,
-  viewCache
-}) => {
+export default ({ mergeDecisionsMeta, executeDecisions, viewCache }) => {
   return ({ personalizationDetails, event, onResponse }) => {
     const viewName = personalizationDetails.getViewName();
 
@@ -33,9 +28,8 @@ export default ({
             });
             return;
           }
-          // if there are no decisions in cache for this view, we will send a empty notification
+          // if there are no decisions in cache for this view, we will merge the events.
           onResponse(() => {
-            collect({ decisionsMeta: [], viewName });
             return composePersonalizationResultingObject(viewDecisions, true);
           });
         });

--- a/test/functional/specs/Personalization/C782718.js
+++ b/test/functional/specs/Personalization/C782718.js
@@ -202,24 +202,21 @@ const simulateViewChangeForNonExistingView = async alloy => {
   );
   // assert that no personalization query was attached to the request
   await t.expect(noViewViewChangeRequestBody.events[0].query).eql(undefined);
-  // assert that a notification call with xdm.web.webPageDetails.viewName and no personalization meta is sent
-  await flushPromiseChains();
-  const noViewNotificationRequest = networkLogger.edgeEndpointLogs.requests[5];
-  const noViewNotificationRequestBody = JSON.parse(
-    noViewNotificationRequest.request.body
-  );
-  await t
-    .expect(noViewNotificationRequestBody.events[0].xdm.eventType)
-    .eql("decisioning.propositionDisplay");
+  // assert that after events merge viewName is passed down from view change
   await t
     .expect(
-      noViewNotificationRequestBody.events[0].xdm.web.webPageDetails.viewName
+      noViewViewChangeRequestBody.events[0].xdm.web.webPageDetails.viewName
     )
     .eql("noView");
   await t
     // eslint-disable-next-line no-underscore-dangle
-    .expect(noViewNotificationRequestBody.events[0].xdm._experience)
+    .expect(noViewViewChangeRequestBody.events[0].xdm._experience)
     .eql(undefined);
+  // assert that after events merge eventType is not decisioning.propositionDisplay instead  noviewoffers
+  await t
+    .expect(noViewViewChangeRequestBody.events[0].xdm.eventType)
+    .eql("noviewoffers");
+  await flushPromiseChains();
 };
 
 test("Test C782718: SPA support with auto-rendering and view notifications", async () => {

--- a/test/unit/specs/components/Personalization/createViewChangeHandler.spec.js
+++ b/test/unit/specs/components/Personalization/createViewChangeHandler.spec.js
@@ -86,7 +86,7 @@ describe("Personalization::createViewChangeHandler", () => {
     expect(collect).not.toHaveBeenCalled();
   });
 
-  it("at onResponse it should trigger collect call when no decisions in cache", () => {
+  it("at onResponse it should trigger only executeDecisions but no collect call when there are no decisions in cache", () => {
     const cartViewPromise = {
       then: callback => callback([])
     };
@@ -109,6 +109,6 @@ describe("Personalization::createViewChangeHandler", () => {
       onResponse
     });
     expect(executeDecisions).toHaveBeenCalledWith([]);
-    expect(collect).toHaveBeenCalled();
+    expect(collect).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
As part of our efforts to optimize the number of notifications sent from Alloy, we are merging couple of events.
In this PR we are merging events for below scenario :
SPA with page-view event for which the proposition was not rendered.

Epic Link: https://jira.corp.adobe.com/browse/TNT-44294
Issue Link: https://jira.corp.adobe.com/browse/TNT-44295


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [X] I have made any necessary test changes and all tests pass.
- [X] I have run the Sandbox successfully.
