### PR TITLE
Remove the option to provide custom event properties.

### DIFF
--- a/src/components/RulesEngine/createEvaluableRulesetPayload.js
+++ b/src/components/RulesEngine/createEvaluableRulesetPayload.js
@@ -66,10 +66,7 @@ export default (payload, eventRegistry) => {
 
   const evaluate = (context) => {
     const displayEvent = eventRegistry.getEvent(DISPLAY, activityId);
-
-    const displayedDate = displayEvent
-      ? displayEvent.firstTimestamp
-      : undefined;
+    const displayedDate = displayEvent?.firstTimestamp;
 
     const qualifyingItems = flattenArray(
       items.map((item) => item.execute(context)),
@@ -77,11 +74,10 @@ export default (payload, eventRegistry) => {
       .map(consequenceAdapter)
       .map((item) => {
         const { firstTimestamp: qualifiedDate } =
-          eventRegistry.addEvent(
-            {},
-            PropositionEventType.TRIGGER,
-            activityId,
-          ) || {};
+          eventRegistry.addEvent({
+            eventType: PropositionEventType.TRIGGER,
+            eventId: activityId,
+          }) || {};
 
         return {
           ...item,

--- a/src/components/RulesEngine/utils.js
+++ b/src/components/RulesEngine/utils.js
@@ -40,24 +40,24 @@ export const getExpirationDate = (retentionPeriod) => {
   expirationDate.setDate(expirationDate.getDate() - retentionPeriod);
   return expirationDate;
 };
-export const getActivityId = (proposition) => {
-  const { scopeDetails = {} } = proposition;
-  const { activity = {} } = scopeDetails;
-  const { id } = activity;
 
-  return id;
-};
+export const getActivityId = (proposition) =>
+  proposition?.scopeDetails?.activity?.id;
+
 export const createInMemoryStorage = () => {
   const inMemoryStorage = {};
+
   return {
     getItem: (key) => {
       return key in inMemoryStorage ? inMemoryStorage[key] : null;
     },
+
     setItem: (key, value) => {
       inMemoryStorage[key] = value;
     },
   };
 };
+
 export const clearLocalStorage = (storage) => {
   storage.clear();
 };


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

There was an option to provide some custom event properties to the Event History. But in all the places were it was used, the value was an empty object.  

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
