### PR TITLE
Switch from testcafe driving the functional test to saucectl

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -3,6 +3,13 @@ on:
   schedule:
     - cron: "0 */24 * * *"
   workflow_dispatch:
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+  SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+  SAUCE_CAPABILITIES_OVERRIDES_PATH: "sauceLabsCapabilities.json"
+  SAUCE_JOB: "Alloy Prod Workflow"
+  ALLOY_ENV: prod
 
 jobs:
   get-testing-tags:
@@ -15,6 +22,14 @@ jobs:
         with:
           fetch-depth: 0
       - run: npm install @octokit/rest semver
+      - uses: actions/upload-artifact@v3
+        with:
+          name: sauce-config
+          path: .sauce
+      - uses: actions/upload-artifact@v3
+        with:
+          name: sauce-ignore
+          path: .sauceignore
       - name: Retrieve tags
         id: list-tags
         uses: actions/github-script@v4
@@ -29,18 +44,12 @@ jobs:
             console.log("matrixInput: ", matrixInput);
 
   chrome_workflow:
-    name: Chrome Latest
+    name: Chrome
     strategy:
+      max-parallel: 8
       matrix: ${{ fromJSON(needs.get-testing-tags.outputs.matrixInput) }}
     needs: get-testing-tags
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-      SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-      SAUCE_CAPABILITIES_OVERRIDES_PATH: "sauceLabsCapabilities.json"
-      SAUCE_JOB: "Alloy Prod Workflow"
-      ALLOY_ENV: prod
     steps:
       - name: Create a workflow dispatch event with ${{ matrix.tag }}
         uses: actions/checkout@v2.3.3
@@ -57,21 +66,154 @@ jobs:
       - name: Get version from package
         id: package-version
         uses: martinbeentjes/npm-get-version-action@master
+      - uses: actions/download-artifact@v3
+        with:
+          name: sauce-config
+          path: .sauce
+      # - uses: actions/download-artifact@v3
+      #   with:
+      #     name: sauce-ignore
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: .sauce
       - name: Install dependencies
         if: steps.npm-cache.outputs.cache-hit != 'true'
         run: npm ci
       - name: Build
         run: npm run test:functional:build:prod
-      - name: Run TestCafe Tests
-        run: npx testcafe -q -c 5 "saucelabs:Chrome@latest:macOS 11.00"
         env:
           ALLOY_PROD_VERSION: ${{ steps.package-version.outputs.current-version }}
+      - name: Suacelabs setup
+        uses: saucelabs/saucectl-run-action@v1
+        with:
+          sauce-username: ${{ secrets.SAUCE_USERNAME }}
+          sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
+          saucectl-version: v0.107.2
+          config-file: .sauce/chrome.yml
+        env:
+          ALLOY_PROD_VERSION: ${{ steps.package-version.outputs.current-version }}
+          ALLOY_ENV: prod
+          NPM_PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
       - uses: craftech-io/slack-action@v1
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: failure
         if: failure()
 
