### PR TITLE
Stringify functions in getLibraryInfo response

### DIFF
--- a/src/components/LibraryInfo/index.js
+++ b/src/components/LibraryInfo/index.js
@@ -13,19 +13,35 @@ governing permissions and limitations under the License.
 import libraryVersion from "../../constants/libraryVersion";
 import { CONFIGURE, SET_DEBUG } from "../../constants/coreCommands";
 
+const prepareLibraryInfo = ({ config, componentRegistry }) => {
+  const allCommands = [
+    ...componentRegistry.getCommandNames(),
+    CONFIGURE,
+    SET_DEBUG
+  ].sort();
+  const resultConfig = { ...config };
+  Object.keys(config).forEach(key => {
+    const value = config[key];
+    if (typeof value !== "function") {
+      return;
+    }
+    resultConfig[key] = value.toString();
+  });
+  return {
+    version: libraryVersion,
+    configs: resultConfig,
+    commands: allCommands
+  };
+};
+
 const createLibraryInfo = ({ config, componentRegistry }) => {
-  const allCommands = componentRegistry.getCommandNames();
-  allCommands.push(CONFIGURE, SET_DEBUG);
+  const libraryInfo = prepareLibraryInfo({ config, componentRegistry });
   return {
     commands: {
       getLibraryInfo: {
         run: () => {
           return {
-            libraryInfo: {
-              version: libraryVersion,
-              configs: config,
-              commands: allCommands.sort()
-            }
+            libraryInfo
           };
         }
       }

--- a/test/functional/specs/LibraryInfo/C2589.js
+++ b/test/functional/specs/LibraryInfo/C2589.js
@@ -49,9 +49,16 @@ test("C2589: getLibraryInfo command returns library information.", async () => {
 
   const alloy = createAlloyProxy();
   await alloy.configure(debugEnabledConfig);
-  const libraryInfo = await alloy.getLibraryInfo();
-  delete libraryInfo.libraryInfo.configs.edgeBasePath;
-  await t.expect(libraryInfo.libraryInfo.version).eql(currentVersion);
-  await t.expect(libraryInfo.libraryInfo.commands).eql(currentCommand);
-  await t.expect(libraryInfo.libraryInfo.configs).eql(currentConfigs);
+  const { libraryInfo } = await alloy.getLibraryInfo();
+  delete libraryInfo.configs.edgeBasePath;
+  await t.expect(libraryInfo.version).eql(currentVersion);
+  await t.expect(libraryInfo.commands).eql(currentCommand);
+  await t.expect(libraryInfo.configs).eql(currentConfigs);
+});
+
+test("C2589: getLibraryInfo correctly serializes functions in the config", async () => {
+  const alloy = createAlloyProxy();
+  await alloy.configure(debugEnabledConfig);
+  const { libraryInfo } = await alloy.getLibraryInfo();
+  await t.expect(typeof libraryInfo.configs.onBeforeEventSend).eql("string");
 });


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

When creating the response for `getLibraryInfo`, find all the functions that are in alloy's config and stringify them so that the response can be better marshaled and serialized.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[PDCL-8643–Web SDK details not found in debugger for Alloy v2.11.0](https://jira.corp.adobe.com/browse/PDCL-8643)

> When running the debugger on a site with Alloy v2.11.0 installed, the details for the Web SDK are not found, and an error shows in the console. I believe this is because libraryInfo now contains the configs which contains a function that cannot be marshaled across to the background page

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
