### PR TITLE
applyPropositions should use array indexOf instead of includes

### DIFF
--- a/src/components/Personalization/createApplyPropositions.js
+++ b/src/components/Personalization/createApplyPropositions.js
@@ -19,7 +19,8 @@ import { EMPTY_PROPOSITIONS } from "./validateApplyPropositionsOptions";
 export const SUPPORTED_SCHEMAS = [DOM_ACTION, HTML_CONTENT_ITEM];
 
 export default ({ executeDecisions }) => {
-  const filterItemsPredicate = item => SUPPORTED_SCHEMAS.includes(item.schema);
+  const filterItemsPredicate = item =>
+    SUPPORTED_SCHEMAS.indexOf(item.schema) > -1;
 
   const updatePropositionItems = ({ items, metadataForScope }) => {
     return items

--- a/test/unit/specs/components/Personalization/createApplyPropositions.spec.js
+++ b/test/unit/specs/components/Personalization/createApplyPropositions.spec.js
@@ -214,7 +214,7 @@ describe("Personalization::createApplyPropositions", () => {
       executedPropositions.forEach(proposition => {
         expect(proposition.items.length).toEqual(1);
         proposition.items.forEach(item => {
-          expect(expectedItemIds.includes(item.id));
+          expect(expectedItemIds.indexOf(item.id) > -1);
         });
       });
     });


### PR DESCRIPTION
Update applyPropositions to use array indexOf() instead of includes() to avoid needing polyfill.  Noticed test failures in CI run:  https://github.com/adobe/alloy/actions/runs/2457283273

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
