### PR TITLE
Support per-command overrides of the datastream ID

### DIFF
--- a/src/components/Identity/getIdentity/createGetIdentity.js
+++ b/src/components/Identity/getIdentity/createGetIdentity.js
@@ -17,8 +17,15 @@ export default ({
   globalConfigOverrides
 }) => {
   return ({ namespaces, edgeConfigOverrides: localConfigOverrides } = {}) => {
+    const { edgeConfigId } = localConfigOverrides || {};
+    if (edgeConfigId) {
+      delete localConfigOverrides.edgeConfigId;
+    }
     const payload = createIdentityRequestPayload(namespaces);
-    const request = createIdentityRequest(payload);
+    const request = createIdentityRequest({
+      payload,
+      edgeConfigIdOverride: edgeConfigId
+    });
     // merge the configurations, but give preference to the command-local configs
     payload.mergeConfigOverride(globalConfigOverrides);
     payload.mergeConfigOverride(localConfigOverrides);

--- a/src/components/Identity/getIdentity/createIdentityRequest.js
+++ b/src/components/Identity/getIdentity/createIdentityRequest.js
@@ -12,9 +12,10 @@ governing permissions and limitations under the License.
 
 import { createRequest } from "../../../utils/request";
 
-export default identityRequestPayload => {
+export default ({ payload, edgeConfigIdOverride }) => {
   return createRequest({
-    payload: identityRequestPayload,
+    payload,
+    edgeConfigIdOverride,
     getAction() {
       return "identity/acquire";
     },

--- a/src/components/Privacy/createConsentRequest.js
+++ b/src/components/Privacy/createConsentRequest.js
@@ -12,9 +12,10 @@ governing permissions and limitations under the License.
 
 import { createRequest } from "../../utils/request";
 
-export default consentRequestPayload => {
+export default ({ payload, edgeConfigIdOverride }) => {
   return createRequest({
-    payload: consentRequestPayload,
+    payload,
+    edgeConfigIdOverride,
     getAction() {
       return "privacy/set-consent";
     },

--- a/src/components/Privacy/injectSendSetConsentRequest.js
+++ b/src/components/Privacy/injectSendSetConsentRequest.js
@@ -24,6 +24,10 @@ export default ({
 }) => {
   const payload = createConsentRequestPayload();
   payload.setConsent(consentOptions);
+  const { edgeConfigId: edgeConfigIdOverride } = localConfigOverrides || {};
+  if (edgeConfigIdOverride) {
+    delete localConfigOverrides.edgeConfigId;
+  }
   payload.mergeConfigOverride(globalConfigOverrides);
   payload.mergeConfigOverride(localConfigOverrides);
   if (isObject(identityMap)) {
@@ -33,7 +37,10 @@ export default ({
       });
     });
   }
-  const request = createConsentRequest(payload);
+  const request = createConsentRequest({
+    payload,
+    edgeConfigIdOverride
+  });
   return sendEdgeNetworkRequest({
     request
   }).then(() => {

--- a/src/core/createEventManager.js
+++ b/src/core/createEventManager.js
@@ -48,6 +48,9 @@ export default ({
      * @param {Object} [options.serverState]
      * This will be passed to components
      * so they can take appropriate action.
+     * @param {Object} [options.edgeConfigOverrides] Settings that take
+     * precedence over the global datastream configuration, including which
+     * datastream to use.
      * @returns {*}
      */
     sendEvent(event, options = {}) {
@@ -58,7 +61,14 @@ export default ({
         personalization
       } = options;
       const payload = createDataCollectionRequestPayload();
-      const request = createDataCollectionRequest(payload);
+      const { edgeConfigId } = localConfigOverrides || {};
+      if (edgeConfigId) {
+        delete localConfigOverrides.edgeConfigId;
+      }
+      const request = createDataCollectionRequest({
+        payload,
+        edgeConfigIdOverride: edgeConfigId
+      });
       const onResponseCallbackAggregator = createCallbackAggregator();
       const onRequestFailureCallbackAggregator = createCallbackAggregator();
       payload.mergeConfigOverride(globalConfigOverrides);
@@ -120,7 +130,7 @@ export default ({
       } = options;
 
       const payload = createDataCollectionRequestPayload();
-      const request = createDataCollectionRequest(payload);
+      const request = createDataCollectionRequest({ payload });
       const onResponseCallbackAggregator = createCallbackAggregator();
 
       return lifecycle

--- a/src/core/edgeNetwork/injectSendEdgeNetworkRequest.js
+++ b/src/core/edgeNetwork/injectSendEdgeNetworkRequest.js
@@ -59,7 +59,9 @@ export default ({
         const edgeBasePathWithLocationHint = locationHint
           ? `${edgeBasePath}/${locationHint}`
           : edgeBasePath;
-        const url = `https://${endpointDomain}/${edgeBasePathWithLocationHint}/${apiVersion}/${request.getAction()}?configId=${edgeConfigId}&requestId=${request.getId()}${getAssuranceValidationTokenParams()}`;
+        const finalEdgeConfigId =
+          request.getEdgeConfigIdOverride() || edgeConfigId;
+        const url = `https://${endpointDomain}/${edgeBasePathWithLocationHint}/${apiVersion}/${request.getAction()}?configId=${finalEdgeConfigId}&requestId=${request.getId()}${getAssuranceValidationTokenParams()}`;
         cookieTransfer.cookiesToPayload(request.getPayload(), endpointDomain);
         return sendNetworkRequest({
           requestId: request.getId(),

--- a/src/utils/request/createDataCollectionRequest.js
+++ b/src/utils/request/createDataCollectionRequest.js
@@ -12,7 +12,10 @@ governing permissions and limitations under the License.
 
 import createRequest from "./createRequest";
 
-export default dataCollectionRequestPayload => {
+export default ({
+  payload: dataCollectionRequestPayload,
+  edgeConfigIdOverride
+}) => {
   const getUseSendBeacon = ({ isIdentityEstablished }) => {
     // When the document may be unloading, we still hit the interact endpoint
     // using fetch if an identity has not been established. If we were instead
@@ -61,6 +64,7 @@ export default dataCollectionRequestPayload => {
         ? "collect"
         : "interact";
     },
-    getUseSendBeacon
+    getUseSendBeacon,
+    edgeConfigIdOverride
   });
 };

--- a/src/utils/request/createRequest.js
+++ b/src/utils/request/createRequest.js
@@ -14,7 +14,12 @@ import { uuid } from "..";
 
 // This provides the base functionality that all types of requests share.
 export default options => {
-  const { payload, getAction, getUseSendBeacon } = options;
+  const {
+    payload,
+    getAction,
+    getUseSendBeacon,
+    edgeConfigIdOverride
+  } = options;
   const id = uuid();
   let shouldUseThirdPartyDomain = false;
   let isIdentityEstablished = false;
@@ -28,6 +33,9 @@ export default options => {
     },
     getAction() {
       return getAction({ isIdentityEstablished });
+    },
+    getEdgeConfigIdOverride() {
+      return edgeConfigIdOverride;
     },
     getUseSendBeacon() {
       return getUseSendBeacon({ isIdentityEstablished });

--- a/test/functional/specs/Config Overrides/C7437530.js
+++ b/test/functional/specs/Config Overrides/C7437530.js
@@ -1,3 +1,14 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
 import { t } from "testcafe";
 import createNetworkLogger from "../../helpers/networkLogger";
 import { responseStatus } from "../../helpers/assertions/index";
@@ -200,6 +211,5 @@ test("Test C7437530: `sendEvent` can override the edgeConfigId", async () => {
   await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
   const [request] = networkLogger.edgeEndpointLogs.requests;
-  await t.expect(request.request.url).notContains(originalEdgeConfigId);
   await t.expect(request.request.url).contains(alternateEdgeConfigId);
 });

--- a/test/functional/specs/Config Overrides/C7437531.js
+++ b/test/functional/specs/Config Overrides/C7437531.js
@@ -149,3 +149,21 @@ test("Test C7437531: empty configuration overrides should not be sent to the Edg
     .eql(overrides.com_adobe_identity.idSyncContainerId);
   await t.expect(request.meta.configOverrides.com_adobe_target).eql(undefined);
 });
+
+test("Test C7437531: `getIdentity` can override the edgeConfigId", async () => {
+  const alloy = createAlloyProxy();
+  await alloy.configure(config);
+  const { edgeConfigId: originalEdgeConfigId } = config;
+  const alternateEdgeConfigId = `${originalEdgeConfigId}:dev`;
+  await alloy.getIdentity({
+    edgeConfigOverrides: {
+      edgeConfigId: alternateEdgeConfigId
+    }
+  });
+
+  await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
+  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
+  const [request] = networkLogger.edgeEndpointLogs.requests;
+  await t.expect(request.request.url).notContains(originalEdgeConfigId);
+  await t.expect(request.request.url).contains(alternateEdgeConfigId);
+});

--- a/test/functional/specs/Config Overrides/C7437531.js
+++ b/test/functional/specs/Config Overrides/C7437531.js
@@ -172,8 +172,8 @@ test("Test C7437531: `getIdentity` can override the edgeConfigId", async () => {
     }
   });
 
-  await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
-  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
-  const [request] = networkLogger.edgeEndpointLogs.requests;
+  await responseStatus(networkLogger.acquireEndpointLogs.requests, 200);
+  await t.expect(networkLogger.acquireEndpointLogs.requests.length).eql(1);
+  const [request] = networkLogger.acquireEndpointLogs.requests;
   await t.expect(request.request.url).contains(alternateEdgeConfigId);
 });

--- a/test/functional/specs/Config Overrides/C7437531.js
+++ b/test/functional/specs/Config Overrides/C7437531.js
@@ -1,3 +1,14 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
 import { t } from "testcafe";
 import createNetworkLogger from "../../helpers/networkLogger";
 import { responseStatus } from "../../helpers/assertions/index";
@@ -164,6 +175,5 @@ test("Test C7437531: `getIdentity` can override the edgeConfigId", async () => {
   await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
   const [request] = networkLogger.edgeEndpointLogs.requests;
-  await t.expect(request.request.url).notContains(originalEdgeConfigId);
   await t.expect(request.request.url).contains(alternateEdgeConfigId);
 });

--- a/test/functional/specs/Config Overrides/C7437532.js
+++ b/test/functional/specs/Config Overrides/C7437532.js
@@ -175,13 +175,14 @@ test("Test C7437532: `appendIdentityToUrl` can override the edgeConfigId", async
   const { edgeConfigId: originalEdgeConfigId } = config;
   const alternateEdgeConfigId = `${originalEdgeConfigId}:dev`;
   await alloy.appendIdentityToUrl({
+    url: "https://example.com",
     edgeConfigOverrides: {
       edgeConfigId: alternateEdgeConfigId
     }
   });
 
-  await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
-  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
-  const [request] = networkLogger.edgeEndpointLogs.requests;
+  await responseStatus(networkLogger.acquireEndpointLogs.requests, 200);
+  await t.expect(networkLogger.acquireEndpointLogs.requests.length).eql(1);
+  const [request] = networkLogger.acquireEndpointLogs.requests;
   await t.expect(request.request.url).contains(alternateEdgeConfigId);
 });

--- a/test/functional/specs/Config Overrides/C7437532.js
+++ b/test/functional/specs/Config Overrides/C7437532.js
@@ -157,3 +157,21 @@ test("Test C7437532: empty configuration overrides should not be sent to the Edg
     .eql(overrides.com_adobe_identity.idSyncContainerId);
   await t.expect(request.meta.configOverrides.com_adobe_target).eql(undefined);
 });
+
+test("Test C7437532: `appendIdentityToUrl` can override the edgeConfigId", async () => {
+  const alloy = createAlloyProxy();
+  await alloy.configure(config);
+  const { edgeConfigId: originalEdgeConfigId } = config;
+  const alternateEdgeConfigId = `${originalEdgeConfigId}:dev`;
+  await alloy.appendIdentityToUrl({
+    edgeConfigOverrides: {
+      edgeConfigId: alternateEdgeConfigId
+    }
+  });
+
+  await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
+  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
+  const [request] = networkLogger.edgeEndpointLogs.requests;
+  await t.expect(request.request.url).notContains(originalEdgeConfigId);
+  await t.expect(request.request.url).contains(alternateEdgeConfigId);
+});

--- a/test/functional/specs/Config Overrides/C7437532.js
+++ b/test/functional/specs/Config Overrides/C7437532.js
@@ -1,3 +1,14 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
 import { t } from "testcafe";
 import createNetworkLogger from "../../helpers/networkLogger";
 import { responseStatus } from "../../helpers/assertions/index";
@@ -172,6 +183,5 @@ test("Test C7437532: `appendIdentityToUrl` can override the edgeConfigId", async
   await responseStatus(networkLogger.edgeEndpointLogs.requests, 200);
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
   const [request] = networkLogger.edgeEndpointLogs.requests;
-  await t.expect(request.request.url).notContains(originalEdgeConfigId);
   await t.expect(request.request.url).contains(alternateEdgeConfigId);
 });

--- a/test/functional/specs/Config Overrides/C7437533.js
+++ b/test/functional/specs/Config Overrides/C7437533.js
@@ -1,3 +1,14 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
 import { t } from "testcafe";
 import createNetworkLogger from "../../helpers/networkLogger";
 import { responseStatus } from "../../helpers/assertions/index";
@@ -165,6 +176,5 @@ test("Test C7437533: `setConsent` can override the edgeConfigId", async () => {
   await responseStatus(networkLogger.setConsentEndpointLogs.requests, 200);
   await t.expect(networkLogger.setConsentEndpointLogs.requests.length).eql(1);
   const [request] = networkLogger.setConsentEndpointLogs.requests;
-  await t.expect(request.request.url).notContains(originalEdgeConfigId);
   await t.expect(request.request.url).contains(alternateEdgeConfigId);
 });

--- a/test/unit/specs/components/Identity/getIdentity/createGetIdentity.spec.js
+++ b/test/unit/specs/components/Identity/getIdentity/createGetIdentity.spec.js
@@ -81,12 +81,18 @@ describe("Identity::createGetIdentity", () => {
       "namespace1",
       "namespace2"
     ]);
-    expect(createIdentityRequest).toHaveBeenCalledWith(payload1);
+    expect(createIdentityRequest).toHaveBeenCalledWith({
+      payload: payload1,
+      edgeConfigIdOverride: undefined
+    });
     expect(sendEdgeNetworkRequest).toHaveBeenCalledWith({
       request: request1
     });
     getIdentity();
-    expect(createIdentityRequest).toHaveBeenCalledWith(payload2);
+    expect(createIdentityRequest).toHaveBeenCalledWith({
+      payload: payload2,
+      edgeConfigIdOverride: undefined
+    });
     expect(sendEdgeNetworkRequest).toHaveBeenCalledWith({
       request: request2
     });
@@ -111,7 +117,10 @@ describe("Identity::createGetIdentity", () => {
       edgeConfigOverrides: configuration
     });
     expect(createIdentityRequestPayload).toHaveBeenCalledWith(["namespace1"]);
-    expect(createIdentityRequest).toHaveBeenCalledWith(requestPayload);
+    expect(createIdentityRequest).toHaveBeenCalledWith({
+      payload: requestPayload,
+      edgeConfigIdOverride: undefined
+    });
     expect(sendEdgeNetworkRequest).toHaveBeenCalledWith({
       request: request1
     });
@@ -141,7 +150,10 @@ describe("Identity::createGetIdentity", () => {
       namespaces: ["namespace1"]
     });
     expect(createIdentityRequestPayload).toHaveBeenCalledWith(["namespace1"]);
-    expect(createIdentityRequest).toHaveBeenCalledWith(requestPayload);
+    expect(createIdentityRequest).toHaveBeenCalledWith({
+      payload: requestPayload,
+      edgeConfigIdOverride: undefined
+    });
     expect(sendEdgeNetworkRequest).toHaveBeenCalledWith({
       request: request1
     });

--- a/test/unit/specs/components/Identity/getIdentity/createIdentityRequest.spec.js
+++ b/test/unit/specs/components/Identity/getIdentity/createIdentityRequest.spec.js
@@ -14,17 +14,17 @@ import describeRequest from "../../../../helpers/describeRequest";
 import createIdentityRequest from "../../../../../../src/components/Identity/getIdentity/createIdentityRequest";
 
 describe("createIdentityRequest", () => {
-  describeRequest(createIdentityRequest);
+  describeRequest(payload => createIdentityRequest({ payload }));
 
   it("provides the appropriate action", () => {
     const payload = {};
-    const request = createIdentityRequest(payload);
+    const request = createIdentityRequest({ payload });
     expect(request.getAction()).toBe("identity/acquire");
   });
 
   it("never uses sendBeacon", () => {
     const payload = {};
-    const request = createIdentityRequest(payload);
+    const request = createIdentityRequest({ payload });
     expect(request.getUseSendBeacon()).toBeFalse();
   });
 });

--- a/test/unit/specs/components/Privacy/createConsentRequest.spec.js
+++ b/test/unit/specs/components/Privacy/createConsentRequest.spec.js
@@ -14,17 +14,17 @@ import describeRequest from "../../../helpers/describeRequest";
 import createConsentRequest from "../../../../../src/components/Privacy/createConsentRequest";
 
 describe("createConsentRequest", () => {
-  describeRequest(createConsentRequest);
+  describeRequest(payload => createConsentRequest({ payload }));
 
   it("provides the appropriate action", () => {
     const payload = {};
-    const request = createConsentRequest(payload);
+    const request = createConsentRequest({ payload });
     expect(request.getAction()).toBe("privacy/set-consent");
   });
 
   it("never uses sendBeacon", () => {
     const payload = {};
-    const request = createConsentRequest(payload);
+    const request = createConsentRequest({ payload });
     expect(request.getUseSendBeacon()).toBeFalse();
   });
 });

--- a/test/unit/specs/core/edgeNetwork/injectSendEdgeNetworkRequest.spec.js
+++ b/test/unit/specs/core/edgeNetwork/injectSendEdgeNetworkRequest.spec.js
@@ -112,7 +112,8 @@ describe("injectSendEdgeNetworkRequest", () => {
         type: "payload"
       },
       getUseIdThirdPartyDomain: false,
-      getUseSendBeacon: false
+      getUseSendBeacon: false,
+      getEdgeConfigIdOverride: ""
     });
     logger = jasmine.createSpyObj("logger", ["info"]);
     lifecycle = jasmine.createSpyObj("lifecycle", {
@@ -480,6 +481,19 @@ describe("injectSendEdgeNetworkRequest", () => {
         payload: {
           type: "payload"
         },
+        useSendBeacon: false
+      });
+    });
+  });
+
+  it("respects the edgeConfigIdOverride", () => {
+    request.getEdgeConfigIdOverride.and.returnValue("myconfigIdOverride");
+    return sendEdgeNetworkRequest({ request }).then(() => {
+      expect(sendNetworkRequest).toHaveBeenCalledWith({
+        payload: request.getPayload(),
+        url:
+          "https://edge.example.com/ee/v1/test-action?configId=myconfigIdOverride&requestId=RID123",
+        requestId: "RID123",
         useSendBeacon: false
       });
     });

--- a/test/unit/specs/utils/request/createDataCollectionRequest.spec.js
+++ b/test/unit/specs/utils/request/createDataCollectionRequest.spec.js
@@ -14,7 +14,7 @@ import { createDataCollectionRequest } from "../../../../../src/utils/request";
 import describeRequest from "../../../helpers/describeRequest";
 
 describe("createDataCollectionRequest", () => {
-  describeRequest(createDataCollectionRequest);
+  describeRequest(payload => createDataCollectionRequest({ payload }));
 
   it("uses collect with sendBeacon if document may unload and identity is established", () => {
     const payload = {
@@ -22,7 +22,7 @@ describe("createDataCollectionRequest", () => {
         return true;
       }
     };
-    const request = createDataCollectionRequest(payload);
+    const request = createDataCollectionRequest({ payload });
     request.setIsIdentityEstablished();
     expect(request.getAction()).toBe("collect");
     expect(request.getUseSendBeacon()).toBeTrue();
@@ -34,7 +34,7 @@ describe("createDataCollectionRequest", () => {
         return true;
       }
     };
-    const request = createDataCollectionRequest(payload);
+    const request = createDataCollectionRequest({ payload });
     expect(request.getAction()).toBe("interact");
     expect(request.getUseSendBeacon()).toBeFalse();
   });
@@ -45,7 +45,7 @@ describe("createDataCollectionRequest", () => {
         return false;
       }
     };
-    const request = createDataCollectionRequest(payload);
+    const request = createDataCollectionRequest({ payload });
     request.setIsIdentityEstablished();
     expect(request.getAction()).toBe("interact");
     expect(request.getUseSendBeacon()).toBeFalse();
@@ -57,8 +57,18 @@ describe("createDataCollectionRequest", () => {
         return false;
       }
     };
-    const request = createDataCollectionRequest(payload);
+    const request = createDataCollectionRequest({ payload });
     expect(request.getAction()).toBe("interact");
     expect(request.getUseSendBeacon()).toBeFalse();
+  });
+
+  it("passes the edgeConfigIdOverride to the request", () => {
+    const payload = {};
+    const edgeConfigIdOverride = "my-edge-config-id-override";
+    const request = createDataCollectionRequest({
+      payload,
+      edgeConfigIdOverride
+    });
+    expect(request.getEdgeConfigIdOverride()).toBe(edgeConfigIdOverride);
   });
 });


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

Support per-command overrides of the datastream ID.

```js
await alloy("configure", {
  orgId: "5BFE274A5F6980A50A495C08@AdobeOrg",
  edgeConfigId: "bc1a10e0-aee4-4e0e-ac5b-cdbb9abbec83"
});

const isDevMode = window.location.search.includes("alloy_debug");
const sendEventOptions = isDevMode ? {
  edgeConfigOverrides: {
    edgeConfigId: "bc1a10e0-aee4-4e0e-ac5b-cdbb9abbec83:dev"
  }
} : {};
await alloy("sendEvent", sendEventOptions);
```

It is supported on all the commands that support config overrides, except `configure`:

* `sendEvent`
* `setConsent`
* `getIdentity`
* `appendIdentityToUrl`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
