### PR TITLE
Fixed an issue with Adobe Target VEC custom code actions where the code was injected into an alternate location than with at.js.

### DIFF
--- a/src/components/Personalization/dom-actions/executeActions.js
+++ b/src/components/Personalization/dom-actions/executeActions.js
@@ -10,7 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import preprocess from "./remapHeadOffers";
+import remapHeadOffers from "./remapHeadOffers";
+import { assign } from "../../../utils";
+import remapCustomCodeOffers from "./remapCustomCodeOffers";
 
 const logActionError = (logger, action, error) => {
   if (logger.enabled) {
@@ -42,6 +44,14 @@ const executeAction = (logger, modules, type, args) => {
   }
   return execute(...args);
 };
+
+const PREPROCESSORS = [remapHeadOffers, remapCustomCodeOffers];
+
+const preprocess = action =>
+  PREPROCESSORS.reduce(
+    (processed, fn) => assign(processed, fn(processed)),
+    action
+  );
 
 export default (actions, modules, logger) => {
   const actionPromises = actions.map(action => {

--- a/src/components/Personalization/dom-actions/remapCustomCodeOffers.js
+++ b/src/components/Personalization/dom-actions/remapCustomCodeOffers.js
@@ -1,0 +1,34 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/*
+ * Preprocess customCode actions before rendering, so that offer selectors are remapped appropriately for
+ * target offers, to align with the way it works in at.js.
+ */
+import { assign } from "../../../utils";
+
+const ACTION_CUSTOM_CODE = "customCode";
+const TARGET_BODY_SELECTOR = "BODY > *:eq(0)";
+
+export default action => {
+  const { selector, type } = action;
+
+  if (type !== ACTION_CUSTOM_CODE) {
+    return action;
+  }
+
+  if (selector !== TARGET_BODY_SELECTOR) {
+    return action;
+  }
+
+  return assign({}, action, { selector: "BODY" });
+};

--- a/test/unit/specs/components/Personalization/dom-actions/remapCustomCodeOffers.spec.js
+++ b/test/unit/specs/components/Personalization/dom-actions/remapCustomCodeOffers.spec.js
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import remapCustomCodeOffers from "../../../../../../src/components/Personalization/dom-actions/remapCustomCodeOffers";
+
+describe("remapCustomCodeOffers", () => {
+  it("changes target selector to parent for standard body selector", () => {
+    expect(
+      remapCustomCodeOffers({
+        type: "customCode",
+        content: "<div>superfluous</div>",
+        selector: "BODY > *:eq(0)"
+      })
+    ).toEqual({
+      type: "customCode",
+      content: "<div>superfluous</div>",
+      selector: "BODY"
+    });
+  });
+
+  it("does not change selector if non-standard", () => {
+    expect(
+      remapCustomCodeOffers({
+        type: "customCode",
+        content: "<div>superfluous</div>",
+        selector: ".whoopie"
+      })
+    ).toEqual({
+      type: "customCode",
+      content: "<div>superfluous</div>",
+      selector: ".whoopie"
+    });
+  });
+
+  it("only handles customCode type", () => {
+    expect(
+      remapCustomCodeOffers({
+        type: "somethingSpecial",
+        content: "<div>superfluous</div>",
+        selector: "BODY > *:eq(0)"
+      })
+    ).toEqual({
+      type: "somethingSpecial",
+      content: "<div>superfluous</div>",
+      selector: "BODY > *:eq(0)"
+    });
+  });
+});


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

There is a problem with the way customCode actions are handled in alloy, compared to at.js.  When customCode actions are created with VEC in target, the selector (for non-HEAD) is always `BODY > *:eq(0)`.  

In at.js customCode offers are always appended to the parent element of the element the selector points to.  In this case it would alway append it to the `BODY` element.

But in alloy, customCode offers are appended to the element targeted by the selector.  So every (non HEAD) offer is injected to the first element within the BODY tag.  

Many customers may not have even noticed this difference, because injecting to the first element could have been enough.  But one customer is having an issue because the first element inside the body of their page is a `script` tag.  So the HTML of the custom code offer is appended to the script tag.  Which obviously causes problems.  

This PR fixes this problem by remapping custom code offers that target `BODY > *:eq(0)` to `BODY`.  

Although I think customCode actions are a target-specific thing, I wanted to preserve the functionality of injecting code directly into the element (just in case it is used or will be used in other personalization solutions).  For the target use case, this code remaps the known selector to the appropriate (parent) one instead.

## Related Issue

https://jira.corp.adobe.com/browse/TNT-46186

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [X] I have made any necessary test changes and all tests pass.
- [X] I have run the Sandbox successfully.
