### PR TITLE
In browser messages e2e

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -54,7 +54,7 @@
       !function(n,o){o.forEach(function(o){n[o]||((n.__alloyNS=n.__alloyNS||
       []).push(o),n[o]=function(){var u=arguments;return new Promise(
       function(i,l){n[o].q.push([i,l,u])})},n[o].q=[])})}
-      (window,["alloy", "organizationTwo", "cjmProd"]);
+      (window,["alloy", "organizationTwo", "cjmProd", 'iamAlloy']);
     </script>
 
     <script nonce="%REACT_APP_NONCE%">

--- a/sandbox/src/components/InAppMessagesDemo/InAppMessages.js
+++ b/sandbox/src/components/InAppMessagesDemo/InAppMessages.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-bitwise, no-console */
-import React from "react";
+import React, { useState } from "react";
 import ContentSecurityPolicy from "../ContentSecurityPolicy";
 import "./InAppMessagesStyle.css";
 
@@ -103,12 +103,21 @@ const fetchMobilePayload = () =>
   });
 
 export default function InAppMessages() {
+  const [customTraitKey, setCustomTraitKey] = useState("");
+  const [customTraitValue, setCustomTraitValue] = useState("");
+
   const renderDecisions = () => {
+    const context = { ...decisionContext };
+
+    if (customTraitKey.length !== 0 && customTraitValue.length !== 0) {
+      context[customTraitKey] = customTraitValue;
+    }
+
     if (surface.startsWith("mobileapp://")) {
       fetchMobilePayload().then(response => {
         window.alloy("applyResponse", {
           renderDecisions: true,
-          decisionContext,
+          decisionContext: context,
           responseBody: response
         });
       });
@@ -118,7 +127,7 @@ export default function InAppMessages() {
         personalization: {
           surfaces: [surface]
         },
-        decisionContext
+        decisionContext: context
       });
     }
   };
@@ -127,9 +136,32 @@ export default function InAppMessages() {
     <div>
       <ContentSecurityPolicy />
       <h1>In App Messages For Web</h1>
-      <button onClick={() => renderDecisions()}>
-        Execute Decisions and Render
-      </button>
+      <div>
+        <div style={{ marginBottom: "20px" }}>
+          <h3>Custom Trait</h3>
+          <span style={{ marginRight: "20px" }}>
+            <label htmlFor="input-custom-trait-key">Key</label>
+            <input
+              id="input-custom-trait-key"
+              type="text"
+              value={customTraitKey}
+              onChange={evt => setCustomTraitKey(evt.target.value)}
+            />
+          </span>
+          <span style={{ marginRight: "20px" }}>
+            <label htmlFor="input-custom-trait-value">Value</label>
+            <input
+              id="input-custom-trait-value"
+              type="text"
+              value={customTraitValue}
+              onChange={evt => setCustomTraitValue(evt.target.value)}
+            />
+          </span>
+        </div>
+        <button onClick={() => renderDecisions()}>
+          Execute Decisions and Render
+        </button>
+      </div>
     </div>
   );
 }

--- a/sandbox/src/components/InAppMessagesDemo/InAppMessages.js
+++ b/sandbox/src/components/InAppMessagesDemo/InAppMessages.js
@@ -3,10 +3,11 @@ import React, { useState } from "react";
 import ContentSecurityPolicy from "../ContentSecurityPolicy";
 import "./InAppMessagesStyle.css";
 
