### PR TITLE
Fixed a case where link collection was sending the entire document contents as the link name

### DIFF
--- a/src/components/ActivityCollector/utils/dom/findClickableElement.js
+++ b/src/components/ActivityCollector/utils/dom/findClickableElement.js
@@ -18,6 +18,10 @@ import isButtonSubmitElement from "./isButtonSubmitElement.js";
 export default (element) => {
   let node = element;
   while (node) {
+    // Stop looking when BODY is reached
+    if (node.nodeName && node.nodeName === "BODY") {
+      break;
+    }
     if (
       isSupportedAnchorElement(node) ||
       elementHasClickHandler(node) ||

--- a/test/unit/specs/components/ActivityCollector/utils/dom/findClickableElement.spec.js
+++ b/test/unit/specs/components/ActivityCollector/utils/dom/findClickableElement.spec.js
@@ -32,4 +32,13 @@ describe("ActivityCollector::findClickableElement", () => {
     parentElement.appendChild(element);
     expect(findClickableElement(element)).toBe(parentElement);
   });
+  it("returns null if the BODY node is reached", () => {
+    const element = document.createElement("div");
+    const parentElement = document.createElement("body");
+    const grandParentElement = document.createElement("html");
+    grandParentElement.setAttribute("onClick", "clickity");
+    grandParentElement.appendChild(parentElement);
+    parentElement.appendChild(element);
+    expect(findClickableElement(element)).toBeNull();
+  });
 });


### PR DESCRIPTION
## Description

In some scenarios the click tracking will consider the document a clickable element (if click handlers are attached). This causes the link name to consider the entire document which can cause large amount of text to be transmitted **unless** a proper link is clicked prior to the next page view event is transmitted.

## Related Issue

AN-378037

## Motivation and Context

Prevents capturing the wrong context for clicks.

## Screenshots (if appropriate):

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
