### PR TITLE
 applyPropositions test should use array filter instead of find

### DIFF
--- a/test/unit/specs/components/Personalization/createApplyPropositions.spec.js
+++ b/test/unit/specs/components/Personalization/createApplyPropositions.spec.js
@@ -237,7 +237,7 @@ describe("Personalization::createApplyPropositions", () => {
       result.propositions.forEach(proposition => {
         const original = originalPropositions.filter(
           originalProposition => originalProposition.id === proposition.id
-        );
+        )[0];
         if (original) {
           numReturnedPropositions += 1;
           expect(proposition).not.toBe(original);

--- a/test/unit/specs/components/Personalization/createApplyPropositions.spec.js
+++ b/test/unit/specs/components/Personalization/createApplyPropositions.spec.js
@@ -235,7 +235,7 @@ describe("Personalization::createApplyPropositions", () => {
       let numReturnedPropositions = 0;
       expect(originalPropositions).toEqual(MIXED_PROPOSITIONS);
       result.propositions.forEach(proposition => {
-        const original = originalPropositions.find(
+        const original = originalPropositions.filter(
           originalProposition => originalProposition.id === proposition.id
         );
         if (original) {

--- a/test/unit/specs/components/Personalization/createApplyPropositions.spec.js
+++ b/test/unit/specs/components/Personalization/createApplyPropositions.spec.js
@@ -235,9 +235,9 @@ describe("Personalization::createApplyPropositions", () => {
       let numReturnedPropositions = 0;
       expect(originalPropositions).toEqual(MIXED_PROPOSITIONS);
       result.propositions.forEach(proposition => {
-        const original = originalPropositions.filter(
+        const [original] = originalPropositions.filter(
           originalProposition => originalProposition.id === proposition.id
-        )[0];
+        );
         if (original) {
           numReturnedPropositions += 1;
           expect(proposition).not.toBe(original);


### PR DESCRIPTION
To avoid using a polyfill for IE I switched a test case from using Array.find() to Array.filter().

<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
