### PR TITLE
Added configurable support for high entropy user-agent client hints

### DIFF
--- a/src/components/Context/createComponent.js
+++ b/src/components/Context/createComponent.js
@@ -28,8 +28,13 @@ export default (config, logger, availableContexts, requiredContexts) => {
     lifecycle: {
       onBeforeEvent({ event }) {
         const xdm = {};
-        contexts.forEach(context => context(xdm));
-        event.mergeXdm(xdm);
+        return Promise.all(
+          contexts.map(context => {
+            return new Promise(resolve => {
+              resolve(context(xdm));
+            });
+          })
+        ).then(event.mergeXdm(xdm));
       }
     }
   };

--- a/src/components/Context/index.js
+++ b/src/components/Context/index.js
@@ -17,6 +17,7 @@ import injectPlaceContext from "./injectPlaceContext";
 import injectTimestamp from "./injectTimestamp";
 import implementationDetails from "./implementationDetails";
 import createComponent from "./createComponent";
+import injectHighEntropyUserAgentHints from "./injectHighEntropyUserAgentHints";
 import { arrayOf, string } from "../../utils/validation";
 
 const web = injectWeb(window);
@@ -24,12 +25,17 @@ const device = injectDevice(window);
 const environment = injectEnvironment(window);
 const placeContext = injectPlaceContext(() => new Date());
 const timestamp = injectTimestamp(() => new Date());
+const highEntropyUserAgentHints = injectHighEntropyUserAgentHints(navigator);
 
