### PR TITLE
Update Unit Test Sauce Labs Compatibility with Firefox GeckoDriver 

### DIFF
--- a/karma.saucelabs.conf.js
+++ b/karma.saucelabs.conf.js
@@ -1,5 +1,4 @@
 const karmaSauceLauncher = require("karma-sauce-launcher");
-
 const karmaConfig = require("./karma.conf");
 
 module.exports = config => {
@@ -9,17 +8,7 @@ module.exports = config => {
       base: "SauceLabs",
       browserName: "chrome",
       browserVersion: "latest",
-      "sauce:options": {
-        tags: ["w3c-chrome"]
-      }
-    },
-    sl_firefoxW3C: {
-      base: "SauceLabs",
-      browserName: "firefox",
-      browserVersion: "latest",
-      "sauce:options": {
-        tags: ["w3c-firefox"]
-      }
+      platform: "Windows 11"
     },
     sl_safariW3C: {
       base: "SauceLabs",
@@ -27,18 +16,33 @@ module.exports = config => {
       browserVersion: "latest",
       platform: "macOS 11.00"
     },
-    sl_ieW3C: {
+    sl_firefoxW3C: {
       base: "SauceLabs",
-      browserName: "internet explorer",
+      browserName: "firefox",
+      platformName: "Windows 11",
       browserVersion: "latest",
-      platform: "Windows 10"
+      "sauce:options": {
+        geckodriverVersion: "0.27.0"
+      }
+    },
+    sl_edgeW3C: {
+      base: "SauceLabs",
+      browserName: "microsoftedge",
+      browserVersion: "latest",
+      platform: "Windows 11"
     }
   };
 
   config.set({
     browsers: Object.keys(customLaunchers),
     customLaunchers,
-
+    concurrency: 10,
+    colors: true,
+    sauceLabs: {
+      screenResolution: "800x600",
+      build: `GH #${process.env.BUILD_NUMBER} (${process.env.BUILD_ID})`,
+      tunnelIdentifier: process.env.JOB_NUMBER
+    },
     plugins: [
       "karma-jasmine",
       "karma-coverage",


### PR DESCRIPTION
Due to a recent change made by Mozilla, Sauce Labs will update Firefox GeckoDriver to version 0.31.0 on October 4, 2022 for Firefox versions 90 and later. 

Use GeckoDriver 0.27.0 with saucelabs for Unit test

<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
