### PR TITLE
Fixed an issue where user-agent client hint properties could be of the wrong type.

### DIFF
--- a/src/components/Context/injectHighEntropyUserAgentHints.js
+++ b/src/components/Context/injectHighEntropyUserAgentHints.js
@@ -24,12 +24,18 @@ export default navigator => {
   return (xdm, logger) => {
     try {
       return navigator.userAgentData
-        .getHighEntropyValues(highEntropyUserAgentHints)
+        .getHighEntropyValues(highEntropyUserAgentHints.map(hint => hint[0]))
         .then(hints => {
           const userAgentClientHints = {};
           highEntropyUserAgentHints.forEach(hint => {
-            if (Object.prototype.hasOwnProperty.call(hints, hint)) {
-              userAgentClientHints[hint] = hints[hint];
+            const hintName = hint[0];
+            const hintType = hint[1];
+            if (
+              Object.prototype.hasOwnProperty.call(hints, hintName) &&
+              /* eslint-disable-next-line valid-typeof */
+              typeof hints[hintName] === hintType
+            ) {
+              userAgentClientHints[hintName] = hints[hintName];
             }
           });
           deepAssign(xdm, {

--- a/src/components/Context/injectHighEntropyUserAgentHints.js
+++ b/src/components/Context/injectHighEntropyUserAgentHints.js
@@ -27,9 +27,7 @@ export default navigator => {
         .getHighEntropyValues(highEntropyUserAgentHints.map(hint => hint[0]))
         .then(hints => {
           const userAgentClientHints = {};
-          highEntropyUserAgentHints.forEach(hint => {
-            const hintName = hint[0];
-            const hintType = hint[1];
+          highEntropyUserAgentHints.forEach(([hintName, hintType]) => {
             if (
               Object.prototype.hasOwnProperty.call(hints, hintName) &&
               /* eslint-disable-next-line valid-typeof */

--- a/src/constants/highEntropyUserAgentClientHints.js
+++ b/src/constants/highEntropyUserAgentClientHints.js
@@ -10,4 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export default ["architecture", "bitness", "model", "platformVersion", "wow64"];
+export default [
+  ["architecture", "string"],
+  ["bitness", "string"],
+  ["model", "string"],
+  ["platformVersion", "string"],
+  ["wow64", "boolean"]
+];


### PR DESCRIPTION
## Description

If the `navigator.userAgentData` were to provide properties with data types not matching the user-agent client hints specifications we can end up populating XDM fields with the wrong type. To prevent this from happening this PR introduces type checking for the hints that we collect. If a type mismatch occurs that property will not be included in the XDM.

## Related Issue

PDCL-9602

## Motivation and Context

Prevent XDM schema verification errors due to wrong user-agent client hint data types.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
