### PR TITLE
Web SDK Error in applyPropositions due to Default Content or Tracking Event

### DIFF
--- a/src/components/Personalization/createApplyPropositions.js
+++ b/src/components/Personalization/createApplyPropositions.js
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 
 import { defer, isEmptyObject, isNonEmptyArray } from "../../utils/index.js";
 import {
+  DEFAULT_CONTENT_ITEM,
   DOM_ACTION,
   HTML_CONTENT_ITEM,
   JSON_CONTENT_ITEM,
@@ -29,6 +30,7 @@ const SUPPORTED_SCHEMAS = {
   [HTML_CONTENT_ITEM]: () => true,
   [JSON_CONTENT_ITEM]: isInteractionTrackingItem,
   [MESSAGE_IN_APP]: () => true,
+  [DEFAULT_CONTENT_ITEM]: () => true,
 };
 
 const filterItemsPredicate = (schema, actionType) =>

--- a/src/components/Personalization/validateApplyPropositionsOptions.js
+++ b/src/components/Personalization/validateApplyPropositionsOptions.js
@@ -31,7 +31,7 @@ export default ({ logger, options }) => {
           objectOf({
             id: string().required(),
             schema: string().required(),
-            data: anything().required(),
+            data: objectOf(anything()),
           }),
         )
           .nonEmpty()

--- a/test/unit/specs/components/Personalization/createApplyPropositions.spec.js
+++ b/test/unit/specs/components/Personalization/createApplyPropositions.spec.js
@@ -76,7 +76,7 @@ describe("Personalization::createApplyPropositions", () => {
     expect(processPropositions).toHaveBeenCalledOnceWith([]);
   });
 
-  it("it should apply user-provided dom-action schema propositions", async () => {
+  it("it should apply user-provided dom-action/default-content schema propositions", async () => {
     const expectedExecuteDecisionsPropositions = clone(
       PAGE_WIDE_SCOPE_DECISIONS,
     ).map((proposition) => {
@@ -99,7 +99,7 @@ describe("Personalization::createApplyPropositions", () => {
       expect(proposition.items).toEqual(
         jasmine.arrayContaining([jasmine.any(Object)]),
       );
-      expect(proposition.items.length).toEqual(2);
+      expect(proposition.items.length).toEqual(3);
     });
   });
 

--- a/test/unit/specs/components/Personalization/validateApplyPropositionsOptions.spec.js
+++ b/test/unit/specs/components/Personalization/validateApplyPropositionsOptions.spec.js
@@ -176,8 +176,7 @@ describe("Personalization::validateApplyPropositionsOptions", () => {
         ],
         errorMessage:
           "'propositions[0].items[0].id' is a required option\n" +
-          "'propositions[0].items[0].schema' is a required option\n" +
-          "'propositions[0].items[0].data' is a required option",
+          "'propositions[0].items[0].schema' is a required option",
       },
       {
         propositions: [
@@ -188,20 +187,7 @@ describe("Personalization::validateApplyPropositionsOptions", () => {
             items: [{ id: "abc" }],
           },
         ],
-        errorMessage:
-          "'propositions[0].items[0].schema' is a required option\n" +
-          "'propositions[0].items[0].data' is a required option",
-      },
-      {
-        propositions: [
-          {
-            id: "abc",
-            scope: "web://aepdemo.com/",
-            scopeDetails,
-            items: [{ id: "abc", schema: DOM_ACTION }],
-          },
-        ],
-        errorMessage: "'propositions[0].items[0].data' is a required option",
+        errorMessage: "'propositions[0].items[0].schema' is a required option",
       },
     ];
 


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->
The issue appeared after this [PR](https://github.com/adobe/alloy/pull/1101/files#diff-f045242682e2082ad8db0b9e09d37458bbe579ae746e9a388f65ec75471c87c2R23) has been released.
`default-content-item` schemas items do not have `item.data`, thus this was leading into validation error and propositions were never applied. Customers do not know when `default-content-item` is returned, which was breaking their implementation and their could not see the impressions. This is a critical issue because it impacts all the customers and can affect any other activities not only those that have `default-content-item`. 
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