+  edge_workflow:
+    name: Edge
+    strategy:
+      max-parallel: 8
+      matrix: ${{ fromJSON(needs.get-testing-tags.outputs.matrixInput) }}
+    needs: get-testing-tags
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create a workflow dispatch event with ${{ matrix.tag }}
+        uses: actions/checkout@v2.3.3
+        with:
+          ref: refs/heads/${{ matrix.tag }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+      - uses: actions/cache@v2
+        id: npm-cache
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}-${{ secrets.NPM_CACHE_VERSION }} # increment NPM_CACHE_VERSION secret to force cache reset
+      - name: Get version from package
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@master
+      - uses: actions/download-artifact@v3
+        with:
+          name: sauce-config
+          path: .sauce
+      # - uses: actions/download-artifact@v3
+      #   with:
+      #     name: sauce-ignore
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: .sauce
+      - name: Install dependencies
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Build
+        run: npm run test:functional:build:prod
+        env:
+          ALLOY_PROD_VERSION: ${{ steps.package-version.outputs.current-version }}
+      - name: Suacelabs setup
+        uses: saucelabs/saucectl-run-action@v1
+        with:
+          sauce-username: ${{ secrets.SAUCE_USERNAME }}
+          sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
+          saucectl-version: v0.107.2
+          config-file: .sauce/edge.yml
+        env:
+          ALLOY_PROD_VERSION: ${{ steps.package-version.outputs.current-version }}
+          ALLOY_ENV: prod
+      - uses: craftech-io/slack-action@v1
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: failure
+        if: failure()
+
+  firefox_workflow:
+    name: Firefox
+    strategy:
+      max-parallel: 8
+      matrix: ${{ fromJSON(needs.get-testing-tags.outputs.matrixInput) }}
+    needs: get-testing-tags
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create a workflow dispatch event with ${{ matrix.tag }}
+        uses: actions/checkout@v2.3.3
+        with:
+          ref: refs/heads/${{ matrix.tag }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+      - uses: actions/cache@v2
+        id: npm-cache
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}-${{ secrets.NPM_CACHE_VERSION }} # increment NPM_CACHE_VERSION secret to force cache reset
+      - name: Get version from package
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@master
+      - uses: actions/download-artifact@v3
+        with:
+          name: sauce-config
+          path: .sauce
+      # - uses: actions/download-artifact@v3
+      #   with:
+      #     name: sauce-ignore
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: .sauce
+      - name: Install dependencies
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Build
+        run: npm run test:functional:build:prod
+        env:
+          ALLOY_PROD_VERSION: ${{ steps.package-version.outputs.current-version }}
+      - name: Suacelabs setup
+        uses: saucelabs/saucectl-run-action@v1
+        with:
+          sauce-username: ${{ secrets.SAUCE_USERNAME }}
+          sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
+          saucectl-version: v0.107.2
+          config-file: .sauce/firefox.yml
+        env:
+          ALLOY_PROD_VERSION: ${{ steps.package-version.outputs.current-version }}
+          ALLOY_ENV: prod
+      - uses: craftech-io/slack-action@v1
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: failure
+        if: failure()
+  
+  # The dist and test payload doesn't work with the saucectl setup.
+  
   safari_workflow:
     name: Safari Latest
     strategy:
@@ -108,94 +250,6 @@ jobs:
         run: npm run test:functional:build:prod
       - name: Run TestCafe Tests
         run: npx testcafe -q -c 5 'saucelabs:Safari@latest:macOS 11.00'
-        env:
-          ALLOY_PROD_VERSION: ${{ steps.package-version.outputs.current-version }}
-      - uses: craftech-io/slack-action@v1
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          status: failure
-        if: failure()
-
-  ie_workflow:
-    name: Internet Explorer Latest
-    strategy:
-      matrix: ${{ fromJSON(needs.get-testing-tags.outputs.matrixInput) }}
-    needs: get-testing-tags
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-      SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-      SAUCE_CAPABILITIES_OVERRIDES_PATH: "sauceLabsCapabilities.json"
-      SAUCE_JOB: "Alloy Prod Workflow"
-      ALLOY_ENV: prod
-    steps:
-      - name: Create a workflow dispatch event with ${{ matrix.tag }}
-        uses: actions/checkout@v2.3.3
-        with:
-          ref: refs/heads/${{ matrix.tag }}
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "16"
-      - uses: actions/cache@v2
-        id: npm-cache
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}-${{ secrets.NPM_CACHE_VERSION }} # increment NPM_CACHE_VERSION secret to force cache reset
-      - name: Get version from package
-        id: package-version
-        uses: martinbeentjes/npm-get-version-action@master
-      - name: Install dependencies
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: npm ci
-      - name: Build
-        run: npm run test:functional:build:prod
-      - name: Run TestCafe Tests
-        run: npx testcafe -q -c 5 'saucelabs:IE@latest:Windows 10'
-        env:
-          ALLOY_PROD_VERSION: ${{ steps.package-version.outputs.current-version }}
-      - uses: craftech-io/slack-action@v1
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          status: failure
-        if: failure()
-
-  firefox_workflow:
-    name: Firefox Latest
-    strategy:
-      matrix: ${{ fromJSON(needs.get-testing-tags.outputs.matrixInput) }}
-    needs: get-testing-tags
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-      SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-      SAUCE_CAPABILITIES_OVERRIDES_PATH: "sauceLabsCapabilities.json"
-      SAUCE_JOB: "Alloy Prod Workflow"
-      ALLOY_ENV: prod
-    steps:
-      - name: Create a workflow dispatch event with ${{ matrix.tag }}
-        uses: actions/checkout@v2.3.3
-        with:
-          ref: refs/heads/${{ matrix.tag }}
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "16"
-      - uses: actions/cache@v2
-        id: npm-cache
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}-${{ secrets.NPM_CACHE_VERSION }} # increment NPM_CACHE_VERSION secret to force cache reset
-      - name: Get version from package
-        id: package-version
-        uses: martinbeentjes/npm-get-version-action@master
-      - name: Install dependencies
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: npm ci
-      - name: Build
-        run: npm run test:functional:build:prod
-      - name: Run TestCafe Tests
-        run: npx testcafe -q -c 5 'saucelabs:Firefox@latest:Windows 10'
         env:
           ALLOY_PROD_VERSION: ${{ steps.package-version.outputs.current-version }}
       - uses: craftech-io/slack-action@v1

