### PR TITLE
Show containers even when renderDecisions is false

### DIFF
--- a/src/components/Personalization/createFetchDataHandler.js
+++ b/src/components/Personalization/createFetchDataHandler.js
@@ -26,6 +26,8 @@ export default ({
   return ({ cacheUpdate, personalizationDetails, event, onResponse }) => {
     if (personalizationDetails.isRenderDecisions()) {
       hideContainers(prehidingStyle);
+    } else {
+      showContainers();
     }
     mergeQuery(event, personalizationDetails.createQueryDetails());
 

--- a/src/components/Personalization/handlers/createProcessPropositions.js
+++ b/src/components/Personalization/handlers/createProcessPropositions.js
@@ -23,8 +23,8 @@ export default ({ schemaProcessors, logger }) => {
       .catch(error => {
         if (logger.enabled) {
           const { message, stack } = error;
-          const errorMessage = `Failed to execute action ${item.toString()}. ${message} ${stack}`;
-          logger.error(errorMessage);
+          const warning = `Failed to execute action ${item.toString()}. ${message} ${stack}`;
+          logger.warn(warning);
         }
         return false;
       });

--- a/test/functional/specs/Personalization/C14299419.js
+++ b/test/functional/specs/Personalization/C14299419.js
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { t, Selector } from "testcafe";
+import createFixture from "../../helpers/createFixture";
+import {
+  compose,
+  orgMainConfigMain,
+  debugEnabled
+} from "../../helpers/constants/configParts";
+import { TEST_PAGE as TEST_PAGE_URL } from "../../helpers/constants/url";
+import createAlloyProxy from "../../helpers/createAlloyProxy";
+import addHtmlToHeader from "../../helpers/dom/addHtmlToHeader";
+
+const config = compose(orgMainConfigMain, debugEnabled);
+
+createFixture({
+  title:
+    "C14299419: Prehiding style is removed when no personalization payload is returned",
+  url: `${TEST_PAGE_URL}?test=C14299419`
+});
+
+test.meta({
+  ID: "C14299419",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+
+test("Test C14299419: Prehiding style is removed when no personalization payload is returned", async () => {
+  await addHtmlToHeader(
+    `<style id="alloy-prehiding">body { visibility: hidden; }</style`
+  );
+
+  const alloy = createAlloyProxy();
+  await alloy.configure(config);
+  await alloy.sendEvent({ renderDecisions: true });
+
+  await t.expect(Selector("#alloy-prehiding").exists).notOk();
+});

--- a/test/functional/specs/Personalization/C14299420.js
+++ b/test/functional/specs/Personalization/C14299420.js
@@ -1,0 +1,46 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { t, Selector } from "testcafe";
+import createFixture from "../../helpers/createFixture";
+import {
+  compose,
+  orgMainConfigMain,
+  debugEnabled
+} from "../../helpers/constants/configParts";
+import { TEST_PAGE as TEST_PAGE_URL } from "../../helpers/constants/url";
+import createAlloyProxy from "../../helpers/createAlloyProxy";
+import addHtmlToHeader from "../../helpers/dom/addHtmlToHeader";
+
+const config = compose(orgMainConfigMain, debugEnabled);
+
+createFixture({
+  title: "C14299420: Prehiding style is removed when renderDecisions is false",
+  url: `${TEST_PAGE_URL}?test=C14299420`
+});
+
+test.meta({
+  ID: "C14299420",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+
+test("Test C14299420: Prehiding style is removed when renderDecisions is false", async () => {
+  await addHtmlToHeader(
+    `<style id="alloy-prehiding">body { visibility: hidden; }</style`
+  );
+
+  const alloy = createAlloyProxy();
+  await alloy.configure(config);
+  await alloy.sendEvent({ renderDecisions: false });
+
+  await t.expect(Selector("#alloy-prehiding").exists).notOk();
+});

--- a/test/functional/specs/Personalization/C14299421.js
+++ b/test/functional/specs/Personalization/C14299421.js
@@ -1,0 +1,59 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { t, Selector } from "testcafe";
+import createFixture from "../../helpers/createFixture";
+import {
+  compose,
+  orgMainConfigMain,
+  debugEnabled
+} from "../../helpers/constants/configParts";
+import { TEST_PAGE as TEST_PAGE_URL } from "../../helpers/constants/url";
+import createAlloyProxy from "../../helpers/createAlloyProxy";
+import addHtmlToHeader from "../../helpers/dom/addHtmlToHeader";
+import addHtmlToBody from "../../helpers/dom/addHtmlToBody";
+import createConsoleLogger from "../../helpers/consoleLogger";
+
+const config = compose(orgMainConfigMain, debugEnabled);
+
+createFixture({
+  title:
+    "C14299421: Prehiding style is removed when there is a problem rendering",
+  url: `${TEST_PAGE_URL}?test=C14299421`
+});
+
+test.meta({
+  ID: "C14299421",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+
+test("Test C14299421: Prehiding style is removed when there is a problem rendering", async () => {
+  const logger = await createConsoleLogger();
+
+  // remove the heading so there is an error when trying to apply the personalization which is attached to the h1
+  await t.eval(() => {
+    window.document.body.children[0].remove();
+  });
+  await addHtmlToBody(`<div>Test C14299421 with missing heading</div>`);
+  await addHtmlToHeader(
+    `<style id="alloy-prehiding">body { visibility: hidden; }</style`
+  );
+
+  const alloy = createAlloyProxy();
+  await alloy.configure(config);
+  await alloy.sendEvent({ renderDecisions: true });
+
+  await t.expect(Selector("#alloy-prehiding").exists).notOk();
+  // wait for the rendering to timeout
+  await new Promise(resolve => setTimeout(resolve, 5000));
+  await logger.warn.expectMessageMatching(/Failed to execute action/);
+});

--- a/test/functional/specs/Personalization/C14299422.js
+++ b/test/functional/specs/Personalization/C14299422.js
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { t, Selector } from "testcafe";
+import createFixture from "../../helpers/createFixture";
+import {
+  compose,
+  orgMainConfigMain,
+  debugEnabled
+} from "../../helpers/constants/configParts";
+import { TEST_PAGE as TEST_PAGE_URL } from "../../helpers/constants/url";
+import createAlloyProxy from "../../helpers/createAlloyProxy";
+import addHtmlToHeader from "../../helpers/dom/addHtmlToHeader";
+
+const config = compose(orgMainConfigMain, debugEnabled);
+
+createFixture({
+  title:
+    "C14299422: Prehiding style is removed when there is a personalization payload",
+  url: `${TEST_PAGE_URL}?test=C14299421`
+});
+
+test.meta({
+  ID: "C14299422",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression"
+});
+
+test("Test C14299422: Prehiding style is removed when there is a personalization payload", async () => {
+  await addHtmlToHeader(
+    `<style id="alloy-prehiding">body { visibility: hidden; }</style`
+  );
+
+  const alloy = createAlloyProxy();
+  await alloy.configure(config);
+  await alloy.sendEvent({ renderDecisions: true });
+
+  await t.expect(Selector("#alloy-prehiding").exists).notOk();
+});


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

This adds 4 functional tests around making sure that showContainers is called promptly in different scenarios. One issue the tests found was that when renderDecisions is false, showContainers was not being called. I fixed that use-case here.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
