### PR TITLE
Update the privacy component so it can be excluded from a custom build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -89,6 +89,7 @@ const bundleSizePlugin = (_options = {}) => {
             })),
         );
         if (options.reportToConsole) {
+          // eslint-disable-next-line no-console
           console.table(sizes);
         }
         // check if the output file exists, create it if it does not exist

--- a/src/components/Privacy/configValidators.js
+++ b/src/components/Privacy/configValidators.js
@@ -1,0 +1,17 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { IN, OUT, PENDING } from "../../constants/consentStatus.js";
+import { objectOf, enumOf } from "../../utils/validation/index.js";
+
+export default objectOf({
+  defaultConsent: enumOf(IN, OUT, PENDING).default(IN),
+});

--- a/src/components/Privacy/index.js
+++ b/src/components/Privacy/index.js
@@ -24,6 +24,7 @@ import createStoredConsent from "./createStoredConsent.js";
 import injectSendSetConsentRequest from "./injectSendSetConsentRequest.js";
 import parseConsentCookie from "./parseConsentCookie.js";
 import validateSetConsentOptions from "./validateSetConsentOptions.js";
+import configValidators from "./configValidators.js";
 
 const createPrivacy = ({
   config,
@@ -66,5 +67,5 @@ const createPrivacy = ({
 };
 
 createPrivacy.namespace = "Privacy";
-
+createPrivacy.configValidators = configValidators;
 export default createPrivacy;

--- a/src/core/config/createCoreConfigs.js
+++ b/src/core/config/createCoreConfigs.js
@@ -14,18 +14,15 @@ import {
   boolean,
   string,
   callback,
-  enumOf,
   objectOf,
 } from "../../utils/validation/index.js";
 import { noop, validateConfigOverride } from "../../utils/index.js";
 import { EDGE as EDGE_DOMAIN } from "../../constants/domain.js";
 import EDGE_BASE_PATH from "../../constants/edgeBasePath.js";
-import { IN, OUT, PENDING } from "../../constants/consentStatus.js";
 
 export default () =>
   objectOf({
     debugEnabled: boolean().default(false),
-    defaultConsent: enumOf(IN, OUT, PENDING).default(IN),
     datastreamId: string().unique().required(),
     edgeDomain: string().domain().default(EDGE_DOMAIN),
     edgeBasePath: string().nonEmpty().default(EDGE_BASE_PATH),

--- a/src/core/consent/createConsentStateMachine.js
+++ b/src/core/consent/createConsentStateMachine.js
@@ -41,8 +41,7 @@ export default ({ logger }) => {
     }
   };
 
-  const awaitInitial = () =>
-    Promise.reject(new Error("Consent has not been initialized."));
+  const awaitInitial = () => Promise.resolve();
   const awaitInDefault = () => Promise.resolve();
   const awaitIn = () => Promise.resolve();
   const awaitOutDefault = () =>

--- a/test/unit/specs/components/Privacy/configValidators.spec.js
+++ b/test/unit/specs/components/Privacy/configValidators.spec.js
@@ -1,0 +1,38 @@
+import configValidators from "../../../../../src/components/Privacy/configValidators.js";
+
+describe("defaultConsent", () => {
+  it("validates defaultConsent=undefined", () => {
+    const config = configValidators({});
+    expect(config.defaultConsent).toEqual("in");
+  });
+  it("validates defaultConsent={}", () => {
+    expect(() => {
+      configValidators({
+        defaultConsent: {},
+      });
+    }).toThrowError();
+  });
+  it("validates defaultConsent='in'", () => {
+    const config = configValidators({
+      defaultConsent: "in",
+    });
+    expect(config.defaultConsent).toEqual("in");
+  });
+  it("validates defaultConsent='pending'", () => {
+    const config = configValidators({
+      defaultConsent: "pending",
+    });
+    expect(config.defaultConsent).toEqual("pending");
+  });
+  it("validates defaultConsent=123", () => {
+    expect(() => {
+      configValidators({ defaultConsent: 123 });
+    }).toThrowError();
+  });
+  it("validates defaultConsent='out'", () => {
+    const config = configValidators({
+      defaultConsent: "out",
+    });
+    expect(config.defaultConsent).toEqual("out");
+  });
+});

--- a/test/unit/specs/core/config/createCoreConfigs.spec.js
+++ b/test/unit/specs/core/config/createCoreConfigs.spec.js
@@ -11,11 +11,6 @@ governing permissions and limitations under the License.
 */
 
 import createCoreConfigs from "../../../../../src/core/config/createCoreConfigs.js";
-import {
-  IN,
-  OUT,
-  PENDING,
-} from "../../../../../src/constants/consentStatus.js";
 
 describe("createCoreConfigs", () => {
   let validator;
@@ -50,47 +45,6 @@ describe("createCoreConfigs", () => {
       expect(() => {
         validator({ debugEnabled: 123, ...baseConfig });
       }).toThrowError();
-    });
-  });
-
-  describe("defaultConsent", () => {
-    it("validates defaultConsent=undefined", () => {
-      const config = validator(baseConfig);
-      expect(config.defaultConsent).toEqual(IN);
-    });
-    it("validates defaultConsent={}", () => {
-      expect(() => {
-        validator({
-          defaultConsent: {},
-          ...baseConfig,
-        });
-      }).toThrowError();
-    });
-    it("validates defaultConsent='in'", () => {
-      const config = validator({
-        defaultConsent: IN,
-        ...baseConfig,
-      });
-      expect(config.defaultConsent).toEqual(IN);
-    });
-    it("validates defaultConsent='pending'", () => {
-      const config = validator({
-        defaultConsent: PENDING,
-        ...baseConfig,
-      });
-      expect(config.defaultConsent).toEqual(PENDING);
-    });
-    it("validates defaultConsent=123", () => {
-      expect(() => {
-        validator({ defaultConsent: 123, ...baseConfig });
-      }).toThrowError();
-    });
-    it("validates defaultConsent='out'", () => {
-      const config = validator({
-        defaultConsent: OUT,
-        ...baseConfig,
-      });
-      expect(config.defaultConsent).toEqual(OUT);
     });
   });
 

--- a/test/unit/specs/core/consent/createConsentStateMachine.spec.js
+++ b/test/unit/specs/core/consent/createConsentStateMachine.spec.js
@@ -96,14 +96,14 @@ describe("createConsentStateMachine", () => {
       });
   });
 
-  it("rejects promises when it is not initialized", () => {
-    const onRejected = jasmine.createSpy("onRejected");
-    return subject
-      .awaitConsent()
-      .catch(onRejected)
-      .then(() => {
-        expect(onRejected).toHaveBeenCalled();
-      });
+  // This is what would happen when the privacy component is not included
+  it("resolves promises when it is not initialized", () => {
+    const onFulfilled = jasmine.createSpy("onFulfilled");
+    subject.awaitConsent().then(onFulfilled);
+
+    return flushPromiseChains().then(() => {
+      expect(onFulfilled).toHaveBeenCalled();
+    });
   });
 
   [


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

When excluding the privacy component and calling send event, it would fail with the error "Identity component has not been initialized". This changes it so that when privacy component is not included, consent defaults to in.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
