### PR TITLE
Fixed an issue where certain propositions were not able to be re-rendered

### DIFF
--- a/src/components/Personalization/dom-actions/action.js
+++ b/src/components/Personalization/dom-actions/action.js
@@ -42,9 +42,12 @@ const renderContent = ({
   decorateProposition,
   renderFunc,
   renderStatusHandler,
+  alwaysRender,
 }) => {
   const executions = containers
-    .filter(renderStatusHandler.shouldRender)
+    .filter(
+      (element) => alwaysRender || renderStatusHandler.shouldRender(element),
+    )
     .map(async (container) => {
       await renderFunc(container, content, decorateProposition);
       renderStatusHandler.markAsRendered(container);
@@ -57,8 +60,9 @@ const renderContent = ({
  * Creates an action function that renders content into a container element.
  *
  * @param {Function} renderFunc - The function that performs the rendering.
+ * @param {boolean} alwaysRender - Whether to always render the content, even if it has already been rendered.
  */
-export const createAction = (renderFunc) => {
+export const createAction = (renderFunc, alwaysRender = false) => {
   /**
    * Renders content into a container element.
    *
@@ -84,6 +88,7 @@ export const createAction = (renderFunc) => {
         decorateProposition,
         renderFunc,
         renderStatusHandler,
+        alwaysRender,
       });
     } finally {
       showElements(prehidingSelector);

--- a/src/components/Personalization/dom-actions/initDomActionsModules.js
+++ b/src/components/Personalization/dom-actions/initDomActionsModules.js
@@ -55,7 +55,7 @@ export default () => {
     [DOM_ACTION_SET_STYLE]: createAction(setStyles, true),
     [DOM_ACTION_MOVE]: createAction(move, true),
     [DOM_ACTION_RESIZE]: createAction(resize, true),
-    [DOM_ACTION_REARRANGE]: createAction(rearrangeChildren, true),
+    [DOM_ACTION_REARRANGE]: createAction(rearrangeChildren),
     [DOM_ACTION_REMOVE]: createAction(removeNode, true),
     [DOM_ACTION_INSERT_AFTER]: createAction(insertHtmlAfter),
     [DOM_ACTION_INSERT_BEFORE]: createAction(insertHtmlBefore),

--- a/src/components/Personalization/dom-actions/initDomActionsModules.js
+++ b/src/components/Personalization/dom-actions/initDomActionsModules.js
@@ -48,7 +48,7 @@ export const DOM_ACTION_COLLECT_INTERACTIONS = "collectInteractions";
 export default () => {
   return {
     [DOM_ACTION_SET_HTML]: createAction(setHtml, true),
-    [DOM_ACTION_CUSTOM_CODE]: createAction(prependHtml, true),
+    [DOM_ACTION_CUSTOM_CODE]: createAction(prependHtml),
     [DOM_ACTION_SET_TEXT]: createAction(setText, true),
     [DOM_ACTION_SET_ATTRIBUTE]: createAction(setAttributes, true),
     [DOM_ACTION_SET_IMAGE_SOURCE]: createAction(swapImage, true),

--- a/src/components/Personalization/dom-actions/initDomActionsModules.js
+++ b/src/components/Personalization/dom-actions/initDomActionsModules.js
@@ -47,21 +47,21 @@ export const DOM_ACTION_COLLECT_INTERACTIONS = "collectInteractions";
 
 export default () => {
   return {
-    [DOM_ACTION_SET_HTML]: createAction(setHtml),
-    [DOM_ACTION_CUSTOM_CODE]: createAction(prependHtml),
-    [DOM_ACTION_SET_TEXT]: createAction(setText),
-    [DOM_ACTION_SET_ATTRIBUTE]: createAction(setAttributes),
-    [DOM_ACTION_SET_IMAGE_SOURCE]: createAction(swapImage),
-    [DOM_ACTION_SET_STYLE]: createAction(setStyles),
-    [DOM_ACTION_MOVE]: createAction(move),
-    [DOM_ACTION_RESIZE]: createAction(resize),
-    [DOM_ACTION_REARRANGE]: createAction(rearrangeChildren),
-    [DOM_ACTION_REMOVE]: createAction(removeNode),
+    [DOM_ACTION_SET_HTML]: createAction(setHtml, true),
+    [DOM_ACTION_CUSTOM_CODE]: createAction(prependHtml, true),
+    [DOM_ACTION_SET_TEXT]: createAction(setText, true),
+    [DOM_ACTION_SET_ATTRIBUTE]: createAction(setAttributes, true),
+    [DOM_ACTION_SET_IMAGE_SOURCE]: createAction(swapImage, true),
+    [DOM_ACTION_SET_STYLE]: createAction(setStyles, true),
+    [DOM_ACTION_MOVE]: createAction(move, true),
+    [DOM_ACTION_RESIZE]: createAction(resize, true),
+    [DOM_ACTION_REARRANGE]: createAction(rearrangeChildren, true),
+    [DOM_ACTION_REMOVE]: createAction(removeNode, true),
     [DOM_ACTION_INSERT_AFTER]: createAction(insertHtmlAfter),
     [DOM_ACTION_INSERT_BEFORE]: createAction(insertHtmlBefore),
     [DOM_ACTION_REPLACE_HTML]: createAction(replaceHtml),
     [DOM_ACTION_PREPEND_HTML]: createAction(prependHtml),
     [DOM_ACTION_APPEND_HTML]: createAction(appendHtml),
-    [DOM_ACTION_COLLECT_INTERACTIONS]: createAction(collectInteractions),
+    [DOM_ACTION_COLLECT_INTERACTIONS]: createAction(collectInteractions, true),
   };
 };

--- a/src/components/Personalization/dom-actions/initDomActionsModules.js
+++ b/src/components/Personalization/dom-actions/initDomActionsModules.js
@@ -59,7 +59,7 @@ export default () => {
     [DOM_ACTION_REMOVE]: createAction(removeNode, true),
     [DOM_ACTION_INSERT_AFTER]: createAction(insertHtmlAfter),
     [DOM_ACTION_INSERT_BEFORE]: createAction(insertHtmlBefore),
-    [DOM_ACTION_REPLACE_HTML]: createAction(replaceHtml),
+    [DOM_ACTION_REPLACE_HTML]: createAction(replaceHtml, true),
     [DOM_ACTION_PREPEND_HTML]: createAction(prependHtml),
     [DOM_ACTION_APPEND_HTML]: createAction(appendHtml),
     [DOM_ACTION_COLLECT_INTERACTIONS]: createAction(collectInteractions, true),

--- a/test/functional/specs/Personalization/C22098199.js
+++ b/test/functional/specs/Personalization/C22098199.js
@@ -141,3 +141,70 @@ const createTest = (action) => async () => {
     );
   },
 );
+
+test.only("setHtml propositions should be able to be re-rendered multiple times.", async () => {
+  const config = compose(orgMainConfigMain, debugEnabled);
+  const propositionId = uuid();
+  const itemId = uuid();
+
+  const targetHeadline = "Target Modified Headline";
+  const originalHeadline = "Original Headline";
+  const propositions = createPropositions({
+    propositionId,
+    items: [
+      {
+        id: itemId,
+        schema: "https://ns.adobe.com/personalization/dom-action",
+        data: {
+          type: "setHtml",
+          content: `<h1>${targetHeadline}</h1>`,
+          selector: `#${containerId}`,
+        },
+      },
+    ],
+  });
+
+  const spaPageBody = `
+  <div id="container">
+    <h1 id="page-header">Hello World!</h1>
+    <div id="${containerId}">
+      <h1>${originalHeadline}</h1>
+    </div>
+  </div>
+  `;
+
+  await addHtmlToBody(spaPageBody, true);
+
+  const alloy = createAlloyProxy();
+  await alloy.configure(config);
+
+  await alloy.applyPropositions({
+    propositions,
+  });
+
+  const container = Selector(`#${containerId}`).addCustomDOMProperties({
+    innerHTML: (el) => el.innerHTML,
+  });
+
+  await t.expect(container.innerHTML).contains(targetHeadline);
+
+  // "Navigate" to new SPA view
+  await t.eval(() => {
+    const targetContainer = document.getElementById("target-container");
+    if (targetContainer) {
+      targetContainer.innerHTML = `<h1>Sports/Politics Content</h1>`;
+    }
+  });
+
+  // Verify "navigation" worked
+  await t.expect(container.innerHTML).contains("Sports/Politics Content");
+
+  // "Navigate" back
+  await alloy.applyPropositions({
+    propositions,
+  });
+
+  // TODO: This fails, but it should pass. applyPropositions should be able to be called multiple times and work every time.
+  await t.expect(container.innerHTML).notContains("Sports/Politics Content");
+  await t.expect(container.innerHTML).contains(targetHeadline);
+});


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->
<!--- For PRs that should increment the patch version, attach the label "bug-fix" or "improvement" -->
<!--- For PRs that should increment the minor version, no labels are required -->
<!--- For PRs that should increment the major version, attach the label "breaking-change" -->

## Description

<!--- Describe your changes in detail -->

In #1271, we prevented all dom action propositions from being rendered twice. This created an issue in SPA use cases where, on view changes, the element would remain the same and the contents would change, then certain dom actions, like `setHtml`, would not be run again.

This PR allows certain dom actions to be able to rerendered and skip that check.

The DOM actions that can always be rerendered:

* `setHtml`
* `customCode`
* `setText`
* `setAttribute`
* `setImageSource`
* `setStyle`
* `move`
* `resize`
* `rearrange`
* `remove`
* `collectInteractions`
* `replaceHtml`

Those that can only be rendered once:

* `insertAfter`
* `insertBefore`
* `prependHtml`
* `appendHtml`

**Question:** does this list make sense? Should any other propositions be allowed/denied rerender privileges?

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://adobedx.slack.com/archives/CQ6DL08UC/p1756227219816229?thread_ts=1754667894.203139&cid=CQ6DL08UC

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
