### PR TITLE
[PDCL-11254] limit personalization event storage to only AJO campaigns

### DIFF
--- a/src/components/DecisioningEngine/createEventRegistry.js
+++ b/src/components/DecisioningEngine/createEventRegistry.js
@@ -14,9 +14,11 @@ import {
   createSaveStorage,
   getExpirationDate,
   getActivityId,
-  hasExperienceData
+  hasExperienceData,
+  getDecisionProvider
 } from "./utils";
 import { EVENT_TYPE_TRUE } from "../../constants/eventType";
+import { ADOBE_JOURNEY_OPTIMIZER } from "../../constants/decisionProvider";
 
 const STORAGE_KEY = "events";
 const MAX_EVENT_RECORDS = 1000;
@@ -129,6 +131,9 @@ export default ({ storage }) => {
       .filter(validPropositionEventType)
       .forEach(propositionEventType => {
         propositions.forEach(proposition => {
+          if (getDecisionProvider(proposition) !== ADOBE_JOURNEY_OPTIMIZER) {
+            return;
+          }
           addEvent(
             {},
             propositionEventType,

--- a/src/components/DecisioningEngine/utils.js
+++ b/src/components/DecisioningEngine/utils.js
@@ -75,3 +75,9 @@ export const hasExperienceData = xdm => {
 
   return true;
 };
+
+export const getDecisionProvider = proposition => {
+  const { scopeDetails = {} } = proposition;
+  const { decisionProvider } = scopeDetails;
+  return decisionProvider;
+};

--- a/src/constants/decisionProvider.js
+++ b/src/constants/decisionProvider.js
@@ -1,0 +1,12 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+export const ADOBE_JOURNEY_OPTIMIZER = "AJO";

--- a/test/unit/specs/components/DecisioningEngine/createEventRegistry.spec.js
+++ b/test/unit/specs/components/DecisioningEngine/createEventRegistry.spec.js
@@ -57,6 +57,17 @@ describe("DecisioningEngine:createEventRegistry", () => {
                     id: "222#bbb"
                   }
                 }
+              },
+              {
+                id: "333",
+                scope: "web://something",
+                scopeDetails: {
+                  decisionProvider: "TGT",
+                  correlationID: "aasfsdf",
+                  activity: {
+                    id: "333#ccc"
+                  }
+                }
               }
             ],
             propositionEventType: {


### PR DESCRIPTION
This PR changes the behavior of eventRegistry so that only experience edge events with a `decisionProvider` equal to `AJO` will be stored.


Related Jira: https://jira.corp.adobe.com/browse/PDCL-11254