### PR TITLE
Now merging DATA and switching to using contextData

### DIFF
--- a/src/components/ActivityCollector/createClickedElementProperties.js
+++ b/src/components/ActivityCollector/createClickedElementProperties.js
@@ -31,7 +31,7 @@ const buildDataFromClickedElementProperties = (props) => {
   return {
     __adobe: {
       analytics: {
-        c: {
+        contextData: {
           a: {
             activitymap: {
               page: props.pageName,
@@ -59,10 +59,10 @@ const populateClickedElementPropertiesFromOptions = (options, props) => {
   // DATA has priority over XDM
   /* eslint no-underscore-dangle: 0 */
   if (data && data.__adobe && data.__adobe.analytics) {
-    const { c } = data.__adobe.analytics;
-    if (c && c.a && c.a.activitymap) {
+    const { contextData } = data.__adobe.analytics;
+    if (contextData && contextData.a && contextData.a.activitymap) {
       // Set the properties if they exists
-      const { page, link, region, pageIDType } = c.a.activitymap;
+      const { page, link, region, pageIDType } = contextData.a.activitymap;
       props.pageName = page || props.pageName;
       props.linkName = link || props.linkName;
       props.linkRegion = region || props.linkRegion;

--- a/src/components/ActivityCollector/createInjectClickedElementProperties.js
+++ b/src/components/ActivityCollector/createInjectClickedElementProperties.js
@@ -68,7 +68,7 @@ export default ({
     } else if (elementProperties.isValidLink()) {
       // Event will be sent
       event.mergeXdm(elementProperties.xdm);
-      event.setUserData(elementProperties.data);
+      event.mergeData(elementProperties.data);
       clickActivityStorage.save({
         pageName: elementProperties.pageName,
         pageIDType: elementProperties.pageIDType,

--- a/src/components/ActivityCollector/createRecallAndInjectClickedElementProperties.js
+++ b/src/components/ActivityCollector/createRecallAndInjectClickedElementProperties.js
@@ -32,7 +32,7 @@ export default ({ clickActivityStorage }) => {
         event.mergeXdm(xdm);
       }
       if (elementProperties.isValidActivityMapData()) {
-        event.setUserData(elementProperties.data);
+        event.mergeData(elementProperties.data);
       }
       // NOTE: We can't clear out all the storage here because we might still need to
       // keep a page-name for multiple link-clicks (e.g. downloads) on the same page.

--- a/test/functional/specs/Data Collector/C8118.js
+++ b/test/functional/specs/Data Collector/C8118.js
@@ -63,7 +63,7 @@ const getXdmFromRequest = (req) => {
 /* eslint no-underscore-dangle: 0 */
 const getActivityMapDataFromRequest = (req) => {
   const bodyJson = JSON.parse(req.request.body);
-  return bodyJson.events[0].data.__adobe.analytics.c.a.activitymap;
+  return bodyJson.events[0].data.__adobe.analytics.contextData.a.activitymap;
 };
 
 const assertRequestXdm = async (req) => {

--- a/test/functional/specs/Data Collector/C81181.js
+++ b/test/functional/specs/Data Collector/C81181.js
@@ -222,7 +222,7 @@ test("Test C81181: Verify that onBeforeLinkClickSend augments a request", async 
   const expectedData = {
     __adobe: {
       analytics: {
-        c: {
+        contextData: {
           a: {
             activitymap: {
               link: "Test Link",
@@ -281,7 +281,7 @@ test("Test C81181: Verify that filterClickDetails can augment a request", async 
   const expectedData = {
     __adobe: {
       analytics: {
-        c: {
+        contextData: {
           a: {
             activitymap: {
               link: "Augmented name",

--- a/test/unit/specs/components/ActivityCollector/createClickedElementProperties.spec.js
+++ b/test/unit/specs/components/ActivityCollector/createClickedElementProperties.spec.js
@@ -57,7 +57,7 @@ describe("ActivityCollector::createClickedElementProperties", () => {
     expect(data).toEqual({
       __adobe: {
         analytics: {
-          c: {
+          contextData: {
             a: {
               activitymap: {
                 page: "testPageName",
@@ -108,7 +108,7 @@ describe("ActivityCollector::createClickedElementProperties", () => {
       data: {
         __adobe: {
           analytics: {
-            c: {
+            contextData: {
               a: {
                 activitymap: {
                   page: "dataPage",
@@ -208,9 +208,9 @@ describe("ActivityCollector::createClickedElementProperties", () => {
         options.data.__adobe &&
         options.data.__adobe.analytics
       ) {
-        const { c } = options.data.__adobe.analytics;
-        if (c && c.a && c.a.activitymap) {
-          const activitymap = c.a.activitymap;
+        const { contextData } = options.data.__adobe.analytics;
+        if (contextData && contextData.a && contextData.a.activitymap) {
+          const activitymap = contextData.a.activitymap;
           activitymap.page = "filtered"; // Page name
           activitymap.link = "filtered"; // Link name
           activitymap.region = "filtered"; // Link region

--- a/test/unit/specs/components/ActivityCollector/createGetClickedElementProperties.spec.js
+++ b/test/unit/specs/components/ActivityCollector/createGetClickedElementProperties.spec.js
@@ -106,7 +106,7 @@ describe("ActivityCollector::createGetClickedElementProperties", () => {
       data: {
         __adobe: {
           analytics: {
-            c: {
+            contextData: {
               a: {
                 activitymap: {
                   page: "https://example.com/",
@@ -226,7 +226,7 @@ describe("ActivityCollector::createGetClickedElementProperties", () => {
       data: {
         __adobe: {
           analytics: {
-            c: {
+            contextData: {
               a: {
                 activitymap: {
                   page: "https://example.com/",

--- a/test/unit/specs/components/ActivityCollector/createInjectClickedElementProperties.spec.js
+++ b/test/unit/specs/components/ActivityCollector/createInjectClickedElementProperties.spec.js
@@ -126,55 +126,16 @@ describe("ActivityCollector::createInjectClickedElementProperties", () => {
         clickActivityStorage,
       },
     );
-    const event = jasmine.createSpyObj("event", ["mergeXdm", "setUserData"]);
+    const event = jasmine.createSpyObj("event", ["mergeXdm", "mergeData"]);
     injectClickedElementProperties({ clickedElement: {}, event });
     // No click data should be saved to storage, only the page data.
     expect(clickActivityStorage.save).toHaveBeenCalledWith({
       pageName: "testPage",
       pageIDType: 1,
     });
-    // If mergeXdm and setUserData are called, it means that the click data was not saved and
+    // If mergeXdm and mergeData are called, it means that the click data was not saved and
     // will instead go out with the event.
     expect(event.mergeXdm).toHaveBeenCalled();
-    expect(event.setUserData).toHaveBeenCalled();
-  });
-
-  it("Does not save click data to storage if onBeforeLinkClickSend is defined", () => {
-    const config = {
-      clickCollectionEnabled: true,
-      clickCollection: {
-        internalLinkEnabled: true,
-        eventGroupingEnabled: true,
-      },
-      onBeforeLinkClickSend: () => {},
-    };
-    const logger = jasmine.createSpyObj("logger", ["info"]);
-    getClickedElementProperties.and.returnValue({
-      isValidLink: () => true,
-      isInternalLink: () => true,
-      pageName: "testPage",
-      pageIDType: 1,
-      linkName: "testLink",
-      linkType: "other",
-    });
-    const injectClickedElementProperties = createInjectClickedElementProperties(
-      {
-        config,
-        logger,
-        getClickedElementProperties,
-        clickActivityStorage,
-      },
-    );
-    const event = jasmine.createSpyObj("event", ["mergeXdm", "setUserData"]);
-    injectClickedElementProperties({ clickedElement: {}, event });
-    // No click data should be saved to storage, only the page data.
-    expect(clickActivityStorage.save).toHaveBeenCalledWith({
-      pageName: "testPage",
-      pageIDType: 1,
-    });
-    // If mergeXdm and setUserData are called, it means that the click data was not saved and
-    // will instead go out with the event.
-    expect(event.mergeXdm).toHaveBeenCalled();
-    expect(event.setUserData).toHaveBeenCalled();
+    expect(event.mergeData).toHaveBeenCalled();
   });
 });

--- a/test/unit/specs/components/ActivityCollector/createRecallAndInjectClickedElementProperties.spec.js
+++ b/test/unit/specs/components/ActivityCollector/createRecallAndInjectClickedElementProperties.spec.js
@@ -63,7 +63,7 @@ describe("ActivityCollector::createRecallAndInjectClickedElementProperties", () 
     expect(event.mergeData).toHaveBeenCalledWith({
       __adobe: {
         analytics: {
-          c: {
+          contextData: {
             a: {
               activitymap: {
                 page: "examplePage",

--- a/test/unit/specs/components/ActivityCollector/createRecallAndInjectClickedElementProperties.spec.js
+++ b/test/unit/specs/components/ActivityCollector/createRecallAndInjectClickedElementProperties.spec.js
@@ -25,7 +25,7 @@ describe("ActivityCollector::createRecallAndInjectClickedElementProperties", () 
     };
     event = {
       mergeXdm: jasmine.createSpy(),
-      setUserData: jasmine.createSpy(),
+      mergeData: jasmine.createSpy(),
     };
   });
 
@@ -60,7 +60,7 @@ describe("ActivityCollector::createRecallAndInjectClickedElementProperties", () 
         },
       },
     });
-    expect(event.setUserData).toHaveBeenCalledWith({
+    expect(event.mergeData).toHaveBeenCalledWith({
       __adobe: {
         analytics: {
           c: {


### PR DESCRIPTION

## Description

The ActivityMap contained in the `DATA` envelope is now using the long name `contextData` instead of `c`. In addition the data added to the `DATA` envelope is now merged with any existing user provided data to avoid it getting overwritten.

## Related Issue

## Motivation and Context

Minor enhancements from PR feedback.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
