### PR TITLE
Fix alloyio.com production deployment

### DIFF
--- a/.github/workflows/main_alloyio.yml
+++ b/.github/workflows/main_alloyio.yml
@@ -19,17 +19,15 @@ jobs:
       - name: Set up Node.js version
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: lts/*
+          cache: "npm"
 
-      - name: Intall packages and build alloy
-        run: |
-          npm install
-          npm run build
+      - name: Intall packages
+        run: npm ci
 
-      - name: Change directory to sandbox and install npm packages and build sandbox
+      - name: Build sandbox
         run: |
           cd sandbox
-          npm install
           npm run build
 
       - name: Upload artifact for deployment job

--- a/sandbox/src/helpers/useAlloy.js
+++ b/sandbox/src/helpers/useAlloy.js
@@ -34,10 +34,6 @@ const setup = ({
   });
 
   initializeAlloy(window, instanceNames);
-  const alloyScriptPath = new URL(
-    "../../../src/standalone.js",
-    import.meta.url,
-  );
 
   if (getUrlParameter("includeVisitor") === "true") {
     includeScript(
@@ -48,10 +44,10 @@ const setup = ({
         doesOptInApply: getUrlParameter("legacyOptIn") === "true",
       });
       // Alloy only looks for window.Visitor when it initially loads, so only load Alloy after Visitor loaded.
-      includeScript(alloyScriptPath, { module: true });
+      return import("../../../src/standalone.js");
     });
   } else {
-    includeScript(alloyScriptPath, { module: true });
+    import("../../../src/standalone.js");
   }
 
   if (onAlloySetupCompleted) {

--- a/sandbox/vite.config.mjs
+++ b/sandbox/vite.config.mjs
@@ -2,7 +2,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-export default defineConfig({
+export default defineConfig((env) => ({
   plugins: [react()],
   server: {
     port: 3000,
@@ -15,5 +15,6 @@ export default defineConfig({
   },
   build: {
     outDir: "build",
+    sourcemap: true,
   },
-});
+}));


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

<!--- Describe your changes in detail -->

* Always build sourcemaps for the sandbox—it's a debugging tool, so it is helpful to always be able to know where in the source code things are happening.
* Adjust the deployment action to use `npm ci` instead of `npm i`, to use the latest lts version of node instead of pegging it to 24, and to cache npm packages
* Instead of building alloy, then injecting it as a script tag on the page, just dynamically `import()` the standalone entry point onto the page.

To test, start in the root of the repo

```sh
rm -rf **/node_modules/
npm ci
cd sandbox
npm run build 
python -m http.server --directory build/
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

https://alloyio.com currently does not load Alloy, but only for production sandbox builds. This is because vite inserts the text of the standalone build as `<script type="module" src="data:text/javascript;base64,LyoKQ29w…"></script>` which is blocked by the Content Security Policy that we define.

In order for the source to be correctly processed by vite, we need to use [a dynamic `import()` with a static string path](https://vite.dev/guide/features.html#dynamic-import).

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
