### PR TITLE
Move decisionContext within personalization

### DIFF
--- a/sandbox/src/components/InAppMessagesDemo/InAppMessages.js
+++ b/sandbox/src/components/InAppMessagesDemo/InAppMessages.js
@@ -84,15 +84,16 @@ export default function InAppMessages() {
     if (useEvaluateRulesetsCommand) {
       alloyInstance("evaluateRulesets", {
         renderDecisions: true,
-        decisionContext: context
+        personalization: {
+          decisionContext: context
+        }
       });
       return;
     }
 
     alloyInstance("sendEvent", {
       renderDecisions: true,
-      decisionContext: context,
-      personalization: { surfaces: ["#hello"] }
+      personalization: { surfaces: ["#hello"], decisionContext: context }
     }).then(() => setSentEvent(true));
   };
 

--- a/src/components/DataCollector/validateApplyResponse.js
+++ b/src/components/DataCollector/validateApplyResponse.js
@@ -21,7 +21,6 @@ import {
 export default ({ options }) => {
   const validator = objectOf({
     renderDecisions: boolean(),
-    decisionContext: objectOf({}),
     responseHeaders: mapOfValues(string().required()),
     responseBody: objectOf({
       handle: arrayOf(
@@ -32,7 +31,8 @@ export default ({ options }) => {
       ).required()
     }).required(),
     personalization: objectOf({
-      sendDisplayEvent: boolean().default(true)
+      sendDisplayEvent: boolean().default(true),
+      decisionContext: objectOf({})
     }).default({ sendDisplayEvent: true })
   }).noUnknownFields();
 

--- a/src/components/DataCollector/validateUserEventOptions.js
+++ b/src/components/DataCollector/validateUserEventOptions.js
@@ -27,14 +27,14 @@ export default ({ options }) => {
     data: objectOf({}),
     documentUnloading: boolean(),
     renderDecisions: boolean(),
-    decisionContext: objectOf({}),
     decisionScopes: arrayOf(string()).uniqueItems(),
     personalization: objectOf({
       decisionScopes: arrayOf(string()).uniqueItems(),
       surfaces: arrayOf(string()).uniqueItems(),
       sendDisplayEvent: boolean().default(true),
       includeRenderedPropositions: boolean().default(false),
-      requestPersonalization: boolean()
+      requestPersonalization: boolean(),
+      decisionContext: objectOf({})
     }).default({ sendDisplayEvent: true }),
     datasetId: string(),
     mergeId: string(),

--- a/src/components/DecisioningEngine/createEvaluateRulesetsCommand.js
+++ b/src/components/DecisioningEngine/createEvaluateRulesetsCommand.js
@@ -14,7 +14,9 @@ import { boolean, objectOf } from "../../utils/validation";
 const validateOptions = ({ options }) => {
   const validator = objectOf({
     renderDecisions: boolean(),
-    decisionContext: objectOf({})
+    personalization: objectOf({
+      decisionContext: objectOf({})
+    })
   }).noUnknownFields();
 
   return validator(options);

--- a/src/components/DecisioningEngine/index.js
+++ b/src/components/DecisioningEngine/index.js
@@ -73,9 +73,11 @@ const createDecisioningEngine = ({
       onBeforeEvent({
         event,
         renderDecisions,
-        decisionContext = {},
+        personalization = {},
         onResponse = noop
       }) {
+        const { decisionContext = {} } = personalization;
+
         onResponse(
           createOnResponseHandler({
             renderDecisions,
@@ -95,8 +97,9 @@ const createDecisioningEngine = ({
     },
     commands: {
       evaluateRulesets: {
-        run: ({ renderDecisions, decisionContext = {} }) =>
-          evaluateRulesetsCommand.run({
+        run: ({ renderDecisions, personalization = {} }) => {
+          const { decisionContext = {} } = personalization;
+          return evaluateRulesetsCommand.run({
             renderDecisions,
             decisionContext: {
               [CONTEXT_KEY.TYPE]: CONTEXT_EVENT_TYPE.RULES_ENGINE,
@@ -104,7 +107,8 @@ const createDecisioningEngine = ({
               ...decisionContext
             },
             applyResponse
-          }),
+          });
+        },
         optionsValidator: evaluateRulesetsCommand.optionsValidator
       },
       subscribeRulesetItems: subscribeRulesetItems.command

--- a/test/functional/specs/DecisioningEngine/C13348429.js
+++ b/test/functional/specs/DecisioningEngine/C13348429.js
@@ -205,10 +205,12 @@ test("Test C13348429: Verify DOM action using the applyResponse command.", async
 
   await alloy.applyResponse({
     renderDecisions: true,
-    decisionContext: {
-      "~type": "com.adobe.eventType.generic.track",
-      "~source": "com.adobe.eventSource.requestContent",
-      "~state.com.adobe.module.lifecycle/lifecyclecontextdata.dayofweek": 2
+    personalization: {
+      decisionContext: {
+        "~type": "com.adobe.eventType.generic.track",
+        "~source": "com.adobe.eventSource.requestContent",
+        "~state.com.adobe.module.lifecycle/lifecyclecontextdata.dayofweek": 2
+      }
     },
     responseBody: mockResponse
   });

--- a/test/functional/specs/DecisioningEngine/C13405889.js
+++ b/test/functional/specs/DecisioningEngine/C13405889.js
@@ -209,10 +209,12 @@ test("Test C13405889: Verify DOM action using the evaluateRulesets command", asy
   });
   await alloy.evaluateRulesets({
     renderDecisions: true,
-    decisionContext: {
-      "~type": "com.adobe.eventType.generic.track",
-      "~source": "com.adobe.eventSource.requestContent",
-      "~state.com.adobe.module.lifecycle/lifecyclecontextdata.dayofweek": 2
+    personalization: {
+      decisionContext: {
+        "~type": "com.adobe.eventType.generic.track",
+        "~source": "com.adobe.eventSource.requestContent",
+        "~state.com.adobe.module.lifecycle/lifecyclecontextdata.dayofweek": 2
+      }
     }
   });
   const containerElement = await getIframeContainer();

--- a/test/functional/specs/DecisioningEngine/C13419240.js
+++ b/test/functional/specs/DecisioningEngine/C13419240.js
@@ -210,10 +210,12 @@ test("Test C13419240: Verify DOM action using the sendEvent command", async () =
 
   await alloy.sendEvent({
     renderDecisions: true,
-    decisionContext: {
-      "~type": "com.adobe.eventType.generic.track",
-      "~source": "com.adobe.eventSource.requestContent",
-      "~state.com.adobe.module.lifecycle/lifecyclecontextdata.dayofweek": 2
+    personalization: {
+      decisionContext: {
+        "~type": "com.adobe.eventType.generic.track",
+        "~source": "com.adobe.eventSource.requestContent",
+        "~state.com.adobe.module.lifecycle/lifecyclecontextdata.dayofweek": 2
+      }
     }
   });
 

--- a/test/unit/specs/components/DecisioningEngine/index.spec.js
+++ b/test/unit/specs/components/DecisioningEngine/index.spec.js
@@ -68,7 +68,7 @@ describe("createDecisioningEngine:commands:evaluateRulesets", () => {
     decisioningEngine.lifecycle.onBeforeEvent({
       event: mockEvent,
       renderDecisions: true,
-      decisionContext: {},
+      personalization: { decisionContext: {} },
       onResponse: onResponseHandler
     });
     const result = decisioningEngine.commands.evaluateRulesets.run({});
@@ -93,7 +93,7 @@ describe("createDecisioningEngine:commands:evaluateRulesets", () => {
     decisioningEngine.lifecycle.onBeforeEvent({
       event: mockEvent,
       renderDecisions: true,
-      decisionContext: {},
+      personalization: { decisionContext: {} },
       onResponse: onResponseHandler
     });
     const result = decisioningEngine.commands.evaluateRulesets.run({});
@@ -118,7 +118,7 @@ describe("createDecisioningEngine:commands:evaluateRulesets", () => {
     decisioningEngine.lifecycle.onBeforeEvent({
       event: mockEvent,
       renderDecisions: true,
-      decisionContext: {},
+      personalization: { decisionContext: {} },
       onResponse: onResponseHandler
     });
     const result = decisioningEngine.commands.evaluateRulesets.run({});
@@ -143,7 +143,7 @@ describe("createDecisioningEngine:commands:evaluateRulesets", () => {
     decisioningEngine.lifecycle.onBeforeEvent({
       event: mockEvent,
       renderDecisions: false,
-      decisionContext: {},
+      personalization: { decisionContext: {} },
       onResponse: onResponseHandler
     });
     const result = decisioningEngine.commands.evaluateRulesets.run({});


### PR DESCRIPTION
This PR moves `decisionContext` within `personalization`.

### Before

**sendEvent**

```js
window.alloy("sendEvent", {
  renderDecisions: true,
  decisionContext: { color: "orange" },
});
```

**evaluateRulesets**
```js
window.alloy("evaluateRulesets", {
  renderDecisions: true,
  decisionContext: { color: "orange" },
});
```

### After

**sendEvent**
```js
window.alloy("sendEvent", {
  renderDecisions: true,
  personalization: {
    decisionContext: { color: "orange" },
  },
});
```

**evaluateRulesets**
```js
window.alloy("evaluateRulesets", {
  renderDecisions: true,
  personalization: {
    decisionContext: { color: "orange" },
  },
});
```

