### PR TITLE
Added support for requesting the CORE id in the getIdentity command

### DIFF
--- a/src/components/Identity/createComponent.js
+++ b/src/components/Identity/createComponent.js
@@ -9,8 +9,8 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import getIdentityOptionsValidator from "./getIdentity/getIdentityOptionsValidator.js";
 import appendIdentityToUrlOptionsValidator from "./appendIdentityToUrl/appendIdentityToUrlOptionsValidator.js";
+import ecidNamespace from "../../constants/ecidNamespace.js";
 
 export default ({
   addEcidQueryToPayload,
@@ -18,13 +18,14 @@ export default ({
   ensureSingleIdentity,
   setLegacyEcid,
   handleResponseForIdSyncs,
-  getEcidFromResponse,
+  getNamespacesFromResponse,
   getIdentity,
   consent,
   appendIdentityToUrl,
   logger,
+  getIdentityOptionsValidator,
 }) => {
-  let ecid;
+  let namespaces;
   let edge = {};
   return {
     lifecycle: {
@@ -36,15 +37,17 @@ export default ({
         return ensureSingleIdentity({ request, onResponse, onRequestFailure });
       },
       onResponse({ response }) {
-        if (!ecid) {
-          ecid = getEcidFromResponse(response);
-
+        const newNamespaces = getNamespacesFromResponse(response);
+        if (
+          (!namespaces || !namespaces[ecidNamespace]) &&
+          newNamespaces &&
+          newNamespaces[ecidNamespace]
+        ) {
           // Only data collection calls will have an ECID in the response.
           // https://jira.corp.adobe.com/browse/EXEG-1234
-          if (ecid) {
-            setLegacyEcid(ecid);
-          }
+          setLegacyEcid(newNamespaces[ecidNamespace]);
         }
+        namespaces = newNamespaces;
         // For sendBeacon requests, getEdge() will return {}, so we are using assign here
         // so that sendBeacon requests don't override the edge info from before.
         edge = { ...edge, ...response.getEdge() };
@@ -56,16 +59,18 @@ export default ({
       getIdentity: {
         optionsValidator: getIdentityOptionsValidator,
         run: (options) => {
+          const { namespaces: requestedNamespaces } = options;
           return consent
             .awaitConsent()
             .then(() => {
-              return ecid ? undefined : getIdentity(options);
+              return namespaces ? undefined : getIdentity(options);
             })
             .then(() => {
               return {
-                identity: {
-                  ECID: ecid,
-                },
+                identity: requestedNamespaces.reduce((acc, namespace) => {
+                  acc[namespace] = namespaces[namespace] || null;
+                  return acc;
+                }, {}),
                 edge,
               };
             });
@@ -77,10 +82,15 @@ export default ({
           return consent
             .withConsent()
             .then(() => {
-              return ecid ? undefined : getIdentity(options);
+              return namespaces ? undefined : getIdentity(options);
             })
             .then(() => {
-              return { url: appendIdentityToUrl(ecid, options.url) };
+              return {
+                url: appendIdentityToUrl(
+                  namespaces[ecidNamespace],
+                  options.url,
+                ),
+              };
             })
             .catch((error) => {
               logger.warn(`Unable to append identity to url. ${error.message}`);

--- a/src/components/Identity/getNamespacesFromResponse.js
+++ b/src/components/Identity/getNamespacesFromResponse.js
@@ -9,13 +9,12 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-
-import ecidNamespace from "../../constants/ecidNamespace.js";
-
-export default (payload) => {
-  payload.mergeQuery({
-    identity: {
-      fetch: [ecidNamespace],
-    },
-  });
+export default (response) => {
+  const identityResultPayloads = response.getPayloadsByType("identity:result");
+  return identityResultPayloads.reduce((acc, payload) => {
+    if (payload.namespace && payload.namespace.code) {
+      acc[payload.namespace.code] = payload.id;
+    }
+    return acc;
+  }, {});
 };

--- a/src/components/Identity/index.js
+++ b/src/components/Identity/index.js
@@ -25,17 +25,18 @@ import awaitVisitorOptIn from "./visitorService/awaitVisitorOptIn.js";
 import injectGetEcidFromVisitor from "./visitorService/injectGetEcidFromVisitor.js";
 import injectHandleResponseForIdSyncs from "./injectHandleResponseForIdSyncs.js";
 import injectEnsureSingleIdentity from "./injectEnsureSingleIdentity.js";
-import addEcidQueryToPayload from "./addEcidQueryToPayload.js";
+import injectAddEcidQueryToPayload from "./injectAddEcidQueryToPayload.js";
 import injectSetDomainForInitialIdentityPayload from "./injectSetDomainForInitialIdentityPayload.js";
 import injectAddLegacyEcidToPayload from "./injectAddLegacyEcidToPayload.js";
 import injectAddQueryStringIdentityToPayload from "./injectAddQueryStringIdentityToPayload.js";
 import addEcidToPayload from "./addEcidToPayload.js";
 import injectAwaitIdentityCookie from "./injectAwaitIdentityCookie.js";
-import getEcidFromResponse from "./getEcidFromResponse.js";
+import getNamespacesFromResponse from "./getNamespacesFromResponse.js";
 import createGetIdentity from "./getIdentity/createGetIdentity.js";
 import createIdentityRequest from "./getIdentity/createIdentityRequest.js";
 import createIdentityRequestPayload from "./getIdentity/createIdentityRequestPayload.js";
 import injectAppendIdentityToUrl from "./appendIdentityToUrl/injectAppendIdentityToUrl.js";
+import createGetIdentityOptionsValidator from "./getIdentity/createGetIdentityOptionsValidator.js";
 
 const createIdentity = ({
   config,
@@ -115,18 +116,26 @@ const createIdentity = ({
     orgId,
     globalConfigOverrides,
   });
+  const getIdentityOptionsValidator = createGetIdentityOptionsValidator({
+    thirdPartyCookiesEnabled,
+  });
+  const addEcidQueryToPayload = injectAddEcidQueryToPayload({
+    thirdPartyCookiesEnabled,
+    areThirdPartyCookiesSupportedByDefault,
+  });
   return createComponent({
     addEcidQueryToPayload,
     addQueryStringIdentityToPayload,
     ensureSingleIdentity,
     setLegacyEcid: legacyIdentity.setEcid,
     handleResponseForIdSyncs,
-    getEcidFromResponse,
+    getNamespacesFromResponse,
     getIdentity,
     consent,
     appendIdentityToUrl,
     logger,
     config,
+    getIdentityOptionsValidator,
   });
 };
 

--- a/src/components/Identity/injectAddEcidQueryToPayload.js
+++ b/src/components/Identity/injectAddEcidQueryToPayload.js
@@ -10,16 +10,22 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import addEcidQueryToPayload from "../../../../../src/components/Identity/addEcidQueryToPayload.js";
+import ecidNamespace from "../../constants/ecidNamespace.js";
+import coreNamespace from "../../constants/coreNamespace.js";
 
-describe("Identity::addEcidQueryToPayload", () => {
-  it("adds an ECID query to the event", () => {
-    const payload = jasmine.createSpyObj("payload", ["mergeQuery"]);
-    addEcidQueryToPayload(payload);
-    expect(payload.mergeQuery).toHaveBeenCalledWith({
-      identity: {
-        fetch: ["ECID"],
-      },
-    });
-  });
-});
+export default ({
+  thirdPartyCookiesEnabled,
+  areThirdPartyCookiesSupportedByDefault,
+}) => {
+  const query = {
+    identity: {
+      fetch: [ecidNamespace],
+    },
+  };
+  if (thirdPartyCookiesEnabled && areThirdPartyCookiesSupportedByDefault()) {
+    query.identity.fetch.push(coreNamespace);
+  }
+  return (payload) => {
+    payload.mergeQuery(query);
+  };
+};

--- a/src/constants/coreNamespace.js
+++ b/src/constants/coreNamespace.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
+Copyright 2024 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -9,12 +9,5 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import ecidNamespace from "../../constants/ecidNamespace.js";
 
-export default (response) => {
-  const identityResultPayloads = response.getPayloadsByType("identity:result");
-  const ecidPayload = identityResultPayloads.find(
-    (payload) => payload.namespace && payload.namespace.code === ecidNamespace,
-  );
-  return ecidPayload ? ecidPayload.id : undefined;
-};
+export default "CORE";

--- a/src/utils/validation/createUniqueItemsValidator.js
+++ b/src/utils/validation/createUniqueItemsValidator.js
@@ -15,5 +15,6 @@ import isUnique from "../isUnique.js";
 export default () => {
   return (value, path) => {
     assertValid(isUnique(value), value, path, "array values to be unique");
+    return value;
   };
 };

--- a/src/utils/validation/index.js
+++ b/src/utils/validation/index.js
@@ -245,7 +245,7 @@ const boundString = string.bind(base);
 const boundEnumOf = function boundEnumOf(...values) {
   return boundAnyOf(
     values.map(boundLiteral),
-    `one of these values: [${JSON.stringify(values)}]`,
+    `one of these values: ${JSON.stringify(values)}`,
   );
 };
 

--- a/test/functional/specs/Identity/C19160486.js
+++ b/test/functional/specs/Identity/C19160486.js
@@ -1,0 +1,153 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { t } from "testcafe";
+import createFixture from "../../helpers/createFixture/index.js";
+import {
+  compose,
+  orgMainConfigMain,
+  debugEnabled,
+  thirdPartyCookiesEnabled,
+  thirdPartyCookiesDisabled,
+} from "../../helpers/constants/configParts/index.js";
+import createAlloyProxy from "../../helpers/createAlloyProxy.js";
+import createNetworkLogger from "../../helpers/networkLogger/index.js";
+import areThirdPartyCookiesSupported from "../../helpers/areThirdPartyCookiesSupported.js";
+import { SECONDARY_TEST_PAGE } from "../../helpers/constants/url.js";
+
+const thirdPartyCookiesEnabledConfig = compose(
+  orgMainConfigMain,
+  debugEnabled,
+  thirdPartyCookiesEnabled,
+);
+const thirdPartyCookiesDisabledConfig = compose(
+  orgMainConfigMain,
+  debugEnabled,
+  thirdPartyCookiesDisabled,
+);
+
+const networkLogger = createNetworkLogger();
+
+createFixture({
+  title: "C19160486: The CORE identity is returned correctly from getIdentity",
+  requestHooks: [
+    networkLogger.edgeEndpointLogs,
+    networkLogger.acquireEndpointLogs,
+  ],
+});
+
+test.meta({
+  ID: "C19160486",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression",
+});
+
+test("C19160486: CORE identity is the same across domains when called first", async () => {
+  const alloy = createAlloyProxy();
+  await alloy.configure(thirdPartyCookiesEnabledConfig);
+  const {
+    identity: { ECID: ecid1, CORE: core1 },
+  } = await alloy.getIdentity({ namespaces: ["ECID", "CORE"] });
+  await t.navigateTo(SECONDARY_TEST_PAGE);
+
+  await alloy.configure(thirdPartyCookiesEnabledConfig);
+  const {
+    identity: { ECID: ecid2, CORE: core2 },
+  } = await alloy.getIdentity({ namespaces: ["ECID", "CORE"] });
+
+  if (areThirdPartyCookiesSupported()) {
+    // ecids are the same because the same orgId is used to go from CORE -> ECID
+    await t.expect(ecid1).eql(ecid2);
+    await t.expect(core1).eql(core2);
+    await t.expect(ecid1).notEql(core1);
+  } else {
+    // ecids are different because third party cookies are not written
+    await t.expect(ecid1).notEql(ecid2);
+    // CORE identity is null because Experience Edge only creates it when called on demdex domain
+    // which only happens on Chrome browsers.
+    await t.expect(core1).eql(null);
+    await t.expect(core2).eql(null);
+  }
+});
+
+test("C19160486: CORE identity is the same across domains when called after sendEvent", async () => {
+  const alloy = createAlloyProxy();
+  await alloy.configure(thirdPartyCookiesEnabledConfig);
+  await alloy.sendEvent();
+  const {
+    identity: { ECID: ecid1, CORE: core1 },
+  } = await alloy.getIdentity({ namespaces: ["ECID", "CORE"] });
+  await t.expect(networkLogger.acquireEndpointLogs.requests.length).eql(0);
+  await t.navigateTo(SECONDARY_TEST_PAGE);
+
+  await alloy.configure(thirdPartyCookiesEnabledConfig);
+  await alloy.sendEvent();
+  const {
+    identity: { ECID: ecid2, CORE: core2 },
+  } = await alloy.getIdentity({ namespaces: ["ECID", "CORE"] });
+  await t.expect(networkLogger.acquireEndpointLogs.requests.length).eql(0);
+
+  if (areThirdPartyCookiesSupported()) {
+    // ecids are the same because the same orgId is used to go from CORE -> ECID
+    await t.expect(ecid1).eql(ecid2);
+    await t.expect(core1).eql(core2);
+    await t.expect(ecid1).notEql(core1);
+  } else {
+    // ecids are different because third party cookies are not written
+    await t.expect(ecid1).notEql(ecid2);
+    // CORE identity is null because Experience Edge only creates it when called on demdex domain
+    // which only happens on Chrome browsers.
+    await t.expect(core1).eql(null);
+    await t.expect(core2).eql(null);
+  }
+});
+
+test("C19160486: CORE identity is not requested when third party cookies are disabled", async () => {
+  const alloy = createAlloyProxy();
+  await alloy.configure(thirdPartyCookiesDisabledConfig);
+  await alloy.sendEvent();
+  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
+  await t.expect(networkLogger.edgeEndpointLogs.count(() => true)).eql(1);
+  const requestBody = JSON.parse(
+    networkLogger.edgeEndpointLogs.requests[0].request.body,
+  );
+  await t.expect(requestBody.query.identity.fetch).eql(["ECID"]);
+});
+
+test("C19160486: CORE identity cannot be requested from getIdentity when third party cookies are disabled", async () => {
+  const alloy = createAlloyProxy();
+  await alloy.configure(thirdPartyCookiesDisabledConfig);
+  const errorMessage = await alloy.getIdentityErrorMessage({
+    namespaces: ["CORE"],
+  });
+  await t
+    .expect(errorMessage)
+    .contains(
+      "The CORE namespace cannot be requested when third-party cookies are disabled",
+    );
+});
+
+test("C19160486: Requesting CORE identity and ECID can be done separately", async () => {
+  const alloy = createAlloyProxy();
+  await alloy.configure(thirdPartyCookiesEnabledConfig);
+  const {
+    identity: { ECID: ecid },
+  } = await alloy.getIdentity({ namespaces: ["ECID"] });
+  await t.expect(ecid).ok();
+  const {
+    identity: { CORE: core },
+  } = await alloy.getIdentity({ namespaces: ["CORE"] });
+  if (areThirdPartyCookiesSupported()) {
+    await t.expect(core).ok();
+  } else {
+    await t.expect(core).eql(null);
+  }
+});

--- a/test/functional/specs/Privacy/C14410.js
+++ b/test/functional/specs/Privacy/C14410.js
@@ -43,7 +43,7 @@ test("Test C14410: Configuring default consent to 'unknown' fails", async (t) =>
   await t
     .expect(errorMessage)
     .contains(
-      `Expected one of these values: [["in","out","pending"]], but got "unknown"`,
+      `Expected one of these values: ["in","out","pending"], but got "unknown"`,
     );
 });
 

--- a/test/functional/specs/Privacy/IAB/C224670.js
+++ b/test/functional/specs/Privacy/IAB/C224670.js
@@ -67,7 +67,6 @@ test("Test C224670: Opt in to IAB", async () => {
   // 2. The ECID should exist in the response payload as well, if queried
   const identityHandle = consentResponse.getPayloadsByType("identity:result");
   const returnedNamespaces = identityHandle.map((i) => i.namespace.code);
-  await t.expect(identityHandle.length).eql(1);
   await t.expect(returnedNamespaces).contains("ECID");
 
   await alloy.sendEvent();

--- a/test/functional/specs/Privacy/IAB/C224671.js
+++ b/test/functional/specs/Privacy/IAB/C224671.js
@@ -70,7 +70,8 @@ test.meta({
 
     // 2. The ECID should exist in the response payload as well, if queried
     const identityHandle = consentResponse.getPayloadsByType("identity:result");
-    await t.expect(identityHandle.length).eql(1);
+    const returnedNamespaces = identityHandle.map((i) => i.namespace.code);
+    await t.expect(returnedNamespaces).contains("ECID");
 
     await alloy.sendEvent();
     await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(0);

--- a/test/functional/specs/Privacy/IAB/C224672.js
+++ b/test/functional/specs/Privacy/IAB/C224672.js
@@ -68,7 +68,6 @@ test("Test C224672: Passing the `gdprContainsPersonalData` flag should return in
   // 2. The ECID should exist in the response payload as well, if queried
   const identityHandle = consentResponse.getPayloadsByType("identity:result");
   const returnedNamespaces = identityHandle.map((i) => i.namespace.code);
-  await t.expect(identityHandle.length).eql(1);
   await t.expect(returnedNamespaces).contains("ECID");
 
   await alloy.sendEvent();

--- a/test/functional/specs/Privacy/IAB/C224673.js
+++ b/test/functional/specs/Privacy/IAB/C224673.js
@@ -67,7 +67,6 @@ test("Test C224673: Opt in to IAB while gdprApplies is FALSE", async () => {
   // 2. The ECID should exist in the response payload as well, if queried
   const identityHandle = consentResponse.getPayloadsByType("identity:result");
   const returnedNamespaces = identityHandle.map((i) => i.namespace.code);
-  await t.expect(identityHandle.length).eql(1);
   await t.expect(returnedNamespaces).contains("ECID");
 
   await alloy.sendEvent();

--- a/test/functional/specs/Privacy/IAB/C224674.js
+++ b/test/functional/specs/Privacy/IAB/C224674.js
@@ -67,7 +67,6 @@ test("Test C224674: Opt out to IAB while gdprApplies is FALSE", async () => {
   // 2. The ECID should exist in the response payload as well, if queried
   const identityHandle = consentResponse.getPayloadsByType("identity:result");
   const returnedNamespaces = identityHandle.map((i) => i.namespace.code);
-  await t.expect(identityHandle.length).eql(1);
   await t.expect(returnedNamespaces).contains("ECID");
 
   await alloy.sendEvent();

--- a/test/functional/specs/Privacy/IAB/C224676.js
+++ b/test/functional/specs/Privacy/IAB/C224676.js
@@ -74,10 +74,9 @@ test("Test C224676: Passing a positive Consent in the sendEvent command", async 
   await t.expect(consentCookieValue).eql("general=in");
 
   // 2. The ECID should exist in the response payload as well, if queried
-  // TODO: We are seeing 2 `identity:result` handles. Bug logged on Konductor side:
-  // https://jira.corp.adobe.com/browse/EXEG-1960
   const identityHandle = response.getPayloadsByType("identity:result");
-  await t.expect(identityHandle.length).eql(1);
+  const returnedNamespaces = identityHandle.map((i) => i.namespace.code);
+  await t.expect(returnedNamespaces).contains("ECID");
 
   await alloy.sendEvent();
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(2);

--- a/test/functional/specs/Privacy/IAB/C224677.js
+++ b/test/functional/specs/Privacy/IAB/C224677.js
@@ -64,7 +64,6 @@ test("Test C224677: Call setConsent when purpose 10 is FALSE", async () => {
   // 2. The ECID should exist in the response payload as well, if queried
   const identityHandle = response.getPayloadsByType("identity:result");
   const returnedNamespaces = identityHandle.map((i) => i.namespace.code);
-  await t.expect(identityHandle.length).eql(1);
   await t.expect(returnedNamespaces).contains("ECID");
 
   // 3. Event calls going forward should remain opted in, even though AAM opts out consents with no purpose 10.

--- a/test/functional/specs/Privacy/IAB/C224678.js
+++ b/test/functional/specs/Privacy/IAB/C224678.js
@@ -76,7 +76,8 @@ test("Test C224678: Passing a negative Consent in the sendEvent command", async 
 
   // 2. The ECID should exist in the response payload as well, even if queried
   const identityHandle = response.getPayloadsByType("identity:result");
-  await t.expect(identityHandle.length).eql(1);
+  const returnedNamespaces = identityHandle.map((i) => i.namespace.code);
+  await t.expect(returnedNamespaces).contains("ECID");
 
   // 3. Should not have any activation, ID Syncs or decisions in the response.
   const handlesThatShouldBeMissing = [

--- a/test/unit/specs/components/Identity/getNamespacesFromResponse.spec.js
+++ b/test/unit/specs/components/Identity/getNamespacesFromResponse.spec.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import getEcidFromResponse from "../../../../../src/components/Identity/getEcidFromResponse.js";
+import getNamespacesFromResponse from "../../../../../src/components/Identity/getNamespacesFromResponse.js";
 
 describe("Identity::getEcidFromResponse", () => {
   it("does not return ECID if ECID does not exist in response", () => {
@@ -25,7 +25,7 @@ describe("Identity::getEcidFromResponse", () => {
       ],
     });
 
-    expect(getEcidFromResponse(response)).toBeUndefined();
+    expect(getNamespacesFromResponse(response)).toEqual({ other: "user123" });
     expect(response.getPayloadsByType).toHaveBeenCalledWith("identity:result");
   });
 
@@ -47,7 +47,10 @@ describe("Identity::getEcidFromResponse", () => {
       ],
     });
 
-    expect(getEcidFromResponse(response)).toBe("user@adobe");
+    expect(getNamespacesFromResponse(response)).toEqual({
+      other: "user123",
+      ECID: "user@adobe",
+    });
     expect(response.getPayloadsByType).toHaveBeenCalledWith("identity:result");
   });
 });

--- a/test/unit/specs/components/Identity/injectAddEcidQueryToPayload.spec.js
+++ b/test/unit/specs/components/Identity/injectAddEcidQueryToPayload.spec.js
@@ -1,0 +1,55 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import injectAddEcidQueryToPayload from "../../../../../src/components/Identity/injectAddEcidQueryToPayload.js";
+
+describe("Identity::addEcidQueryToPayload", () => {
+  it("adds an ECID & CORE query to the event when third party cookies are enabled on Chrome", () => {
+    const addEcidQueryToPayload = injectAddEcidQueryToPayload({
+      thirdPartyCookiesEnabled: true,
+      areThirdPartyCookiesSupportedByDefault: () => true,
+    });
+    const payload = jasmine.createSpyObj("payload", ["mergeQuery"]);
+    addEcidQueryToPayload(payload);
+    expect(payload.mergeQuery).toHaveBeenCalledWith({
+      identity: {
+        fetch: ["ECID", "CORE"],
+      },
+    });
+  });
+  it("adds only ECID query to the event when third party cookies are enabled on Safari", () => {
+    const addEcidQueryToPayload = injectAddEcidQueryToPayload({
+      thirdPartyCookiesEnabled: true,
+      areThirdPartyCookiesSupportedByDefault: () => false,
+    });
+    const payload = jasmine.createSpyObj("payload", ["mergeQuery"]);
+    addEcidQueryToPayload(payload);
+    expect(payload.mergeQuery).toHaveBeenCalledWith({
+      identity: {
+        fetch: ["ECID"],
+      },
+    });
+  });
+  it("adds an ECID query to the event when third party cookies are disabled on Chrome", () => {
+    const addEcidQueryToPayload = injectAddEcidQueryToPayload({
+      thirdPartyCookiesEnabled: false,
+      areThirdPartyCookiesSupportedByDefault: () => true,
+    });
+    const payload = jasmine.createSpyObj("payload", ["mergeQuery"]);
+    addEcidQueryToPayload(payload);
+    expect(payload.mergeQuery).toHaveBeenCalledWith({
+      identity: {
+        fetch: ["ECID"],
+      },
+    });
+  });
+});

--- a/test/unit/specs/utils/validation/createUniqueItemsValidator.spec.js
+++ b/test/unit/specs/utils/validation/createUniqueItemsValidator.spec.js
@@ -18,12 +18,12 @@ import {
 describe("validation::createUniqueItems", () => {
   it(`validates an empty array`, () => {
     const validator = arrayOf(string()).uniqueItems();
-    validator([]);
+    expect(validator([])).toEqual([]);
   });
 
   it(`validates an array of one item`, () => {
     const validator = arrayOf(string()).uniqueItems();
-    validator(["a"]);
+    expect(validator(["a"])).toEqual(["a"]);
   });
 
   it(`throws an error on an array with duplicate (string) items`, () => {
@@ -38,16 +38,16 @@ describe("validation::createUniqueItems", () => {
 
   it(`validates an array of enums`, () => {
     const validator = arrayOf(number()).uniqueItems();
-    validator([]);
+    expect(validator([])).toEqual([]);
   });
 
   it(`validates an array of null or undefined`, () => {
     const validator = arrayOf(string()).uniqueItems();
-    validator([null, undefined]);
+    expect(validator([null, undefined])).toEqual([null, undefined]);
   });
 
   it(`complains about required when null or undefined`, () => {
-    const validator = arrayOf(string()).uniqueItems().required();
+    const validator = arrayOf(string().required()).uniqueItems();
     expect(() => validator([null, undefined])).toThrowError();
   });
 });


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

* Adds the ability to request "CORE" as a namespace in the getIdentity command
* This namespace is only available when thirdPartyCookies are enabled. If third party cookies are not enabled, calling getIdentity with CORE as a namespace throws an error.
* When third party cookies are enabled, all requests in Chrome include the query for "ECID" and "CORE". Otherwise requests only include the query for "ECID".
* The default namespaces for the getIdentity command is still ["ECID"]

<!--- Describe your changes in detail -->

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-12492
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## TEST page

```
<!DOCTYPE html>
<head>
  <script>
  !function(n,o){o.forEach(function(o){n[o]||((n.__alloyNS=n.__alloyNS||
  []).push(o),n[o]=function(){var u=arguments;return new Promise(
  function(i,l){n.setTimeout(function(){n[o].q.push([i,l,u])})})},n[o].q=[])})}
  (window,["alloy"]);
</script>
  <!--<script src="https://cdn1.adoberesources.net/alloy/2.21.1/alloy.min.js" async></script>-->
  <script src="/alloy.js" async></script>
  <script>
    alloy("configure", {
	"datastreamId": "bc1a10e0-aee4-4e0e-ac5b-cdbb9abbec83",
	"orgId": "5BFE274A5F6980A50A495C08@AdobeOrg",
	"edgeBasePath": "ee-pre-prd"
    });
  </script>
</head>
<html>
<body>

  <h1>Test Page for Core ID Library</h1>

  <button id="sendEvent">Send Event</button>
  <button id="sendBeacon">Send Beacon</button>
  <button id="getIdentityE">Get Identity (ECID)</button>
  <button id="getIdentityC">Get Identity (CORE)</button>
  <button id="getIdentityEC">Get Identity (ECID & CORE)</button>
  
  <script>
    document.getElementById("sendEvent").addEventListener("click", () => {
	alloy("sendEvent", {});
    });
    document.getElementById("sendBeacon").addEventListener("click", () => {
	alloy("sendEvent", { documentUnloading: true });
    });
    document.getElementById("getIdentityE").addEventListener("click", () => {
	alloy("getIdentity", { namespaces: ["ECID"] }).then(console.log);
    });
    document.getElementById("getIdentityC").addEventListener("click", () => {
	alloy("getIdentity", { namespaces: ["CORE"] }).then(console.log);
    });
    document.getElementById("getIdentityEC").addEventListener("click", () => {
	alloy("getIdentity", { namespaces: ["ECID", "CORE"] }).then(console.log);
    });
    
  </script>
</body>
</html>
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
