### PR TITLE
Fixed an issue where identities were forgotten after a /collect call was sent

### DIFF
--- a/sandbox/public/index_extension.html
+++ b/sandbox/public/index_extension.html
@@ -33,7 +33,8 @@
         padding: 10px;
       }
       .logo {
-        font-family: "Lucida Sans", "Lucida Sans Regular", "Lucida Grande",
+        font-family:
+          "Lucida Sans", "Lucida Sans Regular", "Lucida Grande",
           "Lucida Sans Unicode", Geneva, Verdana, sans-serif;
       }
       .nav-bar {

--- a/src/components/Identity/createComponent.js
+++ b/src/components/Identity/createComponent.js
@@ -48,7 +48,10 @@ export default ({
           // https://jira.corp.adobe.com/browse/EXEG-1234
           setLegacyEcid(newNamespaces[ecidNamespace]);
         }
-        namespaces = newNamespaces;
+
+        if (newNamespaces && Object.keys(newNamespaces).length > 0) {
+          namespaces = { ...namespaces, ...newNamespaces };
+        }
         // For sendBeacon requests, getEdge() will return {}, so we are using assign here
         // so that sendBeacon requests don't override the edge info from before.
         edge = { ...edge, ...response.getEdge() };

--- a/test/functional/specs/Identity/C21636436.js
+++ b/test/functional/specs/Identity/C21636436.js
@@ -25,8 +25,13 @@ const networkLogger = createNetworkLogger();
 const config = compose(orgMainConfigMain, debugEnabled);
 
 createFixture({
-  title: "Get Identity after Collect Call",
+  title: "C21636436: Get Identity after Collect Call",
   requestHooks: [networkLogger.acquireEndpointLogs],
+});
+test.meta({
+  ID: "C21636436",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression",
 });
 
 test("Preserves ECID after sendEvent call with collect beacon", async () => {

--- a/test/functional/specs/Identity/C21636437.js
+++ b/test/functional/specs/Identity/C21636437.js
@@ -24,8 +24,14 @@ const networkLogger = createNetworkLogger();
 const config = compose(orgMainConfigMain, thirdPartyCookiesEnabled);
 
 createFixture({
-  title: "Demdex Fallback Behavior",
+  title: "C21636437: Demdex Fallback Behavior",
   requestHooks: [networkLogger.edgeEndpointLogs, demdexBlockerMock],
+});
+
+test.meta({
+  ID: "C21636437",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression",
 });
 
 test("Continues collecting data when demdex is blocked", async () => {

--- a/test/functional/specs/Identity/C21636438.js
+++ b/test/functional/specs/Identity/C21636438.js
@@ -24,8 +24,14 @@ const networkLogger = createNetworkLogger();
 const config = compose(orgMainConfigMain, debugEnabled);
 
 createFixture({
-  title: "Decode the kndctr_ORGID_Identity cookie",
+  title: "C21636438: Decode the kndctr_ORGID_Identity cookie",
   requestHooks: [networkLogger.acquireEndpointLogs],
+});
+
+test.meta({
+  ID: "C21636438",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression",
 });
 
 test("Extracts information from kndctr cookie", async () => {

--- a/test/functional/specs/Identity/getIdentityAfterCollectCall.js
+++ b/test/functional/specs/Identity/getIdentityAfterCollectCall.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { t } from "testcafe";
+import createNetworkLogger from "../../helpers/networkLogger/index.js";
+import createFixture from "../../helpers/createFixture/index.js";
+import {
+  compose,
+  orgMainConfigMain,
+  debugEnabled,
+} from "../../helpers/constants/configParts/index.js";
+import createAlloyProxy from "../../helpers/createAlloyProxy.js";
+import createCollectEndpointAsserter from "../../helpers/createCollectEndpointAsserter.js";
+
+const networkLogger = createNetworkLogger();
+const config = compose(orgMainConfigMain, debugEnabled);
+
+createFixture({
+  title: "Get Identity after Collect Call",
+  requestHooks: [networkLogger.acquireEndpointLogs],
+});
+
+test("Preserves ECID after sendEvent call with collect beacon", async () => {
+  const collectEndpointAsserter = await createCollectEndpointAsserter();
+  const alloy = createAlloyProxy();
+  await alloy.configure(config);
+
+  await alloy.sendEvent();
+
+  await collectEndpointAsserter.reset();
+
+  const initialIdentity = await alloy.getIdentity({
+    namespaces: ["ECID"],
+  });
+
+  await t
+    .expect(initialIdentity.identity.ECID)
+    .ok("No ECID in initial response");
+
+  const initialEcid = initialIdentity.identity.ECID;
+
+  await alloy.sendEvent({
+    documentUnloading: true,
+    xdm: {
+      eventType: "test-event",
+    },
+  });
+
+  await collectEndpointAsserter.assertCollectCalledAndNotInteract();
+
+  const subsequentIdentity = await alloy.getIdentity({
+    namespaces: ["ECID"],
+  });
+
+  await t
+    .expect(subsequentIdentity.identity.ECID)
+    .eql(initialEcid, "ECID was not preserved after collect call");
+});

--- a/test/functional/specs/Personalization/C21636439.js
+++ b/test/functional/specs/Personalization/C21636439.js
@@ -48,11 +48,17 @@ const firstInteractCallReturnsInAppMessagesMock = () => {
 
 createFixture({
   title:
-    "Conflict resoulution: show one in app message propositions sorted by rank",
+    "C21636439: Conflict resoulution: show one in app message propositions sorted by rank",
   requestHooks: [
     firstInteractCallReturnsInAppMessagesMock(),
     networkLogger.edgeEndpointLogs,
   ],
+});
+
+test.meta({
+  ID: "C21636439",
+  SEVERITY: "P0",
+  TEST_RUN: "Regression",
 });
 
 test("propositions are sorted ascending by rank", async () => {


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

No longer preserves empty `namespace` objects after a response.



<details>
<summary>For the curious, this PR was 95% written by <a href="https://cursor.com">Cursor</a>, including the test.</summary>  

I prompted Cursor, using the "Composer" in "Agent Mode" (which can edit all files and even run cli commands) and the brand-new Sonnet 3.7 Thinking with the following:

> Here's a bug report.
> 
> > It looks like there is an issue with AEP Web SDK with the "getIdentity" command with version 2.24.0.  The highlighted line in the screenshot causes "namespaces" to be overwritten by any alloy('sendEvent') call that does not return the ECID in the response...which seems to happen for all our collect calls.  
> 
> Start by reproducing it with a functional test.

and telling it to put the tests in a specific file, using `decodeKndctrCookie.js` as a reference for style. It wrote a basic version of the test, but I noticed a few errors. I  told it to

> Use the identity component (which defines the getIdentity command) as a reference in writing the test. 

It searched the codebase and edited the test to make it fit better. It was still making the error of including the `CORE` namespace without third-party cookies, so I told it 

> CORE is only included when third party cookies are enabled, so we don't need to include it here in our test.

and it removed it from the test. I couldn't remember exactly how to force a `sendBeacon`, so I asked it 

> Find out how to send a `/collect` beacon with `sendEvent`. Something like "documentUnloading: true" is the easiest, but verify against the code.

and it searched through to code and modified the test accordingly. I then manually verified that the test it wrote was failing.

Now it was time to start fixing it.

> I've run the functional tests with `npm run test:functional:build:int && npm run test:functional` and it looks like they are failing successfully.
> 
> Where do we start with fixing this? Probably in identity/createcomponent

and it wrote the code into `Identity/createComponent.js`. The end result is the code in the diff as it currently stands. I ran the tests to verify that the test was now passing. 

It is a very simple ticket and fix, but it was still interesting to see that it worked decently and automatically. I think it's worth checking out.
</details>

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[PDCL-13107: Potential Bug in "getIdentity" command](https://jira.corp.adobe.com/browse/PDCL-13107)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
