### PR TITLE
Functional Test the CGID Feature

### DIFF
--- a/test/functional/helpers/cookies.js
+++ b/test/functional/helpers/cookies.js
@@ -11,6 +11,14 @@ export default {
       document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT`;
     }
   }),
+  set: ClientFunction(options => {
+    const { name, value, duration = 3600 } = options;
+    const durationMs = duration * 1000;
+    const expires = new Date(Date.now() + durationMs);
+    document.cookie = `${name}=${escape(
+      value
+    )}; expires=${expires.toUTCString()}; domain=".alloyio.com"`;
+  }),
   get: ClientFunction(name => {
     const cookies = document.cookie
       .split(";")

--- a/test/functional/specs/Identity/cgid_FT1.js
+++ b/test/functional/specs/Identity/cgid_FT1.js
@@ -1,0 +1,77 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { t } from "testcafe";
+import {
+  compose,
+  orgMainConfigMain,
+  debugEnabled,
+  thirdPartyCookiesDisabled,
+  migrationDisabled
+} from "../../helpers/constants/configParts";
+import { TEST_PAGE } from "../../helpers/constants/url";
+import createNetworkLogger from "../../helpers/networkLogger";
+import createAlloyProxy from "../../helpers/createAlloyProxy";
+import getReturnedEcid from "../../helpers/networkLogger/getReturnedEcid";
+import createFixture from "../../helpers/createFixture";
+import reloadPage from "../../helpers/reloadPage";
+import cookies from "../../helpers/cookies";
+import { MAIN_IDENTITY_COOKIE_NAME } from "../../helpers/constants/cookies";
+
+const networkLogger = createNetworkLogger();
+const config = compose(
+  orgMainConfigMain,
+  debugEnabled,
+  thirdPartyCookiesDisabled,
+  migrationDisabled
+);
+
+createFixture({
+  url: TEST_PAGE,
+  title: "cgif_FT1: FPID from the identityMap is used to generate an ECID",
+  requestHooks: [networkLogger.edgeEndpointLogs]
+});
+
+test.meta({
+  ID: "cgif_FT1",
+  SEVERTIY: "P0",
+  TEST_RUN: "Regression"
+});
+
+const fpid = {
+  xdm: {
+    identityMap: {
+      FPID: [
+        {
+          id: "UUID"
+        }
+      ]
+    }
+  }
+};
+
+test("cgif_FT1: FPID from the identityMap generates ECID", async () => {
+  const alloy = createAlloyProxy();
+
+  await alloy.configure(config);
+  await alloy.sendEvent(fpid);
+  const ecid = getReturnedEcid(networkLogger.edgeEndpointLogs.requests[0]);
+
+  await reloadPage();
+  await cookies.remove(MAIN_IDENTITY_COOKIE_NAME);
+  await alloy.configure(config);
+  await alloy.sendEvent(fpid);
+  const ecidCompare = getReturnedEcid(
+    networkLogger.edgeEndpointLogs.requests[1]
+  );
+  await t.expect(ecid).eql(ecidCompare);
+});

--- a/test/functional/specs/Identity/cgid_FT2.js
+++ b/test/functional/specs/Identity/cgid_FT2.js
@@ -1,0 +1,70 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { t } from "testcafe";
+import uuid from "uuid/v4";
+import {
+  compose,
+  orgMainConfigMain,
+  debugEnabled,
+  thirdPartyCookiesDisabled,
+  migrationDisabled
+} from "../../helpers/constants/configParts";
+import { TEST_PAGE } from "../../helpers/constants/url";
+import createNetworkLogger from "../../helpers/networkLogger";
+import createAlloyProxy from "../../helpers/createAlloyProxy";
+import getReturnedEcid from "../../helpers/networkLogger/getReturnedEcid";
+import createFixture from "../../helpers/createFixture";
+import reloadPage from "../../helpers/reloadPage";
+import cookies from "../../helpers/cookies";
+import { MAIN_IDENTITY_COOKIE_NAME } from "../../helpers/constants/cookies";
+
+const networkLogger = createNetworkLogger();
+const config = compose(
+  orgMainConfigMain,
+  debugEnabled,
+  thirdPartyCookiesDisabled,
+  migrationDisabled
+);
+
+createFixture({
+  url: TEST_PAGE,
+  title: "cgif_FT2: FPID from a FPID cookie is used to generate an ECID",
+  requestHooks: [networkLogger.edgeEndpointLogs]
+});
+
+test.meta({
+  ID: "cgif_FT2",
+  SEVERTIY: "P0",
+  TEST_RUN: "Regression"
+});
+
+test("cgif_FT2: FPID from FPID cookie generates ECID", async () => {
+  const alloy = createAlloyProxy();
+
+  await alloy.configure(config);
+  await cookies.set({
+    name: "fpidCookie",
+    value: uuid()
+  });
+
+  await alloy.sendEvent(cookies.value);
+  const ecid = getReturnedEcid(networkLogger.edgeEndpointLogs.requests[0]);
+  await cookies.remove(MAIN_IDENTITY_COOKIE_NAME);
+  await reloadPage();
+  await alloy.configure(config);
+  await alloy.sendEvent(cookies.value);
+  const ecidCompare = getReturnedEcid(
+    networkLogger.edgeEndpointLogs.requests[1]
+  );
+  await t.expect(ecid).eql(ecidCompare);
+});

--- a/test/functional/specs/Identity/cgid_FT3.js
+++ b/test/functional/specs/Identity/cgid_FT3.js
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { t } from "testcafe";
+import {
+  compose,
+  orgMainConfigMain,
+  debugEnabled,
+  thirdPartyCookiesDisabled,
+  migrationDisabled
+} from "../../helpers/constants/configParts";
+import { TEST_PAGE } from "../../helpers/constants/url";
+import createAlloyProxy from "../../helpers/createAlloyProxy";
+import createFixture from "../../helpers/createFixture";
+import createNetworkLogger from "../../helpers/networkLogger";
+import getReturnedEcid from "../../helpers/networkLogger/getReturnedEcid";
+
+const networkLogger = createNetworkLogger();
+const config = compose(
+  orgMainConfigMain,
+  debugEnabled,
+  thirdPartyCookiesDisabled,
+  migrationDisabled
+);
+
+createFixture({
+  url: TEST_PAGE,
+  title:
+    "cgif_FT3: existing identity cookie takes precedence over an FPID provided in the identity map.",
+  requestHooks: [networkLogger.edgeEndpointLogs]
+});
+
+test.meta({
+  ID: "cgif_FT3",
+  SEVERTIY: "P0",
+  TEST_RUN: "Regression"
+});
+
+const fpid = {
+  xdm: {
+    identityMap: {
+      FPID: [
+        {
+          id: "UUID"
+        }
+      ]
+    }
+  }
+};
+
+test("cgif_FT3: identity cookie takes precedence over an FPID", async () => {
+  const alloy = createAlloyProxy();
+  await alloy.configure(config);
+  await alloy.sendEvent();
+  const ecid = await getReturnedEcid(
+    networkLogger.edgeEndpointLogs.requests[0]
+  );
+  await alloy.sendEvent(fpid);
+  const ecidCompare = getReturnedEcid(
+    networkLogger.edgeEndpointLogs.requests[1]
+  );
+  await t.expect(ecid).eql(ecidCompare);
+});


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->
Functional test the CGID Feature:
Test 1: FPID from the identityMap is used to generate an ECID
Test 2: FPID from a FPID cookie is used to generate an ECID
Test 3: Existing identity cookie takes precedence over an FPID provided in the identity map

## Related Issue
ECID / FPID features not yet included in testing.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Testing CGID features.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
