### PR TITLE
Do not send bottom of page events after a redirect

### DIFF
--- a/src/components/Personalization/dom-actions/createRedirect.js
+++ b/src/components/Personalization/dom-actions/createRedirect.js
@@ -10,4 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export default window => url => window.location.replace(url);
+export default window => url => {
+  window.location.replace(url);
+  // Return a promise that never resolves because redirects never complete
+  // within the current page.
+  return new Promise(() => undefined);
+};

--- a/src/components/Personalization/handlers/createProcessRedirect.js
+++ b/src/components/Personalization/handlers/createProcessRedirect.js
@@ -22,8 +22,11 @@ export default ({ logger, executeRedirect, collect }) => item => {
       decisionsMeta: [item.getProposition().getNotification()],
       documentMayUnload: true
     }).then(() => {
-      executeRedirect(content);
-      // We've already sent the display notification, so don't return anything
+      return executeRedirect(content);
+      // Execute redirect will never resolve. If there are bottom of page events that are waiting
+      // for display notifications from this request, they will never run because this promise will
+      // not resolve. This is intentional because we don't want to run bottom of page events if
+      // there is a redirect.
     });
   };
 

--- a/test/functional/specs/Personalization/C205528.js
+++ b/test/functional/specs/Personalization/C205528.js
@@ -61,3 +61,23 @@ test("Test C205528: A redirect offer should not redirect if renderDecisions is f
   await new Promise(resolve => setTimeout(resolve, 1000));
   await t.expect(redirectLogger.count(() => true)).eql(0);
 });
+
+test("Test 205528: When there is a redirect offer web sdk should not send a bottom of page event", async () => {
+  const alloy = createAlloyProxy();
+  await alloy.configure(config);
+  await alloy.sendEventAsync({
+    renderDecisions: true,
+    personalization: {
+      sendDisplayEvent: false
+    }
+  });
+  await alloy.sendEventAsync({
+    personalization: {
+      includeRenderedPropositions: true
+    }
+  });
+
+  await t.expect(redirectLogger.count(() => true)).eql(1);
+  // 1 for the initial request, 1 for the redirect display notification
+  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(2);
+});


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

We found in testing that when running a top of page event with a redirect offer, the bottom of page event was still sent. This PR fixes that issue so that when there are sendEvent calls that are waiting for rendered propositions, they will not run when a redirect is executed.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
