### PR TITLE
Fixed an issue where config override sections were being merged instead of replaced

### DIFF
--- a/src/utils/request/createRequestPayload.js
+++ b/src/utils/request/createRequestPayload.js
@@ -12,17 +12,71 @@ governing permissions and limitations under the License.
 
 import { createMerger, prepareConfigOverridesForEdge } from "../index.js";
 
+/**
+ * createMerger creates a function that does a deep merge. Example:
+ * ```js
+ * payload.mergeConfigOverride({
+ *   com_adobe_analytics: {
+ *     reportSuites: ["reportSuite1"],
+ *   },
+ * });
+ *
+ * payload.mergeConfigOverride({
+ *   com_adobe_analytics: {
+ *     enabled: false,
+ *   },
+ * });
+ *
+ *
+ * // payload.meta.configOverrides is now:
+ * // {
+ * //   com_adobe_analytics: {
+ * //     enabled: false,
+ * //     reportSuites: ["reportSuite1"],
+ * //   },
+ * // }
+ * ```
+ * however, we need the result to be:
+ * ```js
+ * // {
+ * //   com_adobe_analytics: {
+ * //     enabled: false,
+ * //   },
+ * // }
+ * ```
+ * aka a shallow merge, where the second object overwrites the first.
+ * This is because order matters and we don't want to send reportSuites when something is
+ * disabled.
+ * This function does that.
+ *
+ * @param {Object} content
+ * @param {string} key
+ * @returns {(updates: Object) => void}
+ */
+const createMergeConfigOverride = (content, key) => (updates) => {
+  const propertyPath = key.split(".");
+  const hostObjectForUpdates = propertyPath.reduce((obj, propertyName) => {
+    obj[propertyName] = obj[propertyName] || {};
+    return obj[propertyName];
+  }, content);
+
+  Object.assign(hostObjectForUpdates, updates);
+};
+
 // This provides the base functionality that all types of
 // request payloads share.
 export default (options) => {
   const { content, addIdentity, hasIdentity } = options;
-  const mergeConfigOverride = createMerger(content, "meta.configOverrides");
+  const mergeConfigOverrides = createMergeConfigOverride(
+    content,
+    "meta.configOverrides",
+  );
   return {
     mergeMeta: createMerger(content, "meta"),
     mergeState: createMerger(content, "meta.state"),
     mergeQuery: createMerger(content, "query"),
     mergeConfigOverride: (updates) =>
-      mergeConfigOverride(prepareConfigOverridesForEdge(updates)),
+      mergeConfigOverrides(prepareConfigOverridesForEdge(updates)),
     addIdentity,
     hasIdentity,
     toJSON() {

--- a/test/integration/helpers/mswjs/networkRecorder.js
+++ b/test/integration/helpers/mswjs/networkRecorder.js
@@ -40,7 +40,7 @@ class NetworkRecorder {
    * @param {Request} options.request - The request object
    * @param {string} options.requestId - Unique identifier for the request
    */
-  captureRequest({ request, requestId }) {
+  async captureRequest({ request, requestId }) {
     let call = this.calls.find((c) => c.requestId === requestId);
 
     if (!call) {
@@ -48,11 +48,29 @@ class NetworkRecorder {
       this.calls.push(call);
     }
 
+    const requestClone = request.clone();
+    /** @type {string | Object} */
+    let body;
+
+    try {
+      const bodyText = await requestClone.text();
+      try {
+        // Try to parse as JSON first
+        body = JSON.parse(bodyText);
+      } catch {
+        // If not JSON, store as text
+        body = bodyText;
+      }
+    } catch (e) {
+      body = `Unable to read body: ${e.message}`;
+    }
+
     call.request = {
       url: request.url,
       method: request.method,
       headers: Object.fromEntries(request.headers.entries()),
       timestamp: Date.now(),
+      body,
     };
   }
 

--- a/test/integration/specs/Command Logic/configOverrides.spec.js
+++ b/test/integration/specs/Command Logic/configOverrides.spec.js
@@ -1,0 +1,49 @@
+/*
+Copyright 2025 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { test, expect, describe } from "../../helpers/testsSetup/extend.js";
+import { sendEventHandler } from "../../helpers/mswjs/handlers.js";
+import alloyConfig from "../../helpers/alloy/config.js";
+
+describe("Config overrides", () => {
+  test.only("should not include 'global' config overrides in payload if the service is disabled in the command options", async ({
+    alloy,
+    worker,
+    networkRecorder,
+  }) => {
+    worker.use(...[sendEventHandler]);
+
+    const config = structuredClone(alloyConfig);
+    await alloy("configure", {
+      ...config,
+      edgeConfigOverrides: {
+        com_adobe_analytics: {
+          reportSuites: ["reportSuite1"],
+        },
+      },
+    });
+
+    await alloy("sendEvent", {
+      edgeConfigOverrides: {
+        com_adobe_analytics: {
+          enabled: false,
+        },
+      },
+    });
+
+    const call = await networkRecorder.findCall(/edge\.adobedc\.net/);
+    expect(call.request?.body?.meta?.configOverrides).toEqual({
+      com_adobe_analytics: {
+        enabled: false,
+      },
+    });
+  });
+});

--- a/test/integration/specs/Command Logic/configOverrides.spec.js
+++ b/test/integration/specs/Command Logic/configOverrides.spec.js
@@ -14,7 +14,7 @@ import { sendEventHandler } from "../../helpers/mswjs/handlers.js";
 import alloyConfig from "../../helpers/alloy/config.js";
 
 describe("Config overrides", () => {
-  test.only("should not include 'global' config overrides in payload if the service is disabled in the command options", async ({
+  test("should not include 'global' config overrides in payload if the service is disabled in the command options", async ({
     alloy,
     worker,
     networkRecorder,


### PR DESCRIPTION
## Description

Fixed an issue where command-level config overrides (like those from sendEvent) were being deep-merged with global config overrides (from configure) instead of completely replacing them at the service level. 

Example:

```js
    await alloy("configure", {
      ...config,
      edgeConfigOverrides: {
        com_adobe_analytics: {
          reportSuites: ["reportSuite1"],
        },
      },
    });

    await alloy("sendEvent", {
      edgeConfigOverrides: {
        com_adobe_analytics: {
          enabled: false,
        },
      },
    });
```

would result in this config override payload being sent to the edge

```json
{
  "edgeConfigOverrides": {
     "com_adobe_analytics": {
       "enabled": false,
       "reportSuites": ["reportSuite1"]
     }
  }
}
```

which is wrong. It should just be `enabled: false` without the report suite.

The problem was in createRequestPayload.js where we were using deepAssign to merge config overrides. This meant when you disabled a service at the command level (e.g., enabled: false), it would still include other properties from the global config (e.g., reportSuites).

Changed the merging strategy from deep merge to shallow merge using Object.assign, so command-level overrides completely replace global overrides for each service.

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-13853

## Motivation and Context

## Screenshots (if appropriate):



## Checklist:

[x] I have signed the Adobe Open Source CLA https://opensource.adobe.com/cla.html or I'm an Adobe employee.
[x] I have made any necessary test changes and all tests pass.
[x] I have run the Sandbox successfully.