### PR TITLE
Inform Konductor of the original datastream when overriding

### DIFF
--- a/sandbox/src/ConfigOverrides.jsx
+++ b/sandbox/src/ConfigOverrides.jsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 
 const defaultOverrides = {
+  datastreamId: "",
   com_adobe_experience_platform: {
     datasets: {
       event: {

--- a/src/core/edgeNetwork/injectSendEdgeNetworkRequest.js
+++ b/src/core/edgeNetwork/injectSendEdgeNetworkRequest.js
@@ -60,12 +60,16 @@ export default ({
           ? `${edgeBasePath}/${locationHint}`
           : edgeBasePath;
         const configId = request.getDatastreamIdOverride() || datastreamId;
+        const payload = request.getPayload();
+        if (configId !== datastreamId) {
+          payload.mergeMeta(datastreamId, "sdkConfig.datastream.original");
+        }
         const url = `https://${endpointDomain}/${edgeBasePathWithLocationHint}/${apiVersion}/${request.getAction()}?configId=${configId}&requestId=${request.getId()}${getAssuranceValidationTokenParams()}`;
-        cookieTransfer.cookiesToPayload(request.getPayload(), endpointDomain);
+        cookieTransfer.cookiesToPayload(payload, endpointDomain);
         return sendNetworkRequest({
           requestId: request.getId(),
           url,
-          payload: request.getPayload(),
+          payload,
           useSendBeacon: request.getUseSendBeacon()
         });
       })

--- a/src/core/edgeNetwork/injectSendEdgeNetworkRequest.js
+++ b/src/core/edgeNetwork/injectSendEdgeNetworkRequest.js
@@ -62,7 +62,13 @@ export default ({
         const configId = request.getDatastreamIdOverride() || datastreamId;
         const payload = request.getPayload();
         if (configId !== datastreamId) {
-          payload.mergeMeta(datastreamId, "sdkConfig.datastream.original");
+          payload.mergeMeta({
+            sdkConfig: {
+              datastream: {
+                original: datastreamId
+              }
+            }
+          });
         }
         const url = `https://${endpointDomain}/${edgeBasePathWithLocationHint}/${apiVersion}/${request.getAction()}?configId=${configId}&requestId=${request.getId()}${getAssuranceValidationTokenParams()}`;
         cookieTransfer.cookiesToPayload(payload, endpointDomain);

--- a/test/functional/specs/Config Overrides/C7437530.js
+++ b/test/functional/specs/Config Overrides/C7437530.js
@@ -212,4 +212,9 @@ test("Test C7437530: `sendEvent` can override the datastreamId", async () => {
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
   const [request] = networkLogger.edgeEndpointLogs.requests;
   await t.expect(request.request.url).contains(alternateDatastreamId);
+
+  const body = JSON.parse(request.request.body);
+  await t
+    .expect(body.meta.sdkConfig.datastream.original)
+    .eql(originalDatastreamId);
 });

--- a/test/functional/specs/Config Overrides/C7437531.js
+++ b/test/functional/specs/Config Overrides/C7437531.js
@@ -176,4 +176,9 @@ test("Test C7437531: `getIdentity` can override the datastreamId", async () => {
   await t.expect(networkLogger.acquireEndpointLogs.requests.length).eql(1);
   const [request] = networkLogger.acquireEndpointLogs.requests;
   await t.expect(request.request.url).contains(alternateDatastreamId);
+
+  const body = JSON.parse(request.request.body);
+  await t
+    .expect(body.meta.sdkConfig.datastream.original)
+    .eql(originalDatastreamId);
 });

--- a/test/functional/specs/Config Overrides/C7437532.js
+++ b/test/functional/specs/Config Overrides/C7437532.js
@@ -185,4 +185,8 @@ test("Test C7437532: `appendIdentityToUrl` can override the datastreamId", async
   await t.expect(networkLogger.acquireEndpointLogs.requests.length).eql(1);
   const [request] = networkLogger.acquireEndpointLogs.requests;
   await t.expect(request.request.url).contains(alternateDatastreamId);
+  const body = JSON.parse(request.request.body);
+  await t
+    .expect(body.meta.sdkConfig.datastream.original)
+    .eql(originalDatastreamId);
 });

--- a/test/functional/specs/Config Overrides/C7437533.js
+++ b/test/functional/specs/Config Overrides/C7437533.js
@@ -177,4 +177,9 @@ test("Test C7437533: `setConsent` can override the datastreamId", async () => {
   await t.expect(networkLogger.setConsentEndpointLogs.requests.length).eql(1);
   const [request] = networkLogger.setConsentEndpointLogs.requests;
   await t.expect(request.request.url).contains(alternateDatastreamId);
+
+  const body = JSON.parse(request.request.body);
+  await t
+    .expect(body.meta.sdkConfig.datastream.original)
+    .eql(originalDatastreamId);
 });

--- a/test/unit/specs/core/edgeNetwork/injectSendEdgeNetworkRequest.spec.js
+++ b/test/unit/specs/core/edgeNetwork/injectSendEdgeNetworkRequest.spec.js
@@ -482,10 +482,9 @@ describe("injectSendEdgeNetworkRequest", () => {
   it("respects the datastreamIdOverride", () => {
     request.getDatastreamIdOverride.and.returnValue("myconfigIdOverride");
     return sendEdgeNetworkRequest({ request }).then(() => {
-      expect(payload.mergeMeta).toHaveBeenCalledWith(
-        "myconfigId",
-        "sdkConfig.datastream.original"
-      );
+      expect(payload.mergeMeta).toHaveBeenCalledWith({
+        sdkConfig: { datastream: { original: "myconfigId" } }
+      });
       expect(sendNetworkRequest).toHaveBeenCalledWith({
         payload,
         url:


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

When there is a datastream override and just before sending the request, merge the original datastream into the `meta.sdkConfig.datastream.original` position.

**If `injectSendEdgeNetworkRequest` is not the right place, semantically, to be changing the payload, let me know where you think would fit better.**

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#995 


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

This should facilitate logging and problem solving in Konductor when a problem arises.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
