### PR TITLE
Support automatic click tracking from shadow dom elements

### DIFF
--- a/src/components/ActivityCollector/attachClickActivityCollector.js
+++ b/src/components/ActivityCollector/attachClickActivityCollector.js
@@ -23,7 +23,6 @@ const createClickHandler = ({ eventManager, lifecycle, handleError }) => {
       "composedPath" in clickEvent && clickEvent.composedPath().length > 0
         ? clickEvent.composedPath()[0]
         : clickEvent.target;
-    // if the clicked element is a shadow root, drill down into it to find the actual click element
     const event = eventManager.createEvent();
     // this is to make sure a exit link personalization metric use send beacon
     event.documentMayUnload();

--- a/src/components/ActivityCollector/attachClickActivityCollector.js
+++ b/src/components/ActivityCollector/attachClickActivityCollector.js
@@ -19,7 +19,11 @@ const createClickHandler = ({ eventManager, lifecycle, handleError }) => {
       return Promise.resolve();
     }
     // TODO: Consider safeguarding from the same object being clicked multiple times in rapid succession?
-    const clickedElement = clickEvent.target;
+    let clickedElement = clickEvent.target;
+    // if the clicked element is a shadow root, drill down into it to find the actual click element
+    if (clickedElement?.shadowRoot) {
+      clickedElement = clickedElement.shadowRoot.activeElement;
+    }
     const event = eventManager.createEvent();
     // this is to make sure a exit link personalization metric use send beacon
     event.documentMayUnload();

--- a/src/components/ActivityCollector/attachClickActivityCollector.js
+++ b/src/components/ActivityCollector/attachClickActivityCollector.js
@@ -19,11 +19,11 @@ const createClickHandler = ({ eventManager, lifecycle, handleError }) => {
       return Promise.resolve();
     }
     // TODO: Consider safeguarding from the same object being clicked multiple times in rapid succession?
-    let clickedElement = clickEvent.target;
+    const clickedElement =
+      "composedPath" in clickEvent && clickEvent.composedPath().length > 0
+        ? clickEvent.composedPath()[0]
+        : clickEvent.target;
     // if the clicked element is a shadow root, drill down into it to find the actual click element
-    if (clickedElement?.shadowRoot) {
-      clickedElement = clickedElement.shadowRoot.activeElement;
-    }
     const event = eventManager.createEvent();
     // this is to make sure a exit link personalization metric use send beacon
     event.documentMayUnload();

--- a/src/components/Personalization/dom-actions/clicks/collectInteractions.js
+++ b/src/components/Personalization/dom-actions/clicks/collectInteractions.js
@@ -31,7 +31,11 @@ const getInteractionDetail = (clickedElement) => {
   let clickLabel;
   let clickToken;
 
-  while (element && element !== documentElement) {
+  while (
+    element &&
+    element !== documentElement &&
+    !(element instanceof ShadowRoot)
+  ) {
     const interactId = getAttribute(element, INTERACT_ID_DATA_ATTRIBUTE);
 
     if (interactId) {

--- a/test/functional/specs/Personalization/autoClickTrackingShadowDom.js
+++ b/test/functional/specs/Personalization/autoClickTrackingShadowDom.js
@@ -43,45 +43,33 @@ const insertShadowDomLink = ClientFunction(
   },
 );
 
-test("Support click tracking for a link in an open shadow DOM", async () => {
+const testShadowRoot = async ({ testCafe, mode }) => {
   const alloy = createAlloyProxy();
   await alloy.configure(config);
 
-  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(0);
+  await testCafe.expect(networkLogger.edgeEndpointLogs.requests.length).eql(0);
 
   const linkId = "shadow-dom-link-test";
-  const linkText = "open shadow dom link";
+  const linkText = `${mode} shadow dom link`;
   await insertShadowDomLink("open", linkId, linkText);
 
-  await t.click(Selector("body").shadowRoot().find(`#${linkId}`));
+  await testCafe.click(Selector("body").shadowRoot().find(`#${linkId}`));
 
-  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
+  await testCafe.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
 
   const request = JSON.parse(
     networkLogger.edgeEndpointLogs.requests[0].request.body,
   );
 
-  await t.expect(request.events[0].xdm.web.webInteraction.name).eql(linkText);
+  await testCafe
+    .expect(request.events[0].xdm.web.webInteraction.name)
+    .eql(linkText);
+};
+
+test("Support click tracking for a link in an open shadow DOM", async () => {
+  await testShadowRoot({ testCafe: t, mode: "open" });
 });
 
-// Skipped until we have a way to track clicks on a link in a closed shadow DOM
-test.skip("Support click tracking for a link in an closed shadow DOM", async () => {
-  const alloy = createAlloyProxy();
-  await alloy.configure(config);
-
-  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(0);
-
-  const linkId = "shadow-dom-link-test";
-  const linkText = "closed shadow dom link";
-  await insertShadowDomLink("closed", linkId, linkText);
-
-  await t.click(Selector("body").shadowRoot().find(`#${linkId}`));
-
-  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
-
-  const request = JSON.parse(
-    networkLogger.edgeEndpointLogs.requests[0].request.body,
-  );
-
-  await t.expect(request.events[0].xdm.web.webInteraction.name).eql(linkText);
+test("Support click tracking for a link in an closed shadow DOM", async () => {
+  await testShadowRoot({ testCafe: t, mode: "closed" });
 });

--- a/test/functional/specs/Personalization/autoClickTrackingShadowDom.js
+++ b/test/functional/specs/Personalization/autoClickTrackingShadowDom.js
@@ -30,16 +30,17 @@ createFixture({
   requestHooks: [networkLogger.edgeEndpointLogs],
 });
 
-const linkId = "shadow-dom-link-test";
-
 const insertShadowDomLink = ClientFunction(
-  (mode = "open") => {
+  (
+    mode = "open",
+    linkId = "shadow-dom-link-test",
+    innerText = "open shadow dom link",
+  ) => {
     const shadow = document.body.attachShadow({ mode });
     const div = document.createElement("div");
-    div.setHTMLUnsafe(`<a id="${linkId}" href="#">${mode} shadow dom link</a>`);
+    div.setHTMLUnsafe(`<a id="${linkId}" href="#">${innerText}</a>`);
     shadow.appendChild(div);
   },
-  { dependencies: { linkId } },
 );
 
 test("Support click tracking for a link in an open shadow DOM", async () => {
@@ -48,7 +49,9 @@ test("Support click tracking for a link in an open shadow DOM", async () => {
 
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(0);
 
-  await insertShadowDomLink("open");
+  const linkId = "shadow-dom-link-test";
+  const linkText = "open shadow dom link";
+  await insertShadowDomLink("open", linkId, linkText);
 
   await t.click(Selector("body").shadowRoot().find(`#${linkId}`));
 
@@ -58,9 +61,7 @@ test("Support click tracking for a link in an open shadow DOM", async () => {
     networkLogger.edgeEndpointLogs.requests[0].request.body,
   );
 
-  await t
-    .expect(request.events[0].xdm.web.webInteraction.name)
-    .eql("shadow-dom-link-test");
+  await t.expect(request.events[0].xdm.web.webInteraction.name).eql(linkText);
 });
 
 // Skipped until we have a way to track clicks on a link in a closed shadow DOM
@@ -70,7 +71,9 @@ test.skip("Support click tracking for a link in an closed shadow DOM", async () 
 
   await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(0);
 
-  await insertShadowDomLink("closed");
+  const linkId = "shadow-dom-link-test";
+  const linkText = "closed shadow dom link";
+  await insertShadowDomLink("closed", linkId, linkText);
 
   await t.click(Selector("body").shadowRoot().find(`#${linkId}`));
 
@@ -80,7 +83,5 @@ test.skip("Support click tracking for a link in an closed shadow DOM", async () 
     networkLogger.edgeEndpointLogs.requests[0].request.body,
   );
 
-  await t
-    .expect(request.events[0].xdm.web.webInteraction.name)
-    .eql("shadow-dom-link-test");
+  await t.expect(request.events[0].xdm.web.webInteraction.name).eql(linkText);
 });

--- a/test/functional/specs/Personalization/autoClickTrackingShadowDom.js
+++ b/test/functional/specs/Personalization/autoClickTrackingShadowDom.js
@@ -1,0 +1,86 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { t, Selector, ClientFunction } from "testcafe";
+import createNetworkLogger from "../../helpers/networkLogger/index.js";
+import createFixture from "../../helpers/createFixture/index.js";
+import createAlloyProxy from "../../helpers/createAlloyProxy.js";
+import getBaseConfig from "../../helpers/getBaseConfig.js";
+import {
+  compose,
+  debugEnabled,
+} from "../../helpers/constants/configParts/index.js";
+
+const networkLogger = createNetworkLogger();
+
+const config = compose(getBaseConfig(), debugEnabled, {
+  clickCollectionEnabled: true,
+});
+
+createFixture({
+  title: "Supports click tracking for links in shadow DOMs",
+  requestHooks: [networkLogger.edgeEndpointLogs],
+});
+
+const linkId = "shadow-dom-link-test";
+
+const insertShadowDomLink = ClientFunction(
+  (mode = "open") => {
+    const shadow = document.body.attachShadow({ mode });
+    const div = document.createElement("div");
+    div.setHTMLUnsafe(`<a id="${linkId}" href="#">${mode} shadow dom link</a>`);
+    shadow.appendChild(div);
+  },
+  { dependencies: { linkId } },
+);
+
+test("Support click tracking for a link in an open shadow DOM", async () => {
+  const alloy = createAlloyProxy();
+  await alloy.configure(config);
+
+  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(0);
+
+  await insertShadowDomLink("open");
+
+  await t.click(Selector("body").shadowRoot().find(`#${linkId}`));
+
+  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
+
+  const request = JSON.parse(
+    networkLogger.edgeEndpointLogs.requests[0].request.body,
+  );
+
+  await t
+    .expect(request.events[0].xdm.web.webInteraction.name)
+    .eql("shadow-dom-link-test");
+});
+
+// Skipped until we have a way to track clicks on a link in a closed shadow DOM
+test.skip("Support click tracking for a link in an closed shadow DOM", async () => {
+  const alloy = createAlloyProxy();
+  await alloy.configure(config);
+
+  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(0);
+
+  await insertShadowDomLink("closed");
+
+  await t.click(Selector("body").shadowRoot().find(`#${linkId}`));
+
+  await t.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
+
+  const request = JSON.parse(
+    networkLogger.edgeEndpointLogs.requests[0].request.body,
+  );
+
+  await t
+    .expect(request.events[0].xdm.web.webInteraction.name)
+    .eql("shadow-dom-link-test");
+});

--- a/test/functional/specs/Personalization/autoClickTrackingShadowDom.js
+++ b/test/functional/specs/Personalization/autoClickTrackingShadowDom.js
@@ -43,6 +43,11 @@ const insertShadowDomLink = ClientFunction(
   },
 );
 
+/**
+ * @param {Object} params
+ * @param {import('testcafe').TestCafe} params.testCafe
+ * @param {string} params.mode
+ */
 const testShadowRoot = async ({ testCafe, mode }) => {
   const alloy = createAlloyProxy();
   await alloy.configure(config);
@@ -52,7 +57,7 @@ const testShadowRoot = async ({ testCafe, mode }) => {
   const linkId = "shadow-dom-link-test";
   const linkText = `${mode} shadow dom link`;
   await insertShadowDomLink("open", linkId, linkText);
-
+  await testCafe.debug();
   await testCafe.click(Selector("body").shadowRoot().find(`#${linkId}`));
 
   await testCafe.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

Uses [`event.composedPath()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath) instead of `event.target` (what alloy currently does) or `event.target.shadowRoot.activeElement` (my first attempt, only works on `open` shadow doms) to detect the true target of a click event.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[PLATIR-45969: AJO web channel click track breaks on shadow DOM](https://jira.corp.adobe.com/browse/PLATIR-45969)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
