### PR TITLE
Fix show containers timing

### DIFF
--- a/src/components/Personalization/createFetchDataHandler.js
+++ b/src/components/Personalization/createFetchDataHandler.js
@@ -69,15 +69,12 @@ export default ({
           [...pagePropositions, ...currentViewPropositions],
           nonRenderedPropositions
         ));
-        render()
-          .then(decisionsMeta => {
-            showContainers();
-            handleNotifications(decisionsMeta);
-          })
-          .catch(e => {
-            showContainers();
-            throw e;
-          });
+        render().then(handleNotifications);
+
+        // Render could take a long time especially if one of the renders
+        // is waiting for html to appear on the page. We show the containers
+        // immediately, and whatever renders quickly will not have flicker.
+        showContainers();
       } else {
         ({ returnedPropositions, returnedDecisions } = processPropositions(
           [],


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

The personalization refactor contained a change with when showContainers was called. Previously, it was waiting for all rendering to be complete before showing containers. Before the refactor, showContainers was called immediately after starting to render everything. (see https://github.com/adobe/alloy/blob/e1105f1fd43224b46f392798eca823ae8a99fc72/src/components/Personalization/createAutoRenderingHandler.js#L54) With the change in this PR, I've updated the fetchDataHandler to follow the same old behavior.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
