### PR TITLE
Remove console error for failed URL destination.

### DIFF
--- a/src/components/Audiences/injectProcessDestinations.js
+++ b/src/components/Audiences/injectProcessDestinations.js
@@ -55,7 +55,6 @@ export default ({
             // We intentionally do not throw an error if destinations fail. We
             // consider it a non-critical failure and therefore do not want it to
             // reject the promise handed back to the customer.
-            logger.error(createResultLogMessage(urlDestination, false));
           });
       })
     ).then(noop);

--- a/test/unit/specs/components/Audiences/injectProcessDestinations.spec.js
+++ b/test/unit/specs/components/Audiences/injectProcessDestinations.spec.js
@@ -144,9 +144,6 @@ describe("Audiences::injectProcessDestinations", () => {
       expect(logger.info).toHaveBeenCalledWith(
         "URL destination succeeded: http://test.zyx"
       );
-      expect(logger.error).toHaveBeenCalledWith(
-        "URL destination failed: http://test.abc"
-      );
     });
   });
   it("doesn't return a value", () => {


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

When a URL destination fails for any reason, do not show an error. It is up to the customer to make sure that they are entering in valid URL destinations and they will need to monitor their audience performance.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[PDCL-10013: Web SDK fails to inject Facebook Pixel URL destination](https://jira.corp.adobe.com/browse/PDCL-10013)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Facebook Pixel URL destinations return an empty 200 response. This causes Alloy to show a false console error, reporting that the URL destination failed. 

[Silent failure matches the behavior of VisitorJS.](https://git.corp.adobe.com/mc-visitor/visitor-js-client/blob/0a43fd23937eca42ffb55589dbf5984e68baa3ab/lib/units/makeDestinationPublishing.js#L454)

## Alternatives

- Tell the customer to ignore the error, since it only appears in Alloy debug mode.
- Try and `fetch()` the failed URL destination to see the response code.
  - This may run into CORS issues and would make firing a referrer take longer.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