--- a/.sauce/chrome.yml
+++ b/.sauce/chrome.yml
@@ -1,0 +1,39 @@
+apiVersion: v1alpha
+kind: testcafe
+defaults:
+  mode: sauce
+sauce:
+  region: us-west-1
+metadata:
+  name: Testing TestCafe Support
+  tags:
+    - e2e
+    - release team
+    - other tag
+  build: Release $CI_COMMIT_SHORT_SHA
+concurrency: 30
+quarantineMode:
+  attemptLimit: 5
+  successThreshold: 3
+docker:
+  fileTransfer: mount
+showConsoleLog: true
+disablePageCaching: true
+testcafe:
+  version: 2.0.0
+reporters:
+  junit:
+    enabled: true
+    filename: saucectl-report.xml
+env:
+  ALLOY_ENV: prod
+  ALLOY_PROD_VERSION: $ALLOY_PROD_VERSION
+  NPM_PACKAGE_VERSION: $ALLOY_PROD_VERSION
+rootDir: ./
+suites:
+  - name: "Chrome Latest | Windows 11"
+    mode: sauce
+    browserName: "chrome"
+    src:
+      - "test/functional/specs/**/*.js"
+    platformName: "Windows 11"

--- a/.sauce/edge.yml
+++ b/.sauce/edge.yml
@@ -1,0 +1,39 @@
+apiVersion: v1alpha
+kind: testcafe
+defaults:
+  mode: sauce
+sauce:
+  region: us-west-1
+metadata:
+  name: Testing TestCafe Support
+  tags:
+    - e2e
+    - release team
+    - other tag
+  build: Release $CI_COMMIT_SHORT_SHA
+concurrency: 30
+quarantineMode:
+  attemptLimit: 5
+  successThreshold: 3
+docker:
+  fileTransfer: mount
+showConsoleLog: true
+disablePageCaching: true
+testcafe:
+  version: 2.0.0
+reporters:
+  junit:
+    enabled: true
+    filename: saucectl-report.xml
+env:
+  ALLOY_ENV: prod
+  ALLOY_PROD_VERSION: $ALLOY_PROD_VERSION
+  NPM_PACKAGE_VERSION: $ALLOY_PROD_VERSION
+rootDir: ./
+suites:
+  - name: "Edge Latest | Windows 11"
+    mode: sauce
+    browserName: "microsoftedge"
+    src:
+      - "test/functional/specs/**/*.js"
+    platformName: "Windows 11"

--- a/.sauce/firefox.yml
+++ b/.sauce/firefox.yml
@@ -1,0 +1,39 @@
+apiVersion: v1alpha
+kind: testcafe
+defaults:
+  mode: sauce
+sauce:
+  region: us-west-1
+metadata:
+  name: Testing TestCafe Support
+  tags:
+    - e2e
+    - release team
+    - other tag
+  build: Release $CI_COMMIT_SHORT_SHA
+concurrency: 30
+quarantineMode:
+  attemptLimit: 5
+  successThreshold: 3
+docker:
+  fileTransfer: mount
+showConsoleLog: true
+disablePageCaching: true
+testcafe:
+  version: 2.0.0
+reporters:
+  junit:
+    enabled: true
+    filename: saucectl-report.xml
+env:
+  ALLOY_ENV: prod
+  ALLOY_PROD_VERSION: $ALLOY_PROD_VERSION
+  NPM_PACKAGE_VERSION: $ALLOY_PROD_VERSION
+rootDir: ./
+suites:
+  - name: "Firefox Latest | Windows 11"
+    mode: sauce
+    browserName: "firefox"
+    src:
+      - "test/functional/specs/**/*.js"
+    platformName: "Windows 11"

