### PR TITLE
Fixed an issue where viewport width and height were populated as strings in some environments

### DIFF
--- a/src/components/Context/injectDevice.js
+++ b/src/components/Context/injectDevice.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { deepAssign } from "../../utils";
+import { deepAssign, isFunction, toInteger } from "../../utils";
 
 const getScreenOrientationViaProperty = window => {
   const {
@@ -35,11 +35,13 @@ const getScreenOrientationViaProperty = window => {
 };
 
 const getScreenOrientationViaMediaQuery = window => {
-  if (window.matchMedia("(orientation: portrait)").matches) {
-    return "portrait";
-  }
-  if (window.matchMedia("(orientation: landscape)").matches) {
-    return "landscape";
+  if (isFunction(window.matchMedia)) {
+    if (window.matchMedia("(orientation: portrait)").matches) {
+      return "portrait";
+    }
+    if (window.matchMedia("(orientation: landscape)").matches) {
+      return "landscape";
+    }
   }
 
   return null;
@@ -50,10 +52,17 @@ export default window => {
     const {
       screen: { width, height }
     } = window;
-    const device = {
-      screenHeight: height,
-      screenWidth: width
-    };
+    const device = {};
+
+    const screenHeight = toInteger(height);
+    if (screenHeight >= 0) {
+      device.screenHeight = screenHeight;
+    }
+
+    const screenWidth = toInteger(width);
+    if (screenWidth >= 0) {
+      device.screenWidth = screenWidth;
+    }
 
     const orientation =
       getScreenOrientationViaProperty(window) ||
@@ -61,6 +70,8 @@ export default window => {
     if (orientation) {
       device.screenOrientation = orientation;
     }
-    deepAssign(xdm, { device });
+    if (Object.keys(device).length > 0) {
+      deepAssign(xdm, { device });
+    }
   };
 };

--- a/src/components/Context/injectEnvironment.js
+++ b/src/components/Context/injectEnvironment.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { deepAssign, isNumber } from "../../utils";
+import { deepAssign, toInteger } from "../../utils";
 
 export default window => {
   return xdm => {
@@ -21,16 +21,16 @@ export default window => {
     const environment = {
       type: "browser"
     };
-    if (
-      isNumber(clientWidth) &&
-      clientWidth >= 0 &&
-      isNumber(clientHeight) &&
-      clientHeight >= 0
-    ) {
-      environment.browserDetails = {
-        viewportWidth: Math.round(clientWidth),
-        viewportHeight: Math.round(clientHeight)
-      };
+
+    const viewportWidth = toInteger(clientWidth);
+    if (viewportWidth >= 0) {
+      environment.browserDetails = { viewportWidth };
+    }
+
+    const viewportHeight = toInteger(clientHeight);
+    if (viewportHeight >= 0) {
+      environment.browserDetails = environment.browserDetails || {};
+      environment.browserDetails.viewportHeight = viewportHeight;
     }
 
     deepAssign(xdm, { environment });

--- a/src/utils/toInteger.js
+++ b/src/utils/toInteger.js
@@ -10,11 +10,21 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import isNumber from "./isNumber";
+import isString from "./isString";
+
 /*
  * coerce `value` to a number or return `defaultValue` if it cannot be.
+ *
+ * The coersion is attempted if value is a number or string.
  */
 export default (value, defaultValue) => {
-  const n = Math.round(Number(value));
-  // eslint-disable-next-line no-restricted-globals
-  return isNaN(n) ? defaultValue : n;
+  if (isNumber(value) || isString(value)) {
+    const n = Math.round(Number(value));
+    // eslint-disable-next-line no-restricted-globals
+    if (!isNaN(n)) {
+      return n;
+    }
+  }
+  return defaultValue;
 };

--- a/test/unit/specs/components/Context/injectDevice.spec.js
+++ b/test/unit/specs/components/Context/injectDevice.spec.js
@@ -66,6 +66,30 @@ describe("Context::injectDevice", () => {
     });
   });
 
+  it("handles string values for the height and width", () => {
+    window = {
+      screen: {
+        width: "600",
+        height: "800"
+      }
+    };
+    expect(run()).toEqual({
+      device: {
+        screenHeight: 800,
+        screenWidth: 600
+      }
+    });
+  });
+  it("handles no good values", () => {
+    window = {
+      screen: {
+        width: null,
+        height: undefined
+      }
+    };
+    expect(run()).toEqual({});
+  });
+
   [
     undefined,
     null,

--- a/test/unit/specs/components/Context/injectEnvironment.spec.js
+++ b/test/unit/specs/components/Context/injectEnvironment.spec.js
@@ -133,4 +133,59 @@ describe("Context::injectEnvironment", () => {
       }
     }
   );
+
+  run(
+    "handles null values",
+    {
+      document: {
+        documentElement: {
+          clientWidth: null,
+          clientHeight: null
+        }
+      }
+    },
+    {
+      environment: {
+        type: "browser"
+      }
+    }
+  );
+
+  run(
+    "handles only width",
+    {
+      document: {
+        documentElement: {
+          clientWidth: 1234
+        }
+      }
+    },
+    {
+      environment: {
+        type: "browser",
+        browserDetails: {
+          viewportWidth: 1234
+        }
+      }
+    }
+  );
+
+  run(
+    "handles only height",
+    {
+      document: {
+        documentElement: {
+          clientHeight: "1234.5"
+        }
+      }
+    },
+    {
+      environment: {
+        type: "browser",
+        browserDetails: {
+          viewportHeight: 1235
+        }
+      }
+    }
+  );
 });

--- a/test/unit/specs/utils/toInteger.spec.js
+++ b/test/unit/specs/utils/toInteger.spec.js
@@ -22,7 +22,14 @@ describe("toInteger", () => {
     ["123abc", undefined],
     [-42, -42],
     [3.14, 3],
-    [3.99, 4]
+    [3.99, 4],
+    [null, undefined],
+    [undefined, undefined],
+    [{}, undefined],
+    [true, undefined],
+    [false, undefined],
+    [() => 42, undefined],
+    ["1234.5", 1235]
   ].forEach(([input, output]) => {
     it(`converts "${input}" to ${output}`, () => {
       expect(toInteger(input)).toEqual(output);


### PR DESCRIPTION

<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

This change coerces viewport height and width strings into integers. Also, I updated the logic in the browserDetails section to match. I realized that nulls were being reported as 0 instead of undefined.
<!--- Describe your changes in detail -->

## Related Issue

https://jira.corp.adobe.com/browse/PLATIR-23966
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
