### PR TITLE
Fixed an issue where visitor migration does not work if `window.Visitor` is defined after configure

### DIFF
--- a/src/components/Identity/visitorService/injectGetEcidFromVisitor.js
+++ b/src/components/Identity/visitorService/injectGetEcidFromVisitor.js
@@ -13,8 +13,8 @@ governing permissions and limitations under the License.
 import getVisitor from "./getVisitor";
 
 export default ({ logger, orgId, awaitVisitorOptIn }) => {
-  const Visitor = getVisitor(window);
   return () => {
+    const Visitor = getVisitor(window);
     if (Visitor) {
       // Need to explicitly wait for optIn because visitor will call callback
       // with invalid values prior to optIn being approved

--- a/test/functional/helpers/constants/remoteVisitorLibraryUrl.js
+++ b/test/functional/helpers/constants/remoteVisitorLibraryUrl.js
@@ -1,0 +1,13 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+export default "https://github.com/Adobe-Marketing-Cloud/id-service/releases/latest/download/visitorapi.min.js";

--- a/test/functional/helpers/createFixture/clientScripts.js
+++ b/test/functional/helpers/createFixture/clientScripts.js
@@ -15,6 +15,7 @@ import fs from "fs";
 import readCache from "read-cache";
 import { ClientFunction } from "testcafe";
 import { INTEGRATION, PRODUCTION } from "../constants/alloyEnvironment";
+import REMOTE_VISITOR_LIBRARY_URL from "../constants/remoteVisitorLibraryUrl";
 
 const alloyEnv = process.env.ALLOY_ENV || INTEGRATION;
 const alloyProdVersion = process.env.ALLOY_PROD_VERSION;
@@ -38,8 +39,7 @@ const localPromisePolyfillPath = path.join(
 );
 const remotePromisePolyfillPath =
   "https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js";
-const remoteVisitorLibraryUrl =
-  "https://github.com/Adobe-Marketing-Cloud/id-service/releases/latest/download/visitorapi.min.js";
+
 const baseCodePath = path.join(
   __dirname,
   "../../../../distTest/baseCode.min.js"
@@ -116,7 +116,7 @@ const getFixtureClientScriptsForInt = options => {
   if (options.includeVisitorLibrary) {
     addRemoteUrlClientScript({
       clientScripts,
-      url: remoteVisitorLibraryUrl
+      url: REMOTE_VISITOR_LIBRARY_URL
     });
   }
 
@@ -163,7 +163,7 @@ const getFixtureClientScriptsForProd = options => {
   if (options.includeVisitorLibrary) {
     addRemoteUrlClientScript({
       clientScripts,
-      url: remoteVisitorLibraryUrl
+      url: REMOTE_VISITOR_LIBRARY_URL
     });
   }
 

--- a/test/unit/specs/components/Identity/visitorService/injectGetEcidFromVisitor.spec.js
+++ b/test/unit/specs/components/Identity/visitorService/injectGetEcidFromVisitor.spec.js
@@ -74,4 +74,18 @@ describe("getEcidFromVisitor", () => {
       return expectAsync(getEcidFromVisitor()).toBeResolvedTo(undefined);
     });
   });
+
+  it("should find Visitor if it was defined after Web SDK initialization.", () => {
+    const awaitVisitorOptIn = () => {
+      return Promise.resolve();
+    };
+
+    const getEcidFromVisitor = injectGetEcidFromVisitor({
+      logger,
+      orgId,
+      awaitVisitorOptIn
+    });
+    window.Visitor = Visitor;
+    return expectAsync(getEcidFromVisitor()).toBeResolvedTo("ecid123");
+  });
 });

--- a/test/unit/specs/components/Personalization/createNonRenderingHandler.spec.js
+++ b/test/unit/specs/components/Personalization/createNonRenderingHandler.spec.js
@@ -44,7 +44,7 @@ describe("Personalization::createNonRenderingHandler", () => {
       viewCache
     });
 
-    nonRenderingHandler({
+    return nonRenderingHandler({
       viewName,
       redirectDecisions,
       pageWideScopeDecisions,
@@ -67,7 +67,7 @@ describe("Personalization::createNonRenderingHandler", () => {
       viewCache
     });
 
-    nonRenderingHandler({
+    return nonRenderingHandler({
       viewName,
       redirectDecisions,
       pageWideScopeDecisions,


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

This bug occurs when ID migration is turned on, and `window.Visitor` is defined after the Web SDK configure command. In most base library initializations, this bug will not be a problem. This is because the visitor and Web SDK libraries will be loaded at the top of the page, then Web SDK will be initialized. `window.Visitor` is defined when the visitor.js script is loaded. This bug is a problem especially in Adobe Tags where each extension is initialized one at a time. If the Web SDK extension is initialized first, configure will be called before the Experience Cloud ID Service is initialized.
<!--- Describe your changes in detail -->

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-9421

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