--- a/.sauceignore
+++ b/.sauceignore
@@ -1,0 +1,4 @@
+# .sauceignore
+
+# Ignore node_modules
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "start-server-and-test": "^1.10.6",
         "testcafe": "^1.19.0",
         "testcafe-browser-provider-saucelabs": "^1.8.3",
-        "testcafe-reporter-testrail": "^0.6.3",
+        "testcafe-reporter-json": "^2.2.0",
         "url-exists-nodejs": "^0.1.0",
         "url-parse": "^1.4.7",
         "yargs": "^16.2.0"
@@ -13624,19 +13624,6 @@
       "integrity": "sha1-gVb87Q9RMkhlWa1WC8gGdkaSdew=",
       "dev": true
     },
-    "node_modules/testcafe-reporter-testrail": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-testrail/-/testcafe-reporter-testrail-0.6.3.tgz",
-      "integrity": "sha512-SSOGcafNocRqToeNz+/fHMaPO0lsvUZP5gtkcCJCyhmRiHOl5NiJDL90cpV2c3uxQ/F/fLnt6K9S9Qa6vwxWaw==",
-      "dev": true,
-      "dependencies": {
-        "moment": "^2.29.1",
-        "testrail-js-api": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=10.13"
-      }
-    },
     "node_modules/testcafe-reporter-xunit": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/testcafe-reporter-xunit/-/testcafe-reporter-xunit-2.2.1.tgz",
@@ -13943,33 +13930,6 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/testrail-js-api": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/testrail-js-api/-/testrail-js-api-0.2.1.tgz",
-      "integrity": "sha512-tfX3zNIELuoNP4E2RbG/3VFaRXoZBf7Y2vBKYyGuObCMb13LG7KbY2Oal6tDg916AjommAA/MPEXqmoABMbcHQ==",
-      "dev": true,
-      "dependencies": {
-        "form-data": "^3.0.0",
-        "node-fetch": "^2.6.1"
-      },
-      "engines": {
-        "node": ">=10.13"
-      }
-    },
-    "node_modules/testrail-js-api/node_modules/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/text-table": {
@@ -26039,16 +25999,6 @@
       "integrity": "sha1-gVb87Q9RMkhlWa1WC8gGdkaSdew=",
       "dev": true
     },
-    "testcafe-reporter-testrail": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-testrail/-/testcafe-reporter-testrail-0.6.3.tgz",
-      "integrity": "sha512-SSOGcafNocRqToeNz+/fHMaPO0lsvUZP5gtkcCJCyhmRiHOl5NiJDL90cpV2c3uxQ/F/fLnt6K9S9Qa6vwxWaw==",
-      "dev": true,
-      "requires": {
-        "moment": "^2.29.1",
-        "testrail-js-api": "^0.2.0"
-      }
-    },
     "testcafe-reporter-xunit": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/testcafe-reporter-xunit/-/testcafe-reporter-xunit-2.2.1.tgz",
@@ -26060,29 +26010,6 @@
       "resolved": "https://registry.npmjs.org/testcafe-safe-storage/-/testcafe-safe-storage-1.1.2.tgz",
       "integrity": "sha512-6km7D26+KCQGeFlSQ9fVEU7tD8qdioSpqzxU8CCZkd2KzBS0jTFkqaJ54rPaLdd5+wdhgO3+as3LMm4F0EDeYA==",
       "dev": true
-    },
-    "testrail-js-api": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/testrail-js-api/-/testrail-js-api-0.2.1.tgz",
-      "integrity": "sha512-tfX3zNIELuoNP4E2RbG/3VFaRXoZBf7Y2vBKYyGuObCMb13LG7KbY2Oal6tDg916AjommAA/MPEXqmoABMbcHQ==",
-      "dev": true,
-      "requires": {
-        "form-data": "^3.0.0",
-        "node-fetch": "^2.6.1"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "start-server-and-test": "^1.10.6",
     "testcafe": "^1.19.0",
     "testcafe-browser-provider-saucelabs": "^1.8.3",
-    "testcafe-reporter-testrail": "^0.6.3",
+    "testcafe-reporter-json": "^2.2.0",
     "url-exists-nodejs": "^0.1.0",
     "url-parse": "^1.4.7",
     "yargs": "^16.2.0"


### PR DESCRIPTION
When we reach a max parallel test run on saucelabs, the tests fail. Switched to using saucectl to let saucelabs drive the test and properly queue the test runs and provide proper spec reports in the console instead of an error exit code. 

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
