### PR TITLE
fix for click through

### DIFF
--- a/sandbox/src/components/InAppMessagesDemo/InAppMessages.js
+++ b/sandbox/src/components/InAppMessagesDemo/InAppMessages.js
@@ -28,7 +28,7 @@ const config = {
     alloyInstance: window.iamAlloy,
     datastreamId: "8cefc5ca-1c2a-479f-88f2-3d42cc302514",
     orgId: "906E3A095DC834230A495FD6@AdobeOrg",
-    surface: "mobileapp://com.adobe.aguaAppIos",
+    surface: "web://localhost:3000/inAppMessages",
     decisionContext: {},
     edgeDomain: "edge.adobedc.net",
     activeCampaigns: [

--- a/src/components/Personalization/createCollect.js
+++ b/src/components/Personalization/createCollect.js
@@ -20,7 +20,7 @@ export default ({ eventManager, mergeDecisionsMeta }) => {
     propositionAction,
     documentMayUnload = false,
     eventType = DISPLAY,
-    propositionEventType = getPropositionEventType(eventType),
+    propositionEventTypes = [getPropositionEventType(eventType)],
     viewName
   }) => {
     const event = eventManager.createEvent();
@@ -35,7 +35,7 @@ export default ({ eventManager, mergeDecisionsMeta }) => {
       mergeDecisionsMeta(
         event,
         decisionsMeta,
-        propositionEventType,
+        propositionEventTypes,
         propositionAction
       );
     }

--- a/src/components/Personalization/createComponent.js
+++ b/src/components/Personalization/createComponent.js
@@ -33,9 +33,7 @@ export default ({
 }) => {
   return {
     lifecycle: {
-      onDecision({ viewName, renderDecisions, propositions }) {
-        return onDecisionHandler({ viewName, renderDecisions, propositions });
-      },
+      onDecision: onDecisionHandler,
       onBeforeRequest({ request }) {
         setTargetMigration(request);
         return Promise.resolve();

--- a/src/components/Personalization/createOnClickHandler.js
+++ b/src/components/Personalization/createOnClickHandler.js
@@ -47,7 +47,7 @@ export default ({
         mergeDecisionsMeta(
           event,
           decisionsMeta,
-          PropositionEventType.INTERACT,
+          [PropositionEventType.INTERACT],
           eventLabel ? { label: eventLabel } : undefined
         );
       }

--- a/src/components/Personalization/createPendingNotificationsHandler.js
+++ b/src/components/Personalization/createPendingNotificationsHandler.js
@@ -15,6 +15,6 @@ export default ({ pendingDisplayNotifications, mergeDecisionsMeta }) => ({
   event
 }) => {
   return pendingDisplayNotifications.clear().then(decisionsMeta => {
-    mergeDecisionsMeta(event, decisionsMeta, PropositionEventType.DISPLAY);
+    mergeDecisionsMeta(event, decisionsMeta, [PropositionEventType.DISPLAY]);
   });
 };

--- a/src/components/Personalization/createViewChangeHandler.js
+++ b/src/components/Personalization/createViewChangeHandler.js
@@ -44,7 +44,9 @@ export default ({ mergeDecisionsMeta, processPropositions, viewCache }) => {
         return [];
       })
       .then(decisionsMeta => {
-        mergeDecisionsMeta(event, decisionsMeta, PropositionEventType.DISPLAY);
+        mergeDecisionsMeta(event, decisionsMeta, [
+          PropositionEventType.DISPLAY
+        ]);
       });
   };
 };

--- a/src/components/Personalization/event.js
+++ b/src/components/Personalization/event.js
@@ -16,16 +16,20 @@ import { EVENT_TYPE_TRUE } from "../../constants/eventType";
 export const mergeDecisionsMeta = (
   event,
   decisionsMeta,
-  propositionEventType,
+  propositionEventTypes,
   propositionAction
 ) => {
+  const propositionEventType = {};
+
+  propositionEventTypes.forEach(type => {
+    propositionEventType[type] = EVENT_TYPE_TRUE;
+  });
+
   const xdm = {
     _experience: {
       decisioning: {
         propositions: decisionsMeta,
-        propositionEventType: {
-          [propositionEventType]: EVENT_TYPE_TRUE
-        }
+        propositionEventType
       }
     }
   };

--- a/src/components/Personalization/in-app-message-actions/actions/displayIframeContent.js
+++ b/src/components/Personalization/in-app-message-actions/actions/displayIframeContent.js
@@ -14,7 +14,8 @@ import { getNonce } from "../../dom-actions/dom";
 import { createElement, parseAnchor, removeElementById } from "../utils";
 import { TEXT_HTML } from "../../constants/contentType";
 import { assign } from "../../../../utils";
-import { getEventType } from "../../../../constants/propositionEventType";
+import { PropositionEventType } from "../../../../constants/propositionEventType";
+import { INTERACT } from "../../../../constants/eventType";
 
 const ALLOY_MESSAGING_CONTAINER_ID = "alloy-messaging-container";
 const ALLOY_OVERLAY_CONTAINER_ID = "alloy-overlay-container";
@@ -290,10 +291,18 @@ export default (settings, collect) => {
   return new Promise(resolve => {
     const { meta } = settings;
     displayHTMLContentInIframe(settings, (action, propositionAction) => {
+      const propositionEventTypes = new Set();
+      propositionEventTypes.add(PropositionEventType.INTERACT);
+
+      if (Object.values(PropositionEventType).indexOf(action) !== -1) {
+        propositionEventTypes.add(action);
+      }
+
       collect({
         decisionsMeta: [meta],
         propositionAction,
-        eventType: getEventType(action)
+        eventType: INTERACT,
+        propositionEventTypes: Array.from(propositionEventTypes)
       });
     });
 

--- a/test/unit/specs/components/Personalization/createCollect.spec.js
+++ b/test/unit/specs/components/Personalization/createCollect.spec.js
@@ -43,7 +43,7 @@ describe("Personalization::createCollect", () => {
     expect(mergeDecisionsMeta).toHaveBeenCalledWith(
       event,
       decisionsMeta,
-      PropositionEventType.DISPLAY,
+      [PropositionEventType.DISPLAY],
       undefined
     );
     expect(eventManager.sendEvent).toHaveBeenCalled();

--- a/test/unit/specs/components/Personalization/createPendingNotificationsHandler.spec.js
+++ b/test/unit/specs/components/Personalization/createPendingNotificationsHandler.spec.js
@@ -38,7 +38,7 @@ describe("Personalization::createPendingNotificationsHandler", () => {
       expect(mergeDecisionsMeta).toHaveBeenCalledOnceWith(
         event,
         ["mymeta1", "mymeta2"],
-        "display"
+        ["display"]
       );
     });
   });

--- a/test/unit/specs/components/Personalization/createViewChangeHandler.spec.js
+++ b/test/unit/specs/components/Personalization/createViewChangeHandler.spec.js
@@ -73,11 +73,9 @@ describe("Personalization::createViewChangeHandler", () => {
     const result = await run();
 
     expect(processPropositions).toHaveBeenCalledTimes(1);
-    expect(mergeDecisionsMeta).toHaveBeenCalledWith(
-      "myevent",
-      "decisionMeta",
+    expect(mergeDecisionsMeta).toHaveBeenCalledWith("myevent", "decisionMeta", [
       PropositionEventType.DISPLAY
-    );
+    ]);
     expect(result.decisions).toEqual(CART_VIEW_DECISIONS);
   });
 });

--- a/test/unit/specs/components/Personalization/event.spec.js
+++ b/test/unit/specs/components/Personalization/event.spec.js
@@ -35,7 +35,7 @@ describe("Personalization::event", () => {
           scope: "cart"
         }
       ];
-      mergeDecisionsMeta(event, decisionsMeta, PropositionEventType.DISPLAY);
+      mergeDecisionsMeta(event, decisionsMeta, [PropositionEventType.DISPLAY]);
       expect(event.mergeXdm).toHaveBeenCalledWith({
         _experience: {
           decisioning: {


### PR DESCRIPTION
For campaigns with a trigger that shows only until "click through"...

![screenshot-2023-10-17 at 12 01 01@2x](https://github.com/adobe/alloy/assets/427213/e0fcefe3-16b0-4380-a5ed-2e732314aa3c)

a historical condition is added to the ruleset...

![screenshot-2023-10-17 at 12 02 41@2x](https://github.com/adobe/alloy/assets/427213/f04900db-22f8-4a64-afd5-7880669da4e1)

This condition failed to be evaluated properly, because only "dismiss" propositionEventType was sent when clicking the button...

![screenshot-2023-10-17 at 12 04 18@2x](https://github.com/adobe/alloy/assets/427213/4eeb6641-9146-47f5-83a9-2695030e1145)

![screenshot-2023-10-17 at 12 05 32@2x](https://github.com/adobe/alloy/assets/427213/745ce639-2eac-46bb-a4a3-2b9660d6cc95)

![screenshot-2023-10-17 at 12 07 19@2x](https://github.com/adobe/alloy/assets/427213/65c15c2e-4f81-4bfd-9b73-f1b70b46ea88)