-const optionalContexts = {
+const defaultContexts = {
   web,
   device,
   environment,
-  placeContext
+  placeContext,
+  highEntropyUserAgentHints
+};
+const optionalContexts = {
+  ...defaultContexts
 };
 const requiredContexts = [timestamp, implementationDetails];
 const createContext = ({ config, logger }) => {
@@ -38,7 +44,7 @@ const createContext = ({ config, logger }) => {
 
 createContext.namespace = "Context";
 createContext.configValidators = {
-  context: arrayOf(string()).default(Object.keys(optionalContexts))
+  context: arrayOf(string()).default(Object.keys(defaultContexts))
 };
 
 export default createContext;

--- a/src/components/Context/injectHighEntropyUserAgentHints.js
+++ b/src/components/Context/injectHighEntropyUserAgentHints.js
@@ -1,0 +1,43 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { deepAssign, noop } from "../../utils";
+import highEntropyUserAgentHints from "../../constants/highEntropyUserAgentClientHints";
+
+const browserSupportsUserAgentClientHints = navigator => {
+  return typeof navigator.userAgentData !== "undefined";
+};
+
+export default navigator => {
+  if (!browserSupportsUserAgentClientHints(navigator)) {
+    return noop;
+  }
+  return xdm => {
+    return navigator.userAgentData
+      .getHighEntropyValues(highEntropyUserAgentHints)
+      .then(hints => {
+        const userAgentClientHints = {};
+        highEntropyUserAgentHints.forEach(hint => {
+          if (Object.prototype.hasOwnProperty.call(hints, hint)) {
+            userAgentClientHints[hint] = hints[hint];
+          }
+        });
+        deepAssign(xdm, {
+          environment: {
+            browserDetails: {
+              userAgentClientHints
+            }
+          }
+        });
+      });
+  };
+};

--- a/src/constants/highEntropyUserAgentClientHints.js
+++ b/src/constants/highEntropyUserAgentClientHints.js
@@ -1,0 +1,13 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+export default ["architecture", "bitness", "model", "platformVersion", "wow64"];

--- a/test/functional/helpers/constants/highEntropyUserAgentHintsContextConfig.js
+++ b/test/functional/helpers/constants/highEntropyUserAgentHintsContextConfig.js
@@ -1,0 +1,6 @@
+import orgMainConfigMain from "./configParts/orgMainConfigMain";
+
+export default {
+  context: ["highEntropyUserAgentHints"],
+  ...orgMainConfigMain
+};

--- a/test/functional/helpers/isUserAgentClientHintsSupported.js
+++ b/test/functional/helpers/isUserAgentClientHintsSupported.js
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { ClientFunction } from "testcafe";
+
+export default ClientFunction(
+  () => typeof navigator.userAgentData !== "undefined"
+);

--- a/test/functional/specs/Context/C1911390.js
+++ b/test/functional/specs/Context/C1911390.js
@@ -6,8 +6,8 @@ import { orgMainConfigMain } from "../../helpers/constants/configParts";
 
 const networkLogger = createNetworkLogger();
 
-const DESCRIPTION =
-  "C1911390 - Adds only device context data when only device is specified in configuration.";
+const ID = "C1911390";
+const DESCRIPTION = `${ID} - Ensure user-provided fields for context data don't leak across requests.`;
 
 createFixture({
   title: DESCRIPTION,
@@ -15,7 +15,7 @@ createFixture({
 });
 
 test.meta({
-  ID: "C1911390",
+  ID,
   SEVERITY: "P0",
   TEST_RUN: "Regression"
 });

--- a/test/functional/specs/Context/C2597.js
+++ b/test/functional/specs/Context/C2597.js
@@ -2,24 +2,27 @@ import { t } from "testcafe";
 import createNetworkLogger from "../../helpers/networkLogger";
 import { responseStatus } from "../../helpers/assertions/index";
 import createFixture from "../../helpers/createFixture";
-
 import { orgMainConfigMain } from "../../helpers/constants/configParts";
 import createAlloyProxy from "../../helpers/createAlloyProxy";
+import isUserAgentClientHintsSupported from "../../helpers/isUserAgentClientHintsSupported";
 
 const networkLogger = createNetworkLogger();
 
+const ID = "C2597";
+const DESCRIPTION = `${ID} - Adds all context data to requests by default.`;
+
 createFixture({
-  title: "C2597 - Adds all context data to requests by default.",
+  title: DESCRIPTION,
   requestHooks: [networkLogger.edgeEndpointLogs]
 });
 
 test.meta({
-  ID: "C2597",
+  ID,
   SEVERITY: "P0",
   TEST_RUN: "Regression"
 });
 
-test("Test C2597 - Adds all context data to requests by default.", async () => {
+test(DESCRIPTION, async () => {
   const alloy = createAlloyProxy();
   await alloy.configure(orgMainConfigMain);
   await alloy.sendEvent();
@@ -35,4 +38,11 @@ test("Test C2597 - Adds all context data to requests by default.", async () => {
   await t.expect(parsedBody.events[0].xdm.placeContext).ok();
   await t.expect(parsedBody.events[0].xdm.environment.type).ok();
   await t.expect(parsedBody.events[0].xdm.web.webPageDetails).ok();
+  if (await isUserAgentClientHintsSupported()) {
+    await t
+      .expect(
+        parsedBody.events[0].xdm.environment.browserDetails.userAgentClientHints
+      )
+      .ok();
+  }
 });

--- a/test/functional/specs/Context/C2598.js
+++ b/test/functional/specs/Context/C2598.js
@@ -5,23 +5,26 @@ import createFixture from "../../helpers/createFixture";
 import webContextConfig from "../../helpers/constants/webContextConfig";
 import { TEST_PAGE as TEST_PAGE_URL } from "../../helpers/constants/url";
 import createAlloyProxy from "../../helpers/createAlloyProxy";
+import isUserAgentClientHintsSupported from "../../helpers/isUserAgentClientHintsSupported";
 
 const networkLogger = createNetworkLogger();
 
+const ID = "C2598";
+const DESCRIPTION = `${ID} - Adds only web context data when only web is specified in configuration.`;
+
 createFixture({
-  title:
-    "C2598 - Adds only web context data when only web is specified in configuration.",
+  title: DESCRIPTION,
   requestHooks: [networkLogger.edgeEndpointLogs],
   url: TEST_PAGE_URL
 });
 
 test.meta({
-  ID: "C2598",
+  ID,
   SEVERITY: "P0",
   TEST_RUN: "Regression"
 });
 
-test("Test C2598 - Adds only web context data when only web is specified in configuration.", async () => {
+test(DESCRIPTION, async () => {
   // navigate to set the document.referrer
   await t.eval(() => {
     window.document.location = `${window.document.location}`;
@@ -51,4 +54,11 @@ test("Test C2598 - Adds only web context data when only web is specified in conf
   await t.expect(parsedBody.events[0].xdm.device).notOk();
   await t.expect(parsedBody.events[0].xdm.placeContext).notOk();
   await t.expect(parsedBody.events[0].xdm.environment).notOk();
+  if (await isUserAgentClientHintsSupported()) {
+    await t
+      .expect(
+        parsedBody.events[0].xdm.environment.browserDetails.userAgentClientHints
+      )
+      .notOk();
+  }
 });

--- a/test/functional/specs/Context/C2599.js
+++ b/test/functional/specs/Context/C2599.js
@@ -5,17 +5,20 @@ import createFixture from "../../helpers/createFixture";
 import deviceContextConfig from "../../helpers/constants/deviceContextConfig";
 import createAlloyProxy from "../../helpers/createAlloyProxy";
 import { TEST_PAGE as TEST_PAGE_URL } from "../../helpers/constants/url";
+import isUserAgentClientHintsSupported from "../../helpers/isUserAgentClientHintsSupported";
 
 const networkLogger = createNetworkLogger();
 
+const ID = "C2599";
+const DESCRIPTION = `${ID} - Adds only device context data when only device is specified in configuration.`;
+
 createFixture({
-  title:
-    "C2599 - Adds only device context data when only device is specified in configuration.",
+  title: DESCRIPTION,
   requestHooks: [networkLogger.edgeEndpointLogs]
 });
 
 test.meta({
-  ID: "C2599",
+  ID,
   SEVERITY: "P0",
   TEST_RUN: "Regression"
 });
@@ -30,7 +33,7 @@ const sendEventOptions = {
   }
 };
 
-test("C2599 - Adds only device context data when only device is specified in configuration.", async () => {
+test(DESCRIPTION, async () => {
   const alloy = createAlloyProxy();
   await alloy.configure(deviceContextConfig);
   await alloy.sendEvent(sendEventOptions);
@@ -44,7 +47,13 @@ test("C2599 - Adds only device context data when only device is specified in con
 
   await t.expect(parsedBody.events[0].xdm.device).ok();
   await t.expect(parsedBody.events[0].xdm.web.webPageDetails).ok();
-
   await t.expect(parsedBody.events[0].xdm.placeContext).notOk();
   await t.expect(parsedBody.events[0].xdm.environment).notOk();
+  if (await isUserAgentClientHintsSupported()) {
+    await t
+      .expect(
+        parsedBody.events[0].xdm.environment.browserDetails.userAgentClientHints
+      )
+      .notOk();
+  }
 });

--- a/test/functional/specs/Context/C2600.js
+++ b/test/functional/specs/Context/C2600.js
@@ -5,17 +5,20 @@ import createFixture from "../../helpers/createFixture";
 import environmentContextConfig from "../../helpers/constants/environmentContextConfig";
 import createAlloyProxy from "../../helpers/createAlloyProxy";
 import { TEST_PAGE as TEST_PAGE_URL } from "../../helpers/constants/url";
+import isUserAgentClientHintsSupported from "../../helpers/isUserAgentClientHintsSupported";
 
 const networkLogger = createNetworkLogger();
 
+const ID = "C2600";
+const DESCRIPTION = `${ID} - Adds only environment context data when only device is specified in configuration.`;
+
 createFixture({
-  title:
-    "C2600 - Adds only environment context data when only device is specified in configuration.",
+  title: DESCRIPTION,
   requestHooks: [networkLogger.edgeEndpointLogs]
 });
 
 test.meta({
-  ID: "C2600",
+  ID,
   SEVERITY: "P0",
   TEST_RUN: "Regression"
 });
@@ -30,7 +33,7 @@ const sendEventOptions = {
   }
 };
 
-test("C2600 - Adds only environment context data when only device is specified in configuration.", async () => {
+test(DESCRIPTION, async () => {
   const alloy = createAlloyProxy();
   await alloy.configure(environmentContextConfig);
   await alloy.sendEvent(sendEventOptions);
@@ -44,7 +47,13 @@ test("C2600 - Adds only environment context data when only device is specified i
 
   await t.expect(parsedBody.events[0].xdm.environment).ok();
   await t.expect(parsedBody.events[0].xdm.web.webPageDetails).ok();
-
   await t.expect(parsedBody.events[0].xdm.device).notOk();
   await t.expect(parsedBody.events[0].xdm.placeContext).notOk();
+  if (await isUserAgentClientHintsSupported()) {
+    await t
+      .expect(
+        parsedBody.events[0].xdm.environment.browserDetails.userAgentClientHints
+      )
+      .notOk();
+  }
 });

--- a/test/functional/specs/Context/C7311732.js
+++ b/test/functional/specs/Context/C7311732.js
@@ -2,15 +2,15 @@ import { t } from "testcafe";
 import createNetworkLogger from "../../helpers/networkLogger";
 import { responseStatus } from "../../helpers/assertions/index";
 import createFixture from "../../helpers/createFixture";
-import placeContextConfig from "../../helpers/constants/placeContextConfig";
+import highEntropyUserAgentHintsContextConfig from "../../helpers/constants/highEntropyUserAgentHintsContextConfig";
 import createAlloyProxy from "../../helpers/createAlloyProxy";
 import { TEST_PAGE as TEST_PAGE_URL } from "../../helpers/constants/url";
 import isUserAgentClientHintsSupported from "../../helpers/isUserAgentClientHintsSupported";
 
 const networkLogger = createNetworkLogger();
 
-const ID = "C2601";
-const DESCRIPTION = `${ID} - Adds only placeContext context data when only device is specified in configuration.`;
+const ID = "C7311732";
+const DESCRIPTION = `${ID} - Adds only userAgencClientHints context data when only highEntropyUserAgentHints is specified in configuration.`;
 
 createFixture({
   title: DESCRIPTION,
@@ -35,7 +35,7 @@ const sendEventOptions = {
 
 test(DESCRIPTION, async () => {
   const alloy = createAlloyProxy();
-  await alloy.configure(placeContextConfig);
+  await alloy.configure(highEntropyUserAgentHintsContextConfig);
   await alloy.sendEvent(sendEventOptions);
 
   await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
@@ -45,15 +45,15 @@ test(DESCRIPTION, async () => {
     networkLogger.edgeEndpointLogs.requests[0].request.body
   );
 
-  await t.expect(parsedBody.events[0].xdm.placeContext).ok();
+  await t.expect(parsedBody.events[0].xdm.placeContext).notOk();
   await t.expect(parsedBody.events[0].xdm.web.webPageDetails).ok();
-  await t.expect(parsedBody.events[0].xdm.environment).notOk();
   await t.expect(parsedBody.events[0].xdm.device).notOk();
   if (await isUserAgentClientHintsSupported()) {
+    await t.expect(parsedBody.events[0].xdm.environment.type).notOk();
     await t
       .expect(
         parsedBody.events[0].xdm.environment.browserDetails.userAgentClientHints
       )
-      .notOk();
+      .ok();
   }
 });

--- a/test/functional/specs/LibraryInfo/C2589.js
+++ b/test/functional/specs/LibraryInfo/C2589.js
@@ -38,7 +38,13 @@ test("C2589: getLibraryInfo command returns library information.", async () => {
   ];
   const currentConfigs = {
     clickCollectionEnabled: true,
-    context: ["web", "device", "environment", "placeContext"],
+    context: [
+      "web",
+      "device",
+      "environment",
+      "placeContext",
+      "highEntropyUserAgentHints"
+    ],
     debugEnabled: true,
     defaultConsent: "in",
     downloadLinkQualifier:

--- a/test/unit/specs/components/Context/injectHighEntropyUserAgentHints.spec.js
+++ b/test/unit/specs/components/Context/injectHighEntropyUserAgentHints.spec.js
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import injectHighEntropyUserAgentHints from "../../../../../src/components/Context/injectHighEntropyUserAgentHints";
+
+describe("Context::injectHighEntropyUserAgentHints", () => {
+  const navigator = {
+    userAgentData: {
+      getHighEntropyValues() {
+        return Promise.resolve({
+          architecture: "x86",
+          bitness: "64",
+          model: "alloy",
+          platformVersion: "1.2.3",
+          wow64: false,
+          invalidHint: true
+        });
+      }
+    }
+  };
+
+  it("works", done => {
+    const xdm = {};
+    injectHighEntropyUserAgentHints(navigator)(xdm).then(() => {
+      expect(xdm).toEqual({
+        environment: {
+          browserDetails: {
+            userAgentClientHints: {
+              architecture: "x86",
+              bitness: "64",
+              model: "alloy",
+              platformVersion: "1.2.3",
+              wow64: false
+            }
+          }
+        }
+      });
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Description

High entropy user-agent client hints is now supported and can be configured with the `highEntropyUserAgentHints` [context ](https://experienceleague.adobe.com/docs/experience-platform/edge/fundamentals/configuring-the-sdk.html?lang=en#context) setting.

The high entropy user-agent client hints will be collected in the [browser-detail XDM schema](https://github.com/adobe/xdm/blob/master/components/datatypes/browserdetails.schema.json) ([example](https://github.com/adobe/xdm/blob/master/components/datatypes/browserdetails.example.1.json)).

## Related Issue

PDCL-8422

## Motivation and Context

Chromium based browsers are reducing the user-agent HTTP header to contain less identifiable information. This information is being made available through API's instead. The user-agent has historically been used to do device lookups and some of these lookups will only be possible going forward by using high entropy user-agent client hints.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