-const configKey = "stage";
+const configKey = localStorage.getItem("iam-configKey") || "stage";
 
 const config = {
   cjmProdNld2: {
+    name: "CJM Prod NLD2 – Prod (NLD2)",
     datastreamId: "7a19c434-6648-48d3-948f-ba0258505d98",
     orgId: "4DA0571C5FDC4BF70A495FC2@AdobeOrg",
     surface: "mobileapp://com.adobe.iamTutorialiOS",
@@ -22,6 +23,7 @@ const config = {
     ]
   },
   aemonacpprodcampaign: {
+    name: "AEM Assets Departmental - Campaign – Prod (VA7)",
     datastreamId: "8cefc5ca-1c2a-479f-88f2-3d42cc302514",
     orgId: "906E3A095DC834230A495FD6@AdobeOrg",
     surface: "mobileapp://com.adobe.aguaAppIos",
@@ -132,11 +134,29 @@ export default function InAppMessages() {
     }
   };
 
+  const setNewCofigEnv = value => {
+    localStorage.setItem("iam-configKey", value);
+    window.location.reload();
+  };
+
   return (
     <div>
       <ContentSecurityPolicy />
       <h1>In App Messages For Web</h1>
       <div>
+        <label htmlFor="cars">Environment:</label>
+        <select
+          id="configEnv"
+          name="configEnv"
+          onChange={evt => setNewCofigEnv(evt.target.value)}
+          defaultValue={configKey}
+        >
+          {Object.keys(config).map(conf => (
+            <option key={conf} value={conf}>
+              {config[conf].name}
+            </option>
+          ))}
+        </select>
         <div style={{ marginBottom: "20px" }}>
           <h3>Custom Trait</h3>
           <span style={{ marginRight: "20px" }}>

--- a/src/components/DecisioningEngine/consequenceAdapters/inAppMessageConsequenceAdapter.js
+++ b/src/components/DecisioningEngine/consequenceAdapters/inAppMessageConsequenceAdapter.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import { MESSAGE_IN_APP } from "../../Personalization/constants/schema";
-import { APPLICATION_JSON } from "../../Personalization/constants/contentType";
+import { TEXT_HTML } from "../../Personalization/constants/contentType";
 
 export default (id, type, detail) => {
   const { html, mobileParameters } = detail;
@@ -20,12 +20,10 @@ export default (id, type, detail) => {
   return {
     schema: MESSAGE_IN_APP,
     data: {
-      content: {
-        mobileParameters,
-        webParameters,
-        html
-      },
-      contentType: APPLICATION_JSON
+      mobileParameters,
+      webParameters,
+      content: html,
+      contentType: TEXT_HTML
     },
     id
   };

--- a/src/components/DecisioningEngine/consequenceAdapters/schemaTypeConsequenceAdapter.js
+++ b/src/components/DecisioningEngine/consequenceAdapters/schemaTypeConsequenceAdapter.js
@@ -9,24 +9,9 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { MESSAGE_IN_APP } from "../../Personalization/constants/schema";
-import { APPLICATION_JSON } from "../../Personalization/constants/contentType";
 
 export default (id, type, detail) => {
-  const { html, mobileParameters } = detail;
+  const { schema, data, id: detailId } = detail;
 
-  const webParameters = {};
-
-  return {
-    schema: MESSAGE_IN_APP,
-    data: {
-      content: {
-        mobileParameters,
-        webParameters,
-        html
-      },
-      contentType: APPLICATION_JSON
-    },
-    id
-  };
+  return { schema, data, id: detailId || id };
 };

--- a/src/components/DecisioningEngine/createConsequenceAdapter.js
+++ b/src/components/DecisioningEngine/createConsequenceAdapter.js
@@ -1,7 +1,7 @@
 /*
 Copyright 2023 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
+you may not use this file except in compliance with the License. You may obtain a copy s
 of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed under
@@ -10,11 +10,14 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import inAppMessageConsequenceAdapter from "./consequenceAdapters/inAppMessageConsequenceAdapter";
+import schemaTypeConsequenceAdapter from "./consequenceAdapters/schemaTypeConsequenceAdapter";
 
 const CJM_IN_APP_MESSAGE_TYPE = "cjmiam";
+const SCHEMA = "schema";
 
 const adapters = {
-  [CJM_IN_APP_MESSAGE_TYPE]: inAppMessageConsequenceAdapter
+  [CJM_IN_APP_MESSAGE_TYPE]: inAppMessageConsequenceAdapter,
+  [SCHEMA]: schemaTypeConsequenceAdapter
 };
 
 export default () => {

--- a/src/components/DecisioningEngine/createConsequenceAdapter.js
+++ b/src/components/DecisioningEngine/createConsequenceAdapter.js
@@ -1,7 +1,7 @@
 /*
 Copyright 2023 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy s
+you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed under

--- a/src/components/Personalization/constants/contentType.js
+++ b/src/components/Personalization/constants/contentType.js
@@ -10,3 +10,4 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 export const TEXT_HTML = "text/html";
+export const APPLICATION_JSON = "application/json";

--- a/src/components/Personalization/handlers/createProcessInAppMessage.js
+++ b/src/components/Personalization/handlers/createProcessInAppMessage.js
@@ -9,14 +9,12 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
+import { APPLICATION_JSON } from "../constants/contentType";
+
 const DEFAULT_CONTENT = "defaultContent";
 
-const expectedProps = [
-  "mobileParameters",
-  "webParameters",
-  "content",
-  "contentType"
-];
+const expectedProps = ["content", "contentType"];
+const expectedContentProps = ["mobileParameters", "webParameters", "html"];
 
 const isValidInAppMessage = (data, logger) => {
   for (let i = 0; i < expectedProps.length; i += 1) {
@@ -30,42 +28,59 @@ const isValidInAppMessage = (data, logger) => {
     }
   }
 
+  const { content, contentType } = data;
+
+  if (contentType === APPLICATION_JSON) {
+    for (let i = 0; i < expectedContentProps.length; i += 1) {
+      const prop = expectedContentProps[i];
+      if (!Object.prototype.hasOwnProperty.call(content, prop)) {
+        logger.warn(
+          `Invalid in-app message data.content: missing property '${prop}'.`,
+          data
+        );
+        return false;
+      }
+    }
+  }
+
   return true;
 };
 
-export default ({ modules, logger }) => item => {
-  const data = item.getData();
-  const meta = item.getMeta();
+export default ({ modules, logger }) => {
+  return item => {
+    const data = item.getData();
+    const meta = item.getMeta();
 
-  if (!data) {
-    logger.warn("Invalid in-app message data: undefined.", data);
-    return {};
-  }
+    if (!data) {
+      logger.warn("Invalid in-app message data: undefined.", data);
+      return {};
+    }
 
-  const { type = DEFAULT_CONTENT } = data;
+    const { type = DEFAULT_CONTENT } = data;
 
-  if (!modules[type]) {
-    logger.warn("Invalid in-app message data: unknown type.", data);
-    return {};
-  }
+    if (!modules[type]) {
+      logger.warn("Invalid in-app message data: unknown type.", data);
+      return {};
+    }
 
-  if (!isValidInAppMessage(data, logger)) {
-    return {};
-  }
+    if (!isValidInAppMessage(data, logger)) {
+      return {};
+    }
 
-  if (!meta) {
-    logger.warn("Invalid in-app message meta: undefined.", meta);
-    return {};
-  }
+    if (!meta) {
+      logger.warn("Invalid in-app message meta: undefined.", meta);
+      return {};
+    }
 
-  return {
-    render: () => {
-      return modules[type]({
-        ...data,
-        meta
-      });
-    },
-    setRenderAttempted: true,
-    includeInNotification: true
+    return {
+      render: () => {
+        return modules[type]({
+          ...data,
+          meta
+        });
+      },
+      setRenderAttempted: true,
+      includeInNotification: true
+    };
   };
 };

--- a/src/components/Personalization/in-app-message-actions/actions/displayIframeContent.js
+++ b/src/components/Personalization/in-app-message-actions/actions/displayIframeContent.js
@@ -262,13 +262,17 @@ const generateWebParameters = mobileParameters => {
   };
 };
 
-export const displayHTMLContentInIframe = (content, interact) => {
+export const displayHTMLContentInIframe = (settings = {}, interact) => {
   dismissMessage();
-  const { html, mobileParameters } = content;
-  let { webParameters } = content;
+  const { content, contentType, mobileParameters } = settings;
+  let { webParameters } = settings;
+
+  if (contentType !== TEXT_HTML) {
+    return;
+  }
 
   const container = createElement(ALLOY_MESSAGING_CONTAINER_ID);
-  const iframe = createIframe(html, createIframeClickHandler(interact));
+  const iframe = createIframe(content, createIframeClickHandler(interact));
   const overlay = createElement(ALLOY_OVERLAY_CONTAINER_ID);
 
   if (!isValidWebParameters(webParameters)) {
@@ -284,8 +288,8 @@ export const displayHTMLContentInIframe = (content, interact) => {
 
 export default (settings, collect) => {
   return new Promise(resolve => {
-    const { meta, content = {} } = settings;
-    displayHTMLContentInIframe(content, (action, propositionAction) => {
+    const { meta } = settings;
+    displayHTMLContentInIframe(settings, (action, propositionAction) => {
       collect({
         decisionsMeta: [meta],
         propositionAction,

--- a/src/components/Personalization/in-app-message-actions/actions/displayIframeContent.js
+++ b/src/components/Personalization/in-app-message-actions/actions/displayIframeContent.js
@@ -262,17 +262,13 @@ const generateWebParameters = mobileParameters => {
   };
 };
 
-export const displayHTMLContentInIframe = (settings, interact) => {
+export const displayHTMLContentInIframe = (content, interact) => {
   dismissMessage();
-  const { content, contentType, mobileParameters } = settings;
-  let { webParameters } = settings;
-
-  if (contentType !== TEXT_HTML) {
-    return;
-  }
+  const { html, mobileParameters } = content;
+  let { webParameters } = content;
 
   const container = createElement(ALLOY_MESSAGING_CONTAINER_ID);
-  const iframe = createIframe(content, createIframeClickHandler(interact));
+  const iframe = createIframe(html, createIframeClickHandler(interact));
   const overlay = createElement(ALLOY_OVERLAY_CONTAINER_ID);
 
   if (!isValidWebParameters(webParameters)) {
@@ -288,8 +284,8 @@ export const displayHTMLContentInIframe = (settings, interact) => {
 
 export default (settings, collect) => {
   return new Promise(resolve => {
-    const { meta } = settings;
-    displayHTMLContentInIframe(settings, (action, propositionAction) => {
+    const { meta, content = {} } = settings;
+    displayHTMLContentInIframe(content, (action, propositionAction) => {
       collect({
         decisionsMeta: [meta],
         propositionAction,

--- a/test/unit/specs/components/DecisioningEngine/consequenceAdapters/inAppMessageConsequenceAdapter.spec.js
+++ b/test/unit/specs/components/DecisioningEngine/consequenceAdapters/inAppMessageConsequenceAdapter.spec.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import inAppMessageConsequenceAdapter from "../../../../../../src/components/DecisioningEngine/consequenceAdapters/inAppMessageConsequenceAdapter";
-import { APPLICATION_JSON } from "../../../../../../src/components/Personalization/constants/contentType";
+import { TEXT_HTML } from "../../../../../../src/components/Personalization/constants/contentType";
 
 describe("DecisioningEngine:inAppMessageConsequenceAdapter", () => {
   it("handles cjmiam", () => {
@@ -39,25 +39,23 @@ describe("DecisioningEngine:inAppMessageConsequenceAdapter", () => {
     ).toEqual({
       schema: "https://ns.adobe.com/personalization/message/in-app",
       data: {
-        content: {
-          mobileParameters: {
-            verticalAlign: "center",
-            dismissAnimation: "top",
-            verticalInset: 0,
-            backdropOpacity: 0.2,
-            cornerRadius: 15,
-            horizontalInset: 0,
-            uiTakeover: true,
-            horizontalAlign: "center",
-            width: 80,
-            displayAnimation: "top",
-            backdropColor: "#000000",
-            height: 60
-          },
-          webParameters: jasmine.any(Object),
-          html: "<!doctype html></html>"
+        mobileParameters: {
+          verticalAlign: "center",
+          dismissAnimation: "top",
+          verticalInset: 0,
+          backdropOpacity: 0.2,
+          cornerRadius: 15,
+          horizontalInset: 0,
+          uiTakeover: true,
+          horizontalAlign: "center",
+          width: 80,
+          displayAnimation: "top",
+          backdropColor: "#000000",
+          height: 60
         },
-        contentType: APPLICATION_JSON
+        webParameters: jasmine.any(Object),
+        content: "<!doctype html></html>",
+        contentType: TEXT_HTML
       },
       id: "72042c7c-4e34-44f6-af95-1072ae117424"
     });

--- a/test/unit/specs/components/DecisioningEngine/consequenceAdapters/schemaTypeConsequenceAdapter.spec.js
+++ b/test/unit/specs/components/DecisioningEngine/consequenceAdapters/schemaTypeConsequenceAdapter.spec.js
@@ -9,31 +9,40 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import inAppMessageConsequenceAdapter from "../../../../../../src/components/DecisioningEngine/consequenceAdapters/inAppMessageConsequenceAdapter";
+
+import schemaTypeConsequenceAdapter from "../../../../../../src/components/DecisioningEngine/consequenceAdapters/schemaTypeConsequenceAdapter";
 import { APPLICATION_JSON } from "../../../../../../src/components/Personalization/constants/contentType";
 
-describe("DecisioningEngine:inAppMessageConsequenceAdapter", () => {
-  it("handles cjmiam", () => {
+describe("DecisioningEngine:schemaTypeConsequenceAdapter", () => {
+  it("handles schema", () => {
     expect(
-      inAppMessageConsequenceAdapter(
+      schemaTypeConsequenceAdapter(
         "72042c7c-4e34-44f6-af95-1072ae117424",
-        "cjmiam",
+        "schema",
         {
-          mobileParameters: {
-            verticalAlign: "center",
-            dismissAnimation: "top",
-            verticalInset: 0,
-            backdropOpacity: 0.2,
-            cornerRadius: 15,
-            horizontalInset: 0,
-            uiTakeover: true,
-            horizontalAlign: "center",
-            width: 80,
-            displayAnimation: "top",
-            backdropColor: "#000000",
-            height: 60
+          schema: "https://ns.adobe.com/personalization/message/in-app",
+          data: {
+            content: {
+              mobileParameters: {
+                verticalAlign: "center",
+                dismissAnimation: "top",
+                verticalInset: 0,
+                backdropOpacity: 0.2,
+                cornerRadius: 15,
+                horizontalInset: 0,
+                uiTakeover: true,
+                horizontalAlign: "center",
+                width: 80,
+                displayAnimation: "top",
+                backdropColor: "#000000",
+                height: 60
+              },
+              webParameters: jasmine.any(Object),
+              html: "<!doctype html></html>"
+            },
+            contentType: APPLICATION_JSON
           },
-          html: "<!doctype html></html>"
+          id: "72042c7c-4e34-44f6-af95-1072ae117424"
         }
       )
     ).toEqual({

--- a/test/unit/specs/components/DecisioningEngine/consequenceAdapters/schemaTypeConsequenceAdapter.spec.js
+++ b/test/unit/specs/components/DecisioningEngine/consequenceAdapters/schemaTypeConsequenceAdapter.spec.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import schemaTypeConsequenceAdapter from "../../../../../../src/components/DecisioningEngine/consequenceAdapters/schemaTypeConsequenceAdapter";
-import { APPLICATION_JSON } from "../../../../../../src/components/Personalization/constants/contentType";
+import { TEXT_HTML } from "../../../../../../src/components/Personalization/constants/contentType";
 
 describe("DecisioningEngine:schemaTypeConsequenceAdapter", () => {
   it("handles schema", () => {
@@ -22,25 +22,23 @@ describe("DecisioningEngine:schemaTypeConsequenceAdapter", () => {
         {
           schema: "https://ns.adobe.com/personalization/message/in-app",
           data: {
-            content: {
-              mobileParameters: {
-                verticalAlign: "center",
-                dismissAnimation: "top",
-                verticalInset: 0,
-                backdropOpacity: 0.2,
-                cornerRadius: 15,
-                horizontalInset: 0,
-                uiTakeover: true,
-                horizontalAlign: "center",
-                width: 80,
-                displayAnimation: "top",
-                backdropColor: "#000000",
-                height: 60
-              },
-              webParameters: jasmine.any(Object),
-              html: "<!doctype html></html>"
+            mobileParameters: {
+              verticalAlign: "center",
+              dismissAnimation: "top",
+              verticalInset: 0,
+              backdropOpacity: 0.2,
+              cornerRadius: 15,
+              horizontalInset: 0,
+              uiTakeover: true,
+              horizontalAlign: "center",
+              width: 80,
+              displayAnimation: "top",
+              backdropColor: "#000000",
+              height: 60
             },
-            contentType: APPLICATION_JSON
+            webParameters: jasmine.any(Object),
+            content: "<!doctype html></html>",
+            contentType: TEXT_HTML
           },
           id: "72042c7c-4e34-44f6-af95-1072ae117424"
         }
@@ -48,25 +46,23 @@ describe("DecisioningEngine:schemaTypeConsequenceAdapter", () => {
     ).toEqual({
       schema: "https://ns.adobe.com/personalization/message/in-app",
       data: {
-        content: {
-          mobileParameters: {
-            verticalAlign: "center",
-            dismissAnimation: "top",
-            verticalInset: 0,
-            backdropOpacity: 0.2,
-            cornerRadius: 15,
-            horizontalInset: 0,
-            uiTakeover: true,
-            horizontalAlign: "center",
-            width: 80,
-            displayAnimation: "top",
-            backdropColor: "#000000",
-            height: 60
-          },
-          webParameters: jasmine.any(Object),
-          html: "<!doctype html></html>"
+        mobileParameters: {
+          verticalAlign: "center",
+          dismissAnimation: "top",
+          verticalInset: 0,
+          backdropOpacity: 0.2,
+          cornerRadius: 15,
+          horizontalInset: 0,
+          uiTakeover: true,
+          horizontalAlign: "center",
+          width: 80,
+          displayAnimation: "top",
+          backdropColor: "#000000",
+          height: 60
         },
-        contentType: APPLICATION_JSON
+        webParameters: jasmine.any(Object),
+        content: "<!doctype html></html>",
+        contentType: TEXT_HTML
       },
       id: "72042c7c-4e34-44f6-af95-1072ae117424"
     });

--- a/test/unit/specs/components/DecisioningEngine/createConsequenceAdapter.spec.js
+++ b/test/unit/specs/components/DecisioningEngine/createConsequenceAdapter.spec.js
@@ -10,31 +10,29 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import createConsequenceAdapter from "../../../../../src/components/DecisioningEngine/createConsequenceAdapter";
-import { APPLICATION_JSON } from "../../../../../src/components/Personalization/constants/contentType";
+import { TEXT_HTML } from "../../../../../src/components/Personalization/constants/contentType";
 
 describe("DecisioningEngine:createConsequenceAdapter", () => {
   const ADAPTED_CONSEQUENCE = {
     schema: "https://ns.adobe.com/personalization/message/in-app",
     data: {
-      content: {
-        mobileParameters: {
-          verticalAlign: "center",
-          dismissAnimation: "top",
-          verticalInset: 0,
-          backdropOpacity: 0.2,
-          cornerRadius: 15,
-          horizontalInset: 0,
-          uiTakeover: true,
-          horizontalAlign: "center",
-          width: 80,
-          displayAnimation: "top",
-          backdropColor: "#000000",
-          height: 60
-        },
-        webParameters: jasmine.any(Object),
-        html: "<!doctype html></html>"
+      mobileParameters: {
+        verticalAlign: "center",
+        dismissAnimation: "top",
+        verticalInset: 0,
+        backdropOpacity: 0.2,
+        cornerRadius: 15,
+        horizontalInset: 0,
+        uiTakeover: true,
+        horizontalAlign: "center",
+        width: 80,
+        displayAnimation: "top",
+        backdropColor: "#000000",
+        height: 60
       },
-      contentType: APPLICATION_JSON
+      webParameters: jasmine.any(Object),
+      content: "<!doctype html></html>",
+      contentType: TEXT_HTML
     },
     id: "72042c7c-4e34-44f6-af95-1072ae117424"
   };

--- a/test/unit/specs/components/DecisioningEngine/createConsequenceAdapter.spec.js
+++ b/test/unit/specs/components/DecisioningEngine/createConsequenceAdapter.spec.js
@@ -10,13 +10,39 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import createConsequenceAdapter from "../../../../../src/components/DecisioningEngine/createConsequenceAdapter";
-import { TEXT_HTML } from "../../../../../src/components/Personalization/constants/contentType";
+import { APPLICATION_JSON } from "../../../../../src/components/Personalization/constants/contentType";
 
 describe("DecisioningEngine:createConsequenceAdapter", () => {
-  it("works", () => {
+  const ADAPTED_CONSEQUENCE = {
+    schema: "https://ns.adobe.com/personalization/message/in-app",
+    data: {
+      content: {
+        mobileParameters: {
+          verticalAlign: "center",
+          dismissAnimation: "top",
+          verticalInset: 0,
+          backdropOpacity: 0.2,
+          cornerRadius: 15,
+          horizontalInset: 0,
+          uiTakeover: true,
+          horizontalAlign: "center",
+          width: 80,
+          displayAnimation: "top",
+          backdropColor: "#000000",
+          height: 60
+        },
+        webParameters: jasmine.any(Object),
+        html: "<!doctype html></html>"
+      },
+      contentType: APPLICATION_JSON
+    },
+    id: "72042c7c-4e34-44f6-af95-1072ae117424"
+  };
+
+  it("handles cjmiam", () => {
     const consequenceAdapter = createConsequenceAdapter();
 
-    const originalConsequence = {
+    const adaptedConsequence = consequenceAdapter({
       id: "72042c7c-4e34-44f6-af95-1072ae117424",
       type: "cjmiam",
       detail: {
@@ -34,34 +60,24 @@ describe("DecisioningEngine:createConsequenceAdapter", () => {
           backdropColor: "#000000",
           height: 60
         },
-        html: "<!doctype html><div>modal</div></html>"
+        html: "<!doctype html></html>"
       }
-    };
-
-    const adaptedConsequence = consequenceAdapter(originalConsequence);
-
-    expect(adaptedConsequence).toEqual({
-      schema: "https://ns.adobe.com/personalization/message/in-app",
-      data: {
-        mobileParameters: {
-          verticalAlign: "center",
-          dismissAnimation: "top",
-          verticalInset: 0,
-          backdropOpacity: 0.2,
-          cornerRadius: 15,
-          horizontalInset: 0,
-          uiTakeover: true,
-          horizontalAlign: "center",
-          width: 80,
-          displayAnimation: "top",
-          backdropColor: "#000000",
-          height: 60
-        },
-        webParameters: jasmine.any(Object),
-        content: "<!doctype html><div>modal</div></html>",
-        contentType: TEXT_HTML
-      },
-      id: "72042c7c-4e34-44f6-af95-1072ae117424"
     });
+
+    expect(adaptedConsequence).toEqual(ADAPTED_CONSEQUENCE);
+  });
+
+  it("handles schema", () => {
+    const consequenceAdapter = createConsequenceAdapter();
+
+    const adaptedConsequence = consequenceAdapter({
+      id: "72042c7c-4e34-44f6-af95-1072ae117424",
+      type: "schema",
+      detail: {
+        ...ADAPTED_CONSEQUENCE
+      }
+    });
+
+    expect(adaptedConsequence).toEqual(ADAPTED_CONSEQUENCE);
   });
 });


### PR DESCRIPTION
Updated IAM demo to use stage with a web IAM campaign

This PR updates this demo page 👇 
http://localhost:3000/inAppMessages

At the top of the `InAppMessages.js` file you can change `const configKey = "stage";`.  Doing so will use a standard sendEvent call to retrieve a real-life web campaign with IAM directly from konductor. 🎉 

Don't worry, the old method still works if you set `configKey` to one of the other options in prod.

The `consequenceAdapters` take care of translating consequences to work no matter the format they come in.


Here's an in app message coming from a web campaign:

![screenshot-2023-09-28 at 14 16 49](https://github.com/adobe/alloy/assets/427213/23d61e7a-56a5-4fda-b9ed-96fa9c75eb63)
