### PR TITLE
Fixed an issue where HTML content items failed to render due to missing renderStatusHandler

### DIFF
--- a/src/components/Personalization/handlers/createProcessHtmlContent.js
+++ b/src/components/Personalization/handlers/createProcessHtmlContent.js
@@ -10,6 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import createDecorateProposition from "./createDecorateProposition.js";
+import createRenderStatusHandler from "./createRenderStatusHandler.js";
 
 export default ({
     modules,
@@ -40,9 +41,18 @@ export default ({
       storeInteractionMeta,
     );
 
+    const renderStatusHandler = createRenderStatusHandler(
+      item.getProposition().getScopeType(),
+      item.getId(),
+    );
+
     return {
       render: () => {
-        return modules[type](item.getData(), decorateProposition);
+        return modules[type](
+          item.getData(),
+          decorateProposition,
+          renderStatusHandler,
+        );
       },
       setRenderAttempted: true,
       includeInNotification: true,

--- a/test/integration/specs/Personalization/applyPropositions.spec.js
+++ b/test/integration/specs/Personalization/applyPropositions.spec.js
@@ -1,0 +1,183 @@
+/*
+Copyright 2025 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import alloyConfig from "../../helpers/alloy/config.js";
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+} from "../../helpers/testsSetup/extend.js";
+
+describe("applyPropositions", () => {
+  let testElement;
+  const testElementClass = "heroimage";
+  const testElementTag = "div";
+  const testElementSelector = `${testElementTag}.${testElementClass}`;
+  beforeEach(() => {
+    testElement = document.createElement(testElementTag);
+    testElement.className = testElementClass;
+    testElement.innerHTML = "Original content";
+    document.body.appendChild(testElement);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(testElement);
+  });
+
+  // TGT-52945 and PLATIR-51065
+  test("html-content-item should work", async ({ alloy }) => {
+    alloy("configure", {
+      ...alloyConfig,
+      debugEnabled: true,
+    });
+
+    const propositions = [
+      {
+        id: "AT:eyJhY3Rpdml0eUlkIjoiMTY1NjkxNCIsImV4cGVyaWVuY2VJZCI6IjAifQ==",
+        scope: "web://example.com",
+        scopeDetails: {
+          decisionProvider: "TGT",
+          activity: {
+            id: "0",
+          },
+          experience: {
+            id: "0",
+          },
+        },
+        items: [
+          {
+            id: "910278",
+            schema: "https://ns.adobe.com/personalization/html-content-item",
+            data: {
+              id: "910278",
+              format: "text/html",
+              content:
+                '<img style="display: block; user-select: none; margin: auto; background-color: rgb(230, 230, 230); transition: background-color 300ms; --darkreader-inline-bgcolor: #26292b;" src="https://http.cat/200.jpg" data-darkreader-inline-bgcolor="" width="750" height="600">',
+              selector: "div.heroimage",
+              type: "setHtml",
+            },
+            meta: {
+              "experience.id": "0",
+              "activity.name": "App TC: Form Based Composer Activity",
+              "activity.id": "1656914",
+              "experience.name": "Experience A",
+              "geo.zip": "23224",
+              "option.id": "2",
+              "geo.ispName": "comcast cable communications inc.",
+              "profile.productPurchasedId": "",
+              "offer.name":
+                "/app_tc_form_basedcomposeractivity/experiences/0/pages/0/zones/0/1729542513711",
+              "profile.clientHasPurchasedMTP": "false",
+              "offer.id": "910278",
+            },
+          },
+        ],
+      },
+    ];
+    const metadata = {
+      "web://example.com": {
+        selector: testElementSelector,
+        actionType: "setHtml",
+      },
+    };
+
+    expect(async () => {
+      const result = await alloy("applyPropositions", {
+        propositions,
+        metadata,
+      });
+
+      // verify basic result structure
+      expect(result).toBeDefined();
+      expect(result.propositions).toBeDefined();
+      expect(result.propositions.length).toBe(1);
+      expect(result.propositions[0].renderAttempted).toBe(true);
+
+      // Check that the content was actually applied
+      expect(testElement.innerHTML).toContain("http.cat/200.jpg");
+      document.body.removeChild(testElement);
+    }).not.toThrow();
+  });
+
+  test("html-content-item and metadata should work", async ({ alloy }) => {
+    alloy("configure", {
+      ...alloyConfig,
+      debugEnabled: true,
+    });
+
+    const propositions = [
+      {
+        id: "AT:eyJhY3Rpdml0eUlkIjoiMTY1NjkxNCIsImV4cGVyaWVuY2VJZCI6IjAifQ==",
+        scope: "web://example.com",
+        scopeDetails: {
+          decisionProvider: "TGT",
+          activity: {
+            id: "1656914",
+          },
+          experience: {
+            id: "0",
+          },
+        },
+        items: [
+          {
+            id: "910278",
+            schema: "https://ns.adobe.com/personalization/html-content-item",
+            data: {
+              id: "910278",
+              format: "text/html",
+              content:
+                '<img style="display: block; user-select: none; margin: auto; background-color: rgb(230, 230, 230); transition: background-color 300ms; --darkreader-inline-bgcolor: #26292b;" src="https://http.cat/200.jpg" data-darkreader-inline-bgcolor="" width="750" height="600">',
+              selector: "div.heroimage",
+              type: "setHtml",
+            },
+            meta: {
+              "experience.id": "0",
+              "activity.name": "App TC: Form Based Composer Activity",
+              "activity.id": "1656914",
+              "experience.name": "Experience A",
+              "geo.zip": "23224",
+              "option.id": "2",
+              "geo.ispName": "comcast cable communications inc.",
+              "profile.productPurchasedId": "",
+              "offer.name":
+                "/app_tc_form_basedcomposeractivity/experiences/0/pages/0/zones/0/1729542513711",
+              "profile.clientHasPurchasedMTP": "false",
+              "offer.id": "910278",
+            },
+          },
+        ],
+      },
+    ];
+
+    const metadata = {
+      "web://example.com": {
+        selector: testElementSelector,
+        actionType: "setHtml",
+      },
+    };
+
+    expect(async () => {
+      const result = await alloy("applyPropositions", {
+        propositions,
+        metadata,
+      });
+
+      expect(result).toBeDefined();
+      expect(result.propositions).toBeDefined();
+      expect(result.propositions.length).toBe(1);
+      expect(result.propositions[0].renderAttempted).toBe(true);
+
+      expect(testElement.innerHTML).toContain("http.cat/200.jpg");
+    }).not.toThrow();
+  });
+});

--- a/test/unit/specs/components/Personalization/handlers/createProcessHtmlContent.spec.js
+++ b/test/unit/specs/components/Personalization/handlers/createProcessHtmlContent.spec.js
@@ -126,6 +126,7 @@ describe("createProcessHtmlContent", () => {
         content: "mycontent",
       },
       expect.any(Function),
+      expect.any(Object),
     );
   });
 });


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->
<!--- For PRs that should increment the patch version, attach the label "bug-fix" or "improvement" -->
<!--- For PRs that should increment the minor version, no labels are required -->
<!--- For PRs that should increment the major version, attach the label "breaking-change" -->

## Description

<!--- Describe your changes in detail -->

Fixed a bug where HTML content items (like those used in Adobe Target) would fail to render with the error "Cannot read properties of undefined (reading 'shouldRender')". The issue was caused by `createProcessHtmlContent.js` not passing the required `renderStatusHandler` parameter to DOM action modules, while `createProcessDomAction.js` was correctly passing it.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

* [TGT-52945 - Apply Propositions Function Broken (Version: 2.30.1)](https://jira.corp.adobe.com/browse/TGT-52945)
* [PLATIR-51065 - Activity not rendering after web sdk extension update](https://jira.corp.adobe.com/browse/PLATIR-51065)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Recent changes in PR #1271 introduced render status handling to prevent duplicate rendering in SPAs. This required all DOM action calls to receive a `renderStatusHandler` parameter. While `createProcessDomAction.js` was updated to pass this parameter, `createProcessHtmlContent.js` was missed, causing HTML content items to fail with `"shouldRender"` errors.
This fix ensures both DOM action and HTML content processing paths consistently pass the `renderStatusHandler`, resolving the rendering failures reported by customers after upgrading to v2.30.1.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
