### PR TITLE
Implement Fallback for Blocked demdex.net Requests

### DIFF
--- a/src/core/edgeNetwork/injectSendEdgeNetworkRequest.js
+++ b/src/core/edgeNetwork/injectSendEdgeNetworkRequest.js
@@ -16,6 +16,15 @@ import { createCallbackAggregator, noop } from "../../utils/index.js";
 import mergeLifecycleResponses from "./mergeLifecycleResponses.js";
 import handleRequestFailure from "./handleRequestFailure.js";
 
+const isDemdexBlockedError = (error, request) => {
+  return (
+    request.getUseIdThirdPartyDomain() &&
+    (error.name === "TypeError" || // Failed to fetch
+      error.name === "NetworkError" || // Request failed
+      error.status === 0) // Request blocked
+  );
+};
+
 export default ({
   config,
   lifecycle,
@@ -25,8 +34,10 @@ export default ({
   processWarningsAndErrors,
   getLocationHint,
   getAssuranceValidationTokenParams,
+  logger,
 }) => {
   const { edgeDomain, edgeBasePath, datastreamId } = config;
+  let hasDemdexFailed = false;
 
   /**
    * Sends a network request that is aware of payload interfaces,
@@ -52,9 +63,10 @@ export default ({
         onRequestFailure: onRequestFailureCallbackAggregator.add,
       })
       .then(() => {
-        const endpointDomain = request.getUseIdThirdPartyDomain()
-          ? ID_THIRD_PARTY_DOMAIN
-          : edgeDomain;
+        const endpointDomain =
+          hasDemdexFailed || !request.getUseIdThirdPartyDomain()
+            ? edgeDomain
+            : ID_THIRD_PARTY_DOMAIN;
         const locationHint = getLocationHint();
         const edgeBasePathWithLocationHint = locationHint
           ? `${edgeBasePath}/${locationHint}${request.getEdgeSubPath()}`
@@ -83,7 +95,25 @@ export default ({
         processWarningsAndErrors(networkResponse);
         return networkResponse;
       })
-      .catch(handleRequestFailure(onRequestFailureCallbackAggregator))
+      .catch((error) => {
+        if (isDemdexBlockedError(error, request)) {
+          hasDemdexFailed = true;
+          logger.warn(
+            "Third party endpoint appears to be blocked. " +
+              "Falling back to first party endpoint. " +
+              "This may impact cross-domain identification capabilities.",
+          );
+          // Retry with edge domain
+          request.setUseIdThirdPartyDomain(false);
+          return sendNetworkRequest({
+            requestId: request.getId(),
+            url: request.buildUrl(edgeDomain),
+            payload: request.getPayload(),
+            useSendBeacon: request.getUseSendBeacon(),
+          });
+        }
+        return handleRequestFailure(onRequestFailureCallbackAggregator)(error);
+      })
       .then(({ parsedBody, getHeader }) => {
         // Note that networkResponse.parsedBody may be undefined if it was a
         // 204 No Content response. That's fine.

--- a/src/core/edgeNetwork/injectSendEdgeNetworkRequest.js
+++ b/src/core/edgeNetwork/injectSendEdgeNetworkRequest.js
@@ -34,7 +34,6 @@ export default ({
   processWarningsAndErrors,
   getLocationHint,
   getAssuranceValidationTokenParams,
-  logger,
 }) => {
   const { edgeDomain, edgeBasePath, datastreamId } = config;
   let hasDemdexFailed = false;
@@ -98,12 +97,6 @@ export default ({
       .catch((error) => {
         if (isDemdexBlockedError(error, request)) {
           hasDemdexFailed = true;
-          logger.warn(
-            "Third party endpoint appears to be blocked. " +
-              "Falling back to first party endpoint. " +
-              "This may impact cross-domain identification capabilities.",
-          );
-          // Retry with edge domain
           request.setUseIdThirdPartyDomain(false);
           return sendNetworkRequest({
             requestId: request.getId(),

--- a/test/functional/specs/Identity/demdexFallback.js
+++ b/test/functional/specs/Identity/demdexFallback.js
@@ -1,0 +1,50 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { t } from "testcafe";
+import createNetworkLogger from "../../helpers/networkLogger/index.js";
+import createFixture from "../../helpers/createFixture/index.js";
+import {
+  compose,
+  orgMainConfigMain,
+  thirdPartyCookiesEnabled,
+} from "../../helpers/constants/configParts/index.js";
+import createAlloyProxy from "../../helpers/createAlloyProxy.js";
+
+const networkLogger = createNetworkLogger();
+const config = compose(orgMainConfigMain, thirdPartyCookiesEnabled);
+
+createFixture({
+  title: "Demdex Fallback Behavior",
+  requestHooks: [networkLogger.edgeEndpointLogs],
+});
+
+test("Continues collecting data when demdex is blocked", async () => {
+  const alloy = createAlloyProxy();
+
+  // Block demdex.net
+  await t.eval(() => {
+    const originalFetch = window.fetch;
+    window.fetch = (url, ...args) => {
+      if (url.includes("demdex.net")) {
+        return Promise.reject(new TypeError("Failed to fetch"));
+      }
+      return originalFetch(url, ...args);
+    };
+  });
+
+  await alloy.configure(config);
+  await alloy.sendEvent();
+
+  const requests = networkLogger.edgeEndpointLogs.requests;
+  await t.expect(requests.length).eql(1);
+  await t.expect(requests[0].request.url).notContains("demdex.net");
+});


### PR DESCRIPTION
## Summary
Added fallback mechanism to use configured edge domain when demdex.net requests fail. This improves reliability when users have ad blockers or network restrictions that block third-party endpoints.

## Changes
- Added detection of demdex.net failures in network requests
- Implemented fallback to edge domain
- Added test coverage

## Testing
Verified behavior with:
- New functional test suite (demdexFallback.js)
- Updated existing tests (C10922.js)

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
