### PR TITLE
TNT-48367 Make SPA view names lowercase

### DIFF
--- a/src/components/Personalization/createOnClickHandler.js
+++ b/src/components/Personalization/createOnClickHandler.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { isNonEmptyArray } from "../../utils";
+import { isNonEmptyArray, isNonEmptyString } from "../../utils";
 import { INTERACT } from "./constants/eventType";
 import { PropositionEventType } from "./constants/propositionEventType";
 import PAGE_WIDE_SCOPE from "../../constants/pageWideScope";
@@ -35,10 +35,10 @@ export default ({
         const xdm = { eventType: INTERACT };
         const scope = decisionsMeta[0].scope;
 
-        if (scope !== PAGE_WIDE_SCOPE) {
+        if (isNonEmptyString(scope) && scope !== PAGE_WIDE_SCOPE) {
           xdm.web = {
             webPageDetails: {
-              viewName: scope
+              viewName: scope.toLowerCase()
             }
           };
         }

--- a/src/components/Personalization/groupDecisions.js
+++ b/src/components/Personalization/groupDecisions.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { isNonEmptyArray, includes } from "../../utils";
+import { isNonEmptyArray, includes, assign } from "../../utils";
 import isPageWideScope from "./utils/isPageWideScope";
 import {
   DOM_ACTION,
@@ -74,11 +74,16 @@ const splitDecisions = (decisions, ...schemas) => {
   return { matchedDecisions, unmatchedDecisions };
 };
 
-const appendScopeDecision = (scopeDecisions, decision) => {
-  if (!scopeDecisions[decision.scope]) {
-    scopeDecisions[decision.scope] = [];
+const appendViewScopeDecision = (scopeDecisions, decision) => {
+  if (!decision.scope) {
+    return;
   }
-  scopeDecisions[decision.scope].push(decision);
+  // Override view scope to lowercase to fix any casing issues
+  const viewDecision = assign({}, decision, { scope: decision.scope.toLowerCase() });
+  if (!scopeDecisions[viewDecision.scope]) {
+    scopeDecisions[viewDecision.scope] = [];
+  }
+  scopeDecisions[viewDecision.scope].push(viewDecision);
 };
 
 const isViewScope = scopeDetails =>
@@ -96,7 +101,7 @@ const extractDecisionsByScope = decisions => {
       if (isPageWideScope(decision.scope)) {
         pageWideScopeDecisions.push(decision);
       } else if (isViewScope(decision.scopeDetails)) {
-        appendScopeDecision(viewScopeDecisions, decision);
+        appendViewScopeDecision(viewScopeDecisions, decision);
       } else {
         nonPageWideScopeDecisions.push(decision);
       }

--- a/src/core/createEvent.js
+++ b/src/core/createEvent.js
@@ -115,11 +115,11 @@ export default () => {
       return shouldSendEvent;
     },
     getViewName() {
-      if (!userXdm || !userXdm.web || !userXdm.web.webPageDetails) {
+      if (!userXdm || !userXdm.web || !userXdm.web.webPageDetails || !userXdm.web.webPageDetails.viewName) {
         return undefined;
       }
 
-      return userXdm.web.webPageDetails.viewName;
+      return userXdm.web.webPageDetails.viewName.toLowerCase();
     },
     toJSON() {
       if (!isFinalized) {

--- a/test/functional/specs/Personalization/C6364798.js
+++ b/test/functional/specs/Personalization/C6364798.js
@@ -224,7 +224,7 @@ const simulateViewChangeForNonExistingView = async alloy => {
       eventType: "noviewoffers",
       web: {
         webPageDetails: {
-          viewName: "noView"
+          viewName: "noview"
         }
       }
     }
@@ -249,7 +249,7 @@ const simulateViewChangeForNonExistingView = async alloy => {
     .expect(
       noViewNotificationRequestBody.events[0].xdm.web.webPageDetails.viewName
     )
-    .eql("noView");
+    .eql("noview");
   await t
     // eslint-disable-next-line no-underscore-dangle
     .expect(noViewNotificationRequestBody.events[0].xdm._experience)

--- a/test/functional/specs/Personalization/C782718.js
+++ b/test/functional/specs/Personalization/C782718.js
@@ -221,7 +221,7 @@ const simulateViewChangeForNonExistingView = async alloy => {
       eventType: "noviewoffers",
       web: {
         webPageDetails: {
-          viewName: "noView"
+          viewName: "noview"
         }
       }
     }
@@ -246,7 +246,7 @@ const simulateViewChangeForNonExistingView = async alloy => {
     .expect(
       noViewNotificationRequestBody.events[0].xdm.web.webPageDetails.viewName
     )
-    .eql("noView");
+    .eql("noview");
   await t
     // eslint-disable-next-line no-underscore-dangle
     .expect(noViewNotificationRequestBody.events[0].xdm._experience)


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

Considering we still have both internal and external customers running into SPA view case sensitivity issues, we need to fix this in Web SDK, so that for both Target and AJO, SPA view names are consistently lowercase across VEC, at.js and Web SDK.

Note: We're fixing this by setting the view name to lowercase both when using the `viewName` supplied under `xdm.web.webPageDetails.viewName`, as well as by lowercasing the view decision scopes (these are currently being lowercased at authoring time for TNT/AJO activities created in VEC UI, however in case any views were defined directly via TNT APIs these could still be case-sensitive)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/TNT-48367

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
