### PR TITLE
Allow the CORE identity to be requested alongside a cookie-read ECID

### DIFF
--- a/src/components/Identity/createComponent.js
+++ b/src/components/Identity/createComponent.js
@@ -71,12 +71,19 @@ export default ({
                 return undefined;
               }
               const ecidFromCookie = decodeKndctrCookie();
-              if (ecidFromCookie) {
+              if (
+                ecidFromCookie &&
+                requestedNamespaces.includes(ecidNamespace)
+              ) {
                 if (!namespaces) {
                   namespaces = {};
                 }
                 namespaces[ecidNamespace] = ecidFromCookie;
-                return undefined;
+                if (requestedNamespaces.length === 1) {
+                  // If only ECID is requested, we don't need to make an acquire request
+                  // and can return immediately
+                  return undefined;
+                }
               }
               return getIdentity(options);
             })


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

#1230 reads the ECID from the cookie, but cancelled an request no matter yet. If there are other namespaces requested (like `CORE`), then there was a bug where they would not get requested.

This fixes that issue.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
