### PR TITLE
Fix the broken closed shadow dom test

### DIFF
--- a/test/functional/specs/Personalization/C21886916.js
+++ b/test/functional/specs/Personalization/C21886916.js
@@ -62,8 +62,7 @@ const testShadowRoot = async ({ testCafe, mode }) => {
 
   const linkId = "shadow-dom-link-test";
   const linkText = `${mode} shadow dom link`;
-  await insertShadowDomLink("open", linkId, linkText);
-  await testCafe.debug();
+  await insertShadowDomLink(mode, linkId, linkText);
   await testCafe.click(Selector("body").shadowRoot().find(`#${linkId}`));
 
   await testCafe.expect(networkLogger.edgeEndpointLogs.requests.length).eql(1);
@@ -81,6 +80,6 @@ test("C21886916: Support click tracking for a link in an open shadow DOM", async
   await testShadowRoot({ testCafe: t, mode: "open" });
 });
 
-test("C21886916: Support click tracking for a link in an closed shadow DOM", async () => {
+test.skip("C21886916: Support click tracking for a link in an closed shadow DOM", async () => {
   await testShadowRoot({ testCafe: t, mode: "closed" });
 });


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

There was a bug in the functional test in #1250 and #1252 which caused the "closed" shadow dom test to pass when it should not have.
Turns out there still is no way for a host page to use JS to interact with a Shadow DOM. That means clicking, selecting elements, or reading events.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://jira.corp.adobe.com/browse/PLATIR-45969

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
