### PR TITLE
Remove force-resolutions dependency and preinstall script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@adobe/alloy",
       "version": "2.22.0-beta.0",
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/aep-rules-engine": "^2.0.2",
@@ -54,7 +53,6 @@
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-testcafe": "^0.2.1",
-        "force-resolutions": "^1.0.11",
         "glob": "^11.0.0",
         "globals": "^15.9.0",
         "handlebars": "^4.7.8",
@@ -9973,16 +9971,6 @@
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.3"
-      }
-    },
-    "node_modules/force-resolutions": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/force-resolutions/-/force-resolutions-1.0.11.tgz",
-      "integrity": "sha512-8LNaQfr6m1aozCth6s1gZ/7Nx4FNp3sF6q+J0G6ksvDTMkkfdCTyaZ4Le1AhvB7Uri8eOqWnsIrgurdx9YYhSA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "force-resolutions": "dist/index.js"
       }
     },
     "node_modules/foreground-child": {

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "prepare": "husky && cd sandbox && npm install",
     "prepack": "rimraf libEs5 libEs6 && babel src -d libEs5 --env-name npmEs5 && babel src -d libEs6 --env-name npmEs6",
     "checkthattestfilesexist": "./scripts/checkThatTestFilesExist.js",
-    "add-license": "./scripts/add-license.js",
-    "preinstall": "npx force-resolutions"
+    "add-license": "./scripts/add-license.js"
   },
   "lint-staged": {
     "./*.{cjs,mjs,js,jsx}": [
@@ -113,7 +112,6 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-testcafe": "^0.2.1",
-    "force-resolutions": "^1.0.11",
     "glob": "^11.0.0",
     "globals": "^15.9.0",
     "handlebars": "^4.7.8",


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

Alloy has a `preinstall` script that runs before any project (including the alloy sandbox and the alloy Tags extension) installs alloy's dependencies when it includes alloy as a dependency. The preinstall script runs `force-resolutions` which ["This package modifies package-lock.json to force the installation of specified versions of a set of transitive dependencies (dependencies of dependencies)."](https://www.npmjs.com/package/force-resolutions). It was [added back in January as an attempt to fix Saucelab errors around Firefox install.](https://github.com/adobe/alloy/commit/d53bb93fdce6ac33dc4331eb029ad55c941838ae) 

But, for some reason, that package crashes on some machines. I've run it in three environments (Mac, Windows, Ubuntu) and it breaks on Mac.

The error 

```
npm error code 254
npm error path /Users/cmcbride/homebase/code/github.com/adobe/reactor-extension-alloy/node_modules/@adobe/alloy
npm error command failed
npm error command sh -c npx force-resolutions
npm error npm error code ENOENT
npm error npm error syscall lstat
npm error npm error path /private/var/folders/ls/b81s61dd4sj936v7c5gmf_yw0000gq/T/tmp.3Bdu0jwtwy
npm error npm error errno -2
npm error npm error enoent ENOENT: no such file or directory, lstat '/private/var/folders/ls/b81s61dd4sj936v7c5gmf_yw0000gq/T/tmp.3Bdu0jwtwy'
npm error npm error enoent This is related to npm not being able to find a file.
npm error npm error enoent
npm error
npm error npm error A complete log of this run can be found in: /Users/cmcbride/.npm/_logs/2024-08-20T16_38_43_202Z-debug-0.log

npm error A complete log of this run can be found in: /Users/cmcbride/.npm/_logs/2024-08-20T16_38_26_972Z-debug-0.log
```

This prevents the dependency installation from completing (unless you run `npm install --ignore-scripts`.

@shammowla says that it isn't necessary since we have changed the version of the Saucelabs util that we are running, so let's remove it.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
