### PR TITLE
[CJM-53498] support "Send data to platform" trigger

### DIFF
--- a/sandbox/src/components/InAppMessagesDemo/InAppMessages.js
+++ b/sandbox/src/components/InAppMessagesDemo/InAppMessages.js
@@ -1,12 +1,51 @@
+/* eslint-disable no-bitwise */
 import React, { useState, useEffect } from "react";
 import ContentSecurityPolicy from "../ContentSecurityPolicy";
 import "./InAppMessagesStyle.css";
 
+const configKey = "cjmProdNld2";
+
+const config = {
+  cjmProdNld2: {
+    datastreamId: "7a19c434-6648-48d3-948f-ba0258505d98",
+    surface: "mobileapp://com.adobe.iamTutorialiOS",
+    decisionContext: {
+      "~type": "com.adobe.eventType.generic.track",
+      "~source": "com.adobe.eventSource.requestContent",
+      state: "",
+      "~state.com.adobe.module.lifecycle/lifecyclecontextdata.dayofweek": 1
+    },
+    activeCampaigns: [
+      "https://experience.adobe.com/#/@cjmprodnld2/sname:prod/journey-optimizer/campaigns/summary/59bfdc09-03b9-4cd5-9ab8-5c2a045b0b2e"
+    ]
+  },
+  aemonacpprodcampaign: {
+    datastreamId: "8cefc5ca-1c2a-479f-88f2-3d42cc302514",
+    surface: "mobileapp://com.adobe.aguaAppIos",
+    decisionContext: {},
+    activeCampaigns: [
+      "https://experience.adobe.com/#/@aemonacpprodcampaign/sname:prod/journey-optimizer/campaigns/summary/8bb52c05-d381-4d8b-a67a-95f345776322"
+    ]
+  }
+};
+
+const { datastreamId, surface, decisionContext } = config[configKey];
+
+const uuidv4 = () => {
+  return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, c =>
+    (
+      c ^
+      (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))
+    ).toString(16)
+  );
+};
+
 export default function DecisionEngine() {
   const [realResponse, setRealResponse] = useState(null);
+
   const getInAppPayload = async payload => {
     const res = await fetch(
-      `https://edge.adobedc.net/ee/or2/v1/interact?configId=7a19c434-6648-48d3-948f-ba0258505d98&requestId=520353b2-dc0d-428c-9e0d-138fc6cbec4e`,
+      `https://edge.adobedc.net/ee/or2/v1/interact?configId=${datastreamId}&requestId=${uuidv4()}`,
       {
         method: "POST",
         body: JSON.stringify(payload)
@@ -22,7 +61,7 @@ export default function DecisionEngine() {
           {
             query: {
               personalization: {
-                surfaces: ["mobileapp://com.adobe.iamTutorialiOS"]
+                surfaces: [surface]
               }
             },
             xdm: {
@@ -44,21 +83,10 @@ export default function DecisionEngine() {
   const renderDecisions = e => {
     e.stopPropagation();
     e.preventDefault();
-    window.alloy("evaluateRulesets", {
-      "~type": "com.adobe.eventType.generic.track",
-      "~source": "com.adobe.eventSource.requestContent",
-      state: "",
-      "~state.com.adobe.module.lifecycle/lifecyclecontextdata.dayofweek": 1
-    });
 
     window.alloy("applyResponse", {
       renderDecisions: true,
-      decisionContext: {
-        "~type": "com.adobe.eventType.generic.track",
-        "~source": "com.adobe.eventSource.requestContent",
-        state: "",
-        "~state.com.adobe.module.lifecycle/lifecyclecontextdata.dayofweek": 1
-      },
+      decisionContext,
       responseBody: realResponse
     });
   };

--- a/src/components/DecisioningEngine/constants.js
+++ b/src/components/DecisioningEngine/constants.js
@@ -1,0 +1,26 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+export const CONTEXT_KEY = {
+  TYPE: "~type",
+  SOURCE: "~source"
+};
+
+export const MOBILE_EVENT_TYPE = {
+  LIFECYCLE: "com.adobe.eventType.lifecycle",
+  TRACK: "com.adobe.eventType.generic.track",
+  EDGE: "com.adobe.eventType.edge"
+};
+
+export const MOBILE_EVENT_SOURCE = {
+  LAUNCH: "com.adobe.eventSource.applicationLaunch",
+  REQUEST: "com.adobe.eventSource.requestContent"
+};

--- a/src/components/DecisioningEngine/index.js
+++ b/src/components/DecisioningEngine/index.js
@@ -17,6 +17,11 @@ import createEventRegistry from "./createEventRegistry";
 import createContextProvider from "./createContextProvider";
 import createSubscribeRulesetItems from "./createSubscribeRulesetItems";
 import { ensureSchemaBasedRulesetConsequences } from "./utils";
+import {
+  CONTEXT_KEY,
+  MOBILE_EVENT_SOURCE,
+  MOBILE_EVENT_TYPE
+} from "./constants";
 
 const createDecisioningEngine = ({ config, createNamespacedStorage }) => {
   const { orgId } = config;
@@ -52,7 +57,11 @@ const createDecisioningEngine = ({ config, createNamespacedStorage }) => {
             decisionProvider,
             applyResponse,
             event,
-            decisionContext: contextProvider.getContext(decisionContext)
+            decisionContext: contextProvider.getContext({
+              [CONTEXT_KEY.TYPE]: MOBILE_EVENT_TYPE.EDGE,
+              [CONTEXT_KEY.SOURCE]: MOBILE_EVENT_SOURCE.REQUEST,
+              ...decisionContext
+            })
           })
         );
 

--- a/src/components/Personalization/createPersonalizationDetails.js
+++ b/src/components/Personalization/createPersonalizationDetails.js
@@ -19,7 +19,9 @@ import {
   HTML_CONTENT_ITEM,
   MESSAGE_IN_APP,
   JSON_CONTENT_ITEM,
-  REDIRECT_ITEM
+  REDIRECT_ITEM,
+  RULESET_ITEM,
+  MESSAGE_FEED_ITEM
 } from "./constants/schema";
 
 const addPageWideScope = scopes => {
@@ -88,7 +90,9 @@ export default ({
         HTML_CONTENT_ITEM,
         JSON_CONTENT_ITEM,
         REDIRECT_ITEM,
-        MESSAGE_IN_APP
+        RULESET_ITEM,
+        MESSAGE_IN_APP,
+        MESSAGE_FEED_ITEM
       ];
 
       if (includes(scopes, PAGE_WIDE_SCOPE)) {

--- a/test/unit/specs/components/DecisioningEngine/constants.spec.js
+++ b/test/unit/specs/components/DecisioningEngine/constants.spec.js
@@ -1,0 +1,11 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/

--- a/test/unit/specs/components/Personalization/createPersonalizationDetails.spec.js
+++ b/test/unit/specs/components/Personalization/createPersonalizationDetails.spec.js
@@ -18,7 +18,9 @@ import {
   HTML_CONTENT_ITEM,
   MESSAGE_IN_APP,
   JSON_CONTENT_ITEM,
-  REDIRECT_ITEM
+  REDIRECT_ITEM,
+  RULESET_ITEM,
+  MESSAGE_FEED_ITEM
 } from "../../../../../src/components/Personalization/constants/schema";
 
 describe("Personalization::createPersonalizationDetails", () => {
@@ -63,7 +65,9 @@ describe("Personalization::createPersonalizationDetails", () => {
         HTML_CONTENT_ITEM,
         JSON_CONTENT_ITEM,
         REDIRECT_ITEM,
+        RULESET_ITEM,
         MESSAGE_IN_APP,
+        MESSAGE_FEED_ITEM,
         DOM_ACTION
       ],
       decisionScopes: expectedDecisionScopes,
@@ -102,7 +106,9 @@ describe("Personalization::createPersonalizationDetails", () => {
         HTML_CONTENT_ITEM,
         JSON_CONTENT_ITEM,
         REDIRECT_ITEM,
+        RULESET_ITEM,
         MESSAGE_IN_APP,
+        MESSAGE_FEED_ITEM,
         DOM_ACTION
       ],
       decisionScopes: expectedDecisionScopes,
@@ -141,7 +147,9 @@ describe("Personalization::createPersonalizationDetails", () => {
         HTML_CONTENT_ITEM,
         JSON_CONTENT_ITEM,
         REDIRECT_ITEM,
+        RULESET_ITEM,
         MESSAGE_IN_APP,
+        MESSAGE_FEED_ITEM,
         DOM_ACTION
       ],
       decisionScopes: expectedDecisionScopes,
@@ -180,7 +188,9 @@ describe("Personalization::createPersonalizationDetails", () => {
         HTML_CONTENT_ITEM,
         JSON_CONTENT_ITEM,
         REDIRECT_ITEM,
-        MESSAGE_IN_APP
+        RULESET_ITEM,
+        MESSAGE_IN_APP,
+        MESSAGE_FEED_ITEM
       ],
       decisionScopes: expectedDecisionScopes,
       surfaces: []
@@ -220,7 +230,9 @@ describe("Personalization::createPersonalizationDetails", () => {
         HTML_CONTENT_ITEM,
         JSON_CONTENT_ITEM,
         REDIRECT_ITEM,
-        MESSAGE_IN_APP
+        RULESET_ITEM,
+        MESSAGE_IN_APP,
+        MESSAGE_FEED_ITEM
       ],
       decisionScopes: expectedDecisionScopes,
       surfaces: ["web://test1.com/"]
@@ -262,7 +274,9 @@ describe("Personalization::createPersonalizationDetails", () => {
         HTML_CONTENT_ITEM,
         JSON_CONTENT_ITEM,
         REDIRECT_ITEM,
-        MESSAGE_IN_APP
+        RULESET_ITEM,
+        MESSAGE_IN_APP,
+        MESSAGE_FEED_ITEM
       ],
       decisionScopes: expectedDecisionScopes,
       surfaces: ["web://test1.com/"]
@@ -398,7 +412,9 @@ describe("Personalization::createPersonalizationDetails", () => {
         HTML_CONTENT_ITEM,
         JSON_CONTENT_ITEM,
         REDIRECT_ITEM,
+        RULESET_ITEM,
         MESSAGE_IN_APP,
+        MESSAGE_FEED_ITEM,
         DOM_ACTION
       ],
       decisionScopes: expectedDecisionScopes,


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

This PR adds support for the "Sent data to Platform" trigger.
![image](https://github.com/adobe/alloy/assets/427213/72231d5e-bd47-49ac-be81-6dbfa23c7957)

It adds the following key/values to the context object when it is evaluated as a result of calling `sendEvent`

```json
{
  "~type": "com.adobe.eventType.edge",
  "~source": "com.adobe.eventSource.requestContent"
}
```

👆 this satisfies the ruleset generated by the authoring UI.

I also updated the sandbox page so it can be configured to use different configurations to ease testing.

## Related Issue

- https://jira.corp.adobe.com/browse/CJM-53498

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

