### PR TITLE
Fix alloy-extension build

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "LICENSE_BANNER",
     "rollup.config.js",
     ".browserslistrc",
+    "src/core/componentCreators.js",
     "scripts/helpers/entryPointGeneratorBabelPlugin.js",
     "scripts/helpers/path.js"
   ],


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->
<!--- For PRs that should increment the patch version, attach the label "bug-fix" or "improvement" -->
<!--- For PRs that should increment the minor version, no labels are required -->
<!--- For PRs that should increment the major version, attach the label "breaking-change" -->

## Description


The custom build script for the extension (in `scripts/helpers/getAlloyComponents.js` and `scripts/buildAlloy.js`) reads the `dist/libEs6/core/componentCreators.js` file, parses it via Babel in order to get the names of all Alloy components. With #1295, that file was no longer shipped with Alloy because we changed the build process

This PR makes sure that `src/core/componentCreators.js` is included in the npm package. 

To verify this, you package alloy and then check if it is in the resulting archive.

1. `npm pack`
2. `tar --verbose --list --file adobe-alloy-2.28.0-beta.1.tgz | grep "componentCreators"`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
