### PR TITLE
Fixed an issue where cookies were not included when running on localhost

### DIFF
--- a/src/core/createCookieTransfer.js
+++ b/src/core/createCookieTransfer.js
@@ -24,8 +24,10 @@ export default ({
      * the request body so they can be read by the server.
      */
     cookiesToPayload(payload, endpointDomain) {
-      const isEndpointFirstParty = endpointDomain.endsWith(apexDomain);
-
+      // localhost is a special case where the apexDomain is ""
+      // We want to treat localhost as a third-party domain.
+      const isEndpointFirstParty =
+        apexDomain !== "" && endpointDomain.endsWith(apexDomain);
       const state = {
         domain: apexDomain,
         cookiesEnabled: true,


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

The change to drop IE support made a slight change in functionality. It caused localhost to be treated as using a first party collection domain.

- On localhost the apexDomain is set to ""
- Before dropping IE the test for first party domain was `endsWith(endpointDomain, apexDomain)`. This returns false for `endsWith("edge.adobedc.net", "")`
- After dropping IE, the test for first party domain was `endpointDomain.endsWith(apexDomain)`. This returns true for `"edge.adobedc.net".endsWith("")`

This change adds a check for an empty apexDomain.

<!--- Describe your changes in detail -->

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-12457
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
