### PR TITLE
Add auto generation of TypeScript definitions from JavaScript using JSDoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ libEs6
 artifacts
 __screenshots__/
 adobe-alloy-*.tgz
+
+# Ignore auto generated types
+types/

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "testcafe-browser-provider-saucelabs": "^3.0.0",
         "testcafe-reporter-junit": "^3.0.2",
         "testcafe-reporter-saucelabs": "^3.6.0",
+        "typescript": "^5.8.3",
         "url-exists-nodejs": "^0.2.4",
         "url-parse": "^1.5.10",
         "vitest": "^3.1.1"
@@ -16750,12 +16751,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "type": "module",
   "main": "libEs5/index.js",
   "module": "libEs6/index.js",
+  "types": "types/index.d.ts",
   "files": [
     "libEs5",
     "libEs6",
+    "types",
     "LICENSE_BANNER",
     "babel.config.js",
     "rollup.config.js",
@@ -20,9 +22,10 @@
     "alloyBuilder": "scripts/alloyBuilder.js"
   },
   "scripts": {
-    "clean": "rimraf dist distTest libEs5 libEs6",
+    "clean": "rimraf dist distTest libEs5 libEs6 types",
     "lint": "eslint --cache --fix \"*.{js,cjs,mjs,jsx}\" \"{src,test,scripts,sandbox}/**/*.{js,cjs,mjs,jsx}\"",
     "format": "prettier --write \"*.{html,js,cjs,mjs,jsx}\" \"{sandbox,src,test,scripts}/**/*.{html,js,cjs,mjs,jsx}\"",
+    "types": "tsc",
     "test": "npm run test:unit && npm run test:scripts",
     "test:unit": "npx playwright install chromium && vitest run",
     "test:unit:debug": "npx playwright install chromium && vitest --no-file-parallelism --browser.headless=false",
@@ -38,7 +41,7 @@
     "sandbox:build": "rollup -c --environment SANDBOX && cd sandbox && npm run build",
     "dev": "concurrently --names build,sandbox \"rollup -c -w --environment SANDBOX\" \"cd sandbox && export REACT_APP_NONCE=321 && npm start\"",
     "dev:standalone": "npm run clean && rollup -c -w --environment STANDALONE",
-    "build": "npm run clean && rollup -c --environment BASE_CODE_MIN,STANDALONE,STANDALONE_MIN,BUNDLESIZE && echo \"Base Code:\" && cat distTest/baseCode.min.js",
+    "build": "npm run clean && npm run types && rollup -c --environment BASE_CODE_MIN,STANDALONE,STANDALONE_MIN,BUNDLESIZE && echo \"Base Code:\" && cat distTest/baseCode.min.js",
     "build:custom": "node scripts/alloyBuilder.js",
     "prepare": "husky && cd sandbox && npm install",
     "prepack": "rimraf libEs5 libEs6 && babel src -d libEs5 --env-name npmEs5 && babel src -d libEs6 --env-name npmEs6",
@@ -123,6 +126,7 @@
     "testcafe-browser-provider-saucelabs": "^3.0.0",
     "testcafe-reporter-junit": "^3.0.2",
     "testcafe-reporter-saucelabs": "^3.6.0",
+    "typescript": "^5.8.3",
     "url-exists-nodejs": "^0.2.4",
     "url-parse": "^1.5.10",
     "vitest": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -41,10 +41,10 @@
     "sandbox:build": "rollup -c --environment SANDBOX && cd sandbox && npm run build",
     "dev": "concurrently --names build,sandbox \"rollup -c -w --environment SANDBOX\" \"cd sandbox && export REACT_APP_NONCE=321 && npm start\"",
     "dev:standalone": "npm run clean && rollup -c -w --environment STANDALONE",
-    "build": "npm run clean && npm run types && rollup -c --environment BASE_CODE_MIN,STANDALONE,STANDALONE_MIN,BUNDLESIZE && echo \"Base Code:\" && cat distTest/baseCode.min.js",
+    "build": "npm run clean && rollup -c --environment BASE_CODE_MIN,STANDALONE,STANDALONE_MIN,BUNDLESIZE && echo \"Base Code:\" && cat distTest/baseCode.min.js",
     "build:custom": "node scripts/alloyBuilder.js",
     "prepare": "husky && cd sandbox && npm install",
-    "prepack": "rimraf libEs5 libEs6 && babel src -d libEs5 --env-name npmEs5 && babel src -d libEs6 --env-name npmEs6",
+    "prepack": "rimraf libEs5 libEs6 types && babel src -d libEs5 --env-name npmEs5 && babel src -d libEs6 --env-name npmEs6 && npm run types",
     "checkthattestfilesexist": "./scripts/checkThatTestFilesExist.js",
     "add-license": "./scripts/add-license.js"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -31,16 +31,17 @@ const createNamespacedStorage = injectStorage(window);
 
 /**
  * Creates a custom Alloy instance which can reduce the library size and increase performance.
- * 
+ *
+ * @type {(options: Object) => Function}
  * @param {Object} [options] - Configuration options for the instance.
  * @param {string} [options.name] - (Optional) The name of the instance. Defaults to "alloy".
  * @param {Array<Object>} [options.monitors] - (Optional) Monitors for the instance.
  * @param {Array<Function>} [options.components] - Components for the instance.
  * @returns {(commandName: string, options?: Object) => Promise<any>} A callable Alloy instance.
- * 
+ *
  * @see {@link https://experienceleague.adobe.com/en/docs/experience-platform/web-sdk/install/create-custom-build} for more details.
  */
-export function createCustomInstance(options = {}) {
+export const createCustomInstance = (options = {}) => {
   const eventOptionsValidator = objectOf({
     name: string().default("alloy"),
     monitors: arrayOf(objectOf({})).default([]),
@@ -74,19 +75,20 @@ export function createCustomInstance(options = {}) {
 
 /**
  * Creates a new Alloy instance.
- * 
+ *
+ * @type {(options?: Object) => Function}
  * @param {Object} [options] - (Optional) Configuration options for the instance.
  * @param {string} [options.name] - (Optional) The name of the instance. Defaults to "alloy".
  * @param {Array<Object>} [options.monitors] - (Optional) Monitors for the instance.
  * @returns {(commandName: string, options?: Object) => Promise<any>} A callable Alloy instance.
- * 
+ *
  * @example
  * const alloy = createInstance({ name: "myInstance" });
  * alloy("configure", { datastreamId: "myDatastreamId", orgId: "myOrgId" });
- * 
+ *
  * @see {@link https://experienceleague.adobe.com/en/docs/experience-platform/web-sdk/install/npm} for more details.
  */
-export function createInstance(options = {}) {
+export const createInstance = (options = {}) => {
   const eventOptionsValidator = objectOf({
     name: string().default("alloy"),
     monitors: arrayOf(objectOf({})).default([]),

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,18 @@ import * as optionalComponents from "./core/componentCreators.js";
 const { console } = window;
 const createNamespacedStorage = injectStorage(window);
 
-export const createCustomInstance = (options = {}) => {
+/**
+ * Creates a custom Alloy instance which can reduce the library size and increase performance.
+ * 
+ * @param {Object} [options] - Configuration options for the instance.
+ * @param {string} [options.name] - (Optional) The name of the instance. Defaults to "alloy".
+ * @param {Array<Object>} [options.monitors] - (Optional) Monitors for the instance.
+ * @param {Array<Function>} [options.components] - Components for the instance.
+ * @returns {(commandName: string, options?: Object) => Promise<any>} A callable Alloy instance.
+ * 
+ * @see {@link https://experienceleague.adobe.com/en/docs/experience-platform/web-sdk/install/create-custom-build} for more details.
+ */
+export function createCustomInstance(options = {}) {
   const eventOptionsValidator = objectOf({
     name: string().default("alloy"),
     monitors: arrayOf(objectOf({})).default([]),
@@ -61,7 +72,21 @@ export const createCustomInstance = (options = {}) => {
   return instance;
 };
 
-export const createInstance = (options = {}) => {
+/**
+ * Creates a new Alloy instance.
+ * 
+ * @param {Object} [options] - (Optional) Configuration options for the instance.
+ * @param {string} [options.name] - (Optional) The name of the instance. Defaults to "alloy".
+ * @param {Array<Object>} [options.monitors] - (Optional) Monitors for the instance.
+ * @returns {(commandName: string, options?: Object) => Promise<any>} A callable Alloy instance.
+ * 
+ * @example
+ * const alloy = createInstance({ name: "myInstance" });
+ * alloy("configure", { datastreamId: "myDatastreamId", orgId: "myOrgId" });
+ * 
+ * @see {@link https://experienceleague.adobe.com/en/docs/experience-platform/web-sdk/install/npm} for more details.
+ */
+export function createInstance(options = {}) {
   const eventOptionsValidator = objectOf({
     name: string().default("alloy"),
     monitors: arrayOf(objectOf({})).default([]),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": ["src/**/*"],
+  "exclude": ["node_modules"],
   "compilerOptions": {
     "allowJs": true,
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "types",
+    "declarationMap": true,
+  }
+}


### PR DESCRIPTION
## Description

* Add auto generated TypeScript definitions for Alloy so when the library is installed it doesn't immediately throw warnings.
* Add JSDoc comments so IDEs can show inline documentation.

See https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html

Fixes https://github.com/adobe/alloy/issues/1276
Fixes https://github.com/adobe/alloy/issues/799

## Related Issue
https://github.com/adobe/alloy/issues/1276
https://github.com/adobe/alloy/issues/799

## Motivation and Context

Adding TypeScript definitions to the Alloy library aligns with modern best practices, as TypeScript is widely adopted in the JavaScript ecosystem. Providing type definitions out of the box makes it easier for developers to get started with the library, as they benefit from features like type safety, autocompletion, and inline documentation in their IDEs.

The current developer experience when installing Alloy into a brand new TypeScript project is:

```
Could not find a declaration file for module '@adobe/alloy'. 'c:/git/alloy-demo/alloy-demo/node_modules/@adobe/alloy/libEs5/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/adobe__alloy` if it exists or add a new declaration (.d.ts) file containing `declare module '@adobe/alloy';`
```

There are ways around this using hacks like `// @ts-ignore` which sometimes needs to be done in a few different places depending on the framework. We can make the developer experience nicer by not needing workarounds to get the library working straight away.

## Screenshots
**Before**
![image](https://github.com/user-attachments/assets/52d0b014-c15b-4702-8004-9ad2f134cf78)

**After**
![image](https://github.com/user-attachments/assets/6a63e537-f2c4-4556-b41c-0735b74d63f4)

## Testing
I ran `npm pack` to generate the npm package and directly installed it in a brand-new project. The `Could not find a declaration file for module '@adobe/alloy'` error disappeared (see after screenshot) and I was able to create a new alloy instance and send `configure` without issues.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
