### PR TITLE
For a particular instance, only add the referrer to XDM on the first sendEvent.

### DIFF
--- a/src/components/Context/index.js
+++ b/src/components/Context/index.js
@@ -19,21 +19,27 @@ import implementationDetails from "./implementationDetails";
 import createComponent from "./createComponent";
 import { arrayOf, string } from "../../utils/validation";
 
-const web = injectWeb(window);
 const device = injectDevice(window);
 const environment = injectEnvironment(window);
 const placeContext = injectPlaceContext(() => new Date());
 const timestamp = injectTimestamp(() => new Date());
 
 const optionalContexts = {
-  web,
   device,
   environment,
   placeContext
 };
 const requiredContexts = [timestamp, implementationDetails];
 const createContext = ({ config, logger }) => {
-  return createComponent(config, logger, optionalContexts, requiredContexts);
+  // The web context is created for each instance so that the referrer is sent once
+  // per instance per page load.
+  const web = injectWeb(window);
+  return createComponent(
+    config,
+    logger,
+    { web, ...optionalContexts },
+    requiredContexts
+  );
 };
 
 createContext.namespace = "Context";

--- a/src/components/Context/injectWeb.js
+++ b/src/components/Context/injectWeb.js
@@ -13,15 +13,19 @@ governing permissions and limitations under the License.
 import { deepAssign } from "../../utils";
 
 export default window => {
+  let referrerPopulatedOnce = false;
   return xdm => {
     const web = {
       webPageDetails: {
         URL: window.location.href || window.location
-      },
-      webReferrer: {
-        URL: window.document.referrer
       }
     };
+    if (!referrerPopulatedOnce) {
+      web.webReferrer = {
+        URL: window.document.referrer
+      };
+      referrerPopulatedOnce = true;
+    }
     deepAssign(xdm, { web });
   };
 };

--- a/test/functional/helpers/constants/webContextAltConfig.js
+++ b/test/functional/helpers/constants/webContextAltConfig.js
@@ -1,0 +1,6 @@
+import orgAltConfigAlt from "./configParts/orgAltConfigAlt";
+
+export default {
+  context: ["web"],
+  ...orgAltConfigAlt
+};

--- a/test/functional/specs/Context/C2598.js
+++ b/test/functional/specs/Context/C2598.js
@@ -3,6 +3,7 @@ import createNetworkLogger from "../../helpers/networkLogger";
 import { responseStatus } from "../../helpers/assertions/index";
 import createFixture from "../../helpers/createFixture";
 import webContextConfig from "../../helpers/constants/webContextConfig";
+import webContextAltConfig from "../../helpers/constants/webContextAltConfig";
 import { TEST_PAGE as TEST_PAGE_URL } from "../../helpers/constants/url";
 import createAlloyProxy from "../../helpers/createAlloyProxy";
 
@@ -22,10 +23,15 @@ test.meta({
 });
 
 test("Test C2598 - Adds only web context data when only web is specified in configuration.", async () => {
+  const expectedReferrer = TEST_PAGE_URL;
+  const expectedURL = `${TEST_PAGE_URL}?test=C2598`;
   // navigate to set the document.referrer
-  await t.eval(() => {
-    window.document.location = `${window.document.location}`;
-  });
+  await t.eval(
+    () => {
+      window.document.location = expectedURL;
+    },
+    { dependencies: { expectedURL } }
+  );
 
   const alloy = createAlloyProxy();
   await alloy.configure(webContextConfig);
@@ -42,13 +48,34 @@ test("Test C2598 - Adds only web context data when only web is specified in conf
   await t.expect(parsedBody.events[0].xdm.web.webPageDetails).ok();
   await t
     .expect(parsedBody.events[0].xdm.web.webPageDetails.URL)
-    .eql(TEST_PAGE_URL);
+    .eql(expectedURL);
   await t.expect(parsedBody.events[0].xdm.web.webReferrer).ok();
   await t
     .expect(parsedBody.events[0].xdm.web.webReferrer.URL)
-    .eql(TEST_PAGE_URL);
+    .eql(expectedReferrer);
 
   await t.expect(parsedBody.events[0].xdm.device).notOk();
   await t.expect(parsedBody.events[0].xdm.placeContext).notOk();
   await t.expect(parsedBody.events[0].xdm.environment).notOk();
+
+  // make sure the second event doesn't have a referrer
+  await alloy.sendEvent();
+  const parsedBody2 = JSON.parse(
+    networkLogger.edgeEndpointLogs.requests[1].request.body
+  );
+  await t.expect(parsedBody2.events[0].xdm.web).ok();
+  await t.expect(parsedBody2.events[0].xdm.web.webReferrer).notOk();
+
+  // make sure another request on a different instance does have the referrer
+  const alloy2 = createAlloyProxy("instance2");
+  await alloy2.configure(webContextAltConfig);
+  await alloy2.sendEvent();
+  const parsedBody3 = JSON.parse(
+    networkLogger.edgeEndpointLogs.requests[2].request.body
+  );
+  await t.expect(parsedBody3.events[0].xdm.web).ok();
+  await t.expect(parsedBody3.events[0].xdm.web.webReferrer).ok();
+  await t
+    .expect(parsedBody3.events[0].xdm.web.webReferrer.URL)
+    .eql(expectedReferrer);
 });

--- a/test/unit/specs/components/Context/injectWeb.spec.js
+++ b/test/unit/specs/components/Context/injectWeb.spec.js
@@ -22,4 +22,27 @@ describe("Context::injectWeb", () => {
       }
     });
   });
+
+  it("only populates the referrer once", () => {
+    const xdm1 = {};
+    const xdm2 = {};
+    const web = injectWeb(window);
+    web(xdm1);
+    web(xdm2);
+    expect(xdm2).toEqual({
+      web: {
+        webPageDetails: {
+          URL: "http://mylocation.com"
+        }
+      }
+    });
+  });
+
+  it("populates the referrer once for each instance", () => {
+    const xdm1 = {};
+    const xdm2 = {};
+    injectWeb(window)(xdm1);
+    injectWeb(window)(xdm2);
+    expect(xdm2.web.webReferrer.URL).toEqual("http://myreferrer.com");
+  });
 });


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

For a particular instance, only add the referrer to XDM on the first sendEvent.

<!--- Describe your changes in detail -->

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-8762

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

AppMeasurement only sends the referrer once. The reports in the legacy Analytics are getting inflated by the extra referrers.
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
