### PR TITLE
Send auth data using base64 url safe.

### DIFF
--- a/src/components/PushNotifications/helpers/getPushSubscriptionDetails.js
+++ b/src/components/PushNotifications/helpers/getPushSubscriptionDetails.js
@@ -95,8 +95,12 @@ const getPushSubscriptionDetails = async ({ vapidPublicKey, window }) => {
     return {
       endpoint: subscription.endpoint,
       keys: {
-        p256dh: bytesToBase64(new Uint8Array(subscription.getKey("p256dh"))),
-        auth: bytesToBase64(new Uint8Array(subscription.getKey("auth"))),
+        p256dh: bytesToBase64(new Uint8Array(subscription.getKey("p256dh")), {
+          urlSafe: true,
+        }),
+        auth: bytesToBase64(new Uint8Array(subscription.getKey("auth")), {
+          urlSafe: true,
+        }),
       },
     };
   } catch (e) {

--- a/src/utils/bytes.js
+++ b/src/utils/bytes.js
@@ -29,6 +29,17 @@ export const base64ToBytes = (base64String) => {
 /**
  * Takes a Uint8Array and returns a base64 string.
  * @param {Uint8Array} bytes
+ * @param {Object} [options={}] - Options for encoding
+ * @param {boolean} [options.urlSafe=false] - Whether to return URL-safe base64 (no padding, + becomes -, / becomes _)
  * @returns {string}
  */
-export const bytesToBase64 = (bytes) => btoa(String.fromCharCode(...bytes));
+export const bytesToBase64 = (bytes, options = {}) => {
+  const { urlSafe = false } = options || {};
+  const base64 = btoa(String.fromCharCode(...bytes));
+
+  if (urlSafe) {
+    return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+  }
+
+  return base64;
+};

--- a/test/unit/specs/components/PushNotifications/helpers/getPushSubscriptionDetails.spec.js
+++ b/test/unit/specs/components/PushNotifications/helpers/getPushSubscriptionDetails.spec.js
@@ -153,8 +153,8 @@ describe("getPushSubscriptionDetails", () => {
       expect(result).toEqual({
         endpoint: "https://fcm.googleapis.com/fcm/send/test-endpoint",
         keys: {
-          p256dh: "AQIDBA==",
-          auth: "BQYHCA==",
+          p256dh: "AQIDBA",
+          auth: "BQYHCA",
         },
       });
 
@@ -197,8 +197,8 @@ describe("getPushSubscriptionDetails", () => {
       expect(result).toEqual({
         endpoint: "https://fcm.googleapis.com/fcm/send/test-endpoint",
         keys: {
-          p256dh: "AQIDBA==",
-          auth: "BQYHCA==",
+          p256dh: "AQIDBA",
+          auth: "BQYHCA",
         },
       });
     });

--- a/test/unit/specs/utils/bytes.spec.js
+++ b/test/unit/specs/utils/bytes.spec.js
@@ -1,0 +1,135 @@
+/*
+Copyright 2025 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { describe, it, expect } from "vitest";
+import { base64ToBytes, bytesToBase64 } from "../../../../src/utils/bytes.js";
+
+describe("bytes utilities", () => {
+  describe("bytesToBase64", () => {
+    it("converts bytes to standard base64", () => {
+      const bytes = new Uint8Array([72, 101, 108, 108, 111]);
+      const result = bytesToBase64(bytes);
+      expect(result).toBe("SGVsbG8=");
+    });
+
+    it("converts bytes to URL-safe base64 when urlSafe option is true", () => {
+      const bytes = new Uint8Array([72, 101, 108, 108, 111]);
+      const result = bytesToBase64(bytes, { urlSafe: true });
+      expect(result).toBe("SGVsbG8");
+    });
+
+    it("converts bytes with + and / characters to URL-safe base64", () => {
+      const bytes = new Uint8Array([62, 63, 254, 255]);
+      const standardResult = bytesToBase64(bytes);
+      const urlSafeResult = bytesToBase64(bytes, { urlSafe: true });
+
+      expect(standardResult).toBe("Pj/+/w==");
+      expect(urlSafeResult).toBe("Pj_-_w");
+    });
+
+    it("handles empty options object", () => {
+      const bytes = new Uint8Array([72, 101, 108, 108, 111]);
+      const result = bytesToBase64(bytes, {});
+      expect(result).toBe("SGVsbG8=");
+    });
+
+    it("defaults to standard base64 when no options provided", () => {
+      const bytes = new Uint8Array([72, 101, 108, 108, 111]);
+      const result = bytesToBase64(bytes);
+      expect(result).toBe("SGVsbG8=");
+    });
+
+    it("handles empty byte array", () => {
+      const bytes = new Uint8Array([]);
+      const result = bytesToBase64(bytes);
+      expect(result).toBe("");
+    });
+
+    it("handles single byte", () => {
+      const bytes = new Uint8Array([65]);
+      const standardResult = bytesToBase64(bytes);
+      const urlSafeResult = bytesToBase64(bytes, { urlSafe: true });
+
+      expect(standardResult).toBe("QQ==");
+      expect(urlSafeResult).toBe("QQ");
+    });
+
+    it("produces output compatible with base64ToBytes", () => {
+      const originalBytes = new Uint8Array([
+        72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100,
+      ]);
+
+      const standardBase64 = bytesToBase64(originalBytes);
+      const urlSafeBase64 = bytesToBase64(originalBytes, { urlSafe: true });
+
+      const decodedFromStandard = base64ToBytes(standardBase64);
+      const decodedFromUrlSafe = base64ToBytes(urlSafeBase64);
+
+      expect(decodedFromStandard).toEqual(originalBytes);
+      expect(decodedFromUrlSafe).toEqual(originalBytes);
+    });
+  });
+
+  describe("base64ToBytes", () => {
+    it("converts standard base64 to bytes", () => {
+      const base64 = "SGVsbG8=";
+      const result = base64ToBytes(base64);
+      expect(result).toEqual(new Uint8Array([72, 101, 108, 108, 111]));
+    });
+
+    it("converts URL-safe base64 to bytes", () => {
+      const base64 = "SGVsbG8";
+      const result = base64ToBytes(base64);
+      expect(result).toEqual(new Uint8Array([72, 101, 108, 108, 111]));
+    });
+
+    it("handles base64 with + and / characters", () => {
+      const base64 = "P/7/";
+      const result = base64ToBytes(base64);
+      expect(result).toEqual(new Uint8Array([63, 254, 255]));
+    });
+
+    it("handles URL-safe base64 with - and _ characters", () => {
+      const base64 = "P_7_";
+      const result = base64ToBytes(base64);
+      expect(result).toEqual(new Uint8Array([63, 254, 255]));
+    });
+  });
+
+  describe("round-trip compatibility", () => {
+    it("standard base64 round-trip", () => {
+      const originalBytes = new Uint8Array([255, 254, 253, 252, 251]);
+      const base64 = bytesToBase64(originalBytes);
+      const decodedBytes = base64ToBytes(base64);
+      expect(decodedBytes).toEqual(originalBytes);
+    });
+
+    it("URL-safe base64 round-trip", () => {
+      const originalBytes = new Uint8Array([255, 254, 253, 252, 251]);
+      const base64 = bytesToBase64(originalBytes, { urlSafe: true });
+      const decodedBytes = base64ToBytes(base64);
+      expect(decodedBytes).toEqual(originalBytes);
+    });
+
+    it("large byte array round-trip", () => {
+      const originalBytes = new Uint8Array(256).map((_, i) => i);
+      const standardBase64 = bytesToBase64(originalBytes);
+      const urlSafeBase64 = bytesToBase64(originalBytes, { urlSafe: true });
+
+      const decodedFromStandard = base64ToBytes(standardBase64);
+      const decodedFromUrlSafe = base64ToBytes(urlSafeBase64);
+
+      expect(decodedFromStandard).toEqual(originalBytes);
+      expect(decodedFromUrlSafe).toEqual(originalBytes);
+    });
+  });
+});


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->
<!--- For PRs that should increment the patch version, attach the label "bug-fix" or "improvement" -->
<!--- For PRs that should increment the minor version, no labels are required -->
<!--- For PRs that should increment the major version, attach the label "breaking-change" -->

## Description

Send subscription auth data encode as base 64 url safe.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
