### PR TITLE
Fix the broken parsing of the adobemc expiration time query parameter

### DIFF
--- a/src/components/Identity/injectAddQueryStringIdentityToPayload.js
+++ b/src/components/Identity/injectAddQueryStringIdentityToPayload.js
@@ -42,7 +42,7 @@ export default ({ locationSearch, dateProvider, orgId, logger }) =>
     const properties = queryStringValue.split("|").reduce((memo, keyValue) => {
       const [key, value] = keyValue.split("=");
       memo[key] = decodeUriComponentSafely(value);
-      memo[key] = memo[key].replace(/[^a-zA-Z0-9@_-]/g, ""); // sanitization
+      memo[key] = memo[key].replace(/[^a-zA-Z0-9@.]/g, ""); // sanitization
       return memo;
     }, {});
     // We are using MCMID and MCORGID to be compatible with Visitor.


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

The functional tests caught this one. 

[The security scan ticket asked us to sanitize query parameters](https://jira.corp.adobe.com/browse/PDCL-12967) and [I was too aggressive](https://github.com/adobe/alloy/pull/1234/files#diff-6e3e741dcb6c7019835603cfb579bba259f95b89df57a89363b68f00caa71181R45), which broke expiration of the `adobe_mc` parameter. The expiration time is a number with a decimal point, which was being stripped out.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
