### PR TITLE
Use only `npm ci` in CI actions

### DIFF
--- a/.github/workflows/ee-prd.yml
+++ b/.github/workflows/ee-prd.yml
@@ -87,9 +87,6 @@ jobs:
       - name: Store Alloy version into env
         uses: nyaa8/package-version@v1
 
-      - name: NPM Install
-        run: npm install
-
       - name: Install dependencies
         if: steps.npm-cache.outputs.cache-hit != 'true'
         run: npm ci

--- a/.github/workflows/pre-edge-deploy.yaml
+++ b/.github/workflows/pre-edge-deploy.yaml
@@ -74,9 +74,6 @@ jobs:
       - name: Store Alloy version into env
         uses: nyaa8/package-version@v1
 
-      - name: NPM Install
-        run: npm install
-
       - name: Install dependencies
         if: steps.npm-cache.outputs.cache-hit != 'true'
         run: npm ci


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->
<!--- For PRs that should increment the patch version, attach the label "bug-fix" or "improvement" -->
<!--- For PRs that should increment the minor version, no labels are required -->
<!--- For PRs that should increment the major version, attach the label "breaking-change" -->

## Description

<!--- Describe your changes in detail -->

In the past few weeks, there has been a slew of npm packages that, through phishing attacks, became malicious[1][2][3]. The attack is that these packages would be published with new `postinstall` scripts defined in the `package.json`. When the package is installed, either with `npm install` or `npm ci` and either locally or on a CI server, the `postinstall` script would run. These scripts would then exfiltrate secrets stored in the ENV. We have several secrets that would be bad to lose, like the NPM auth token, and it would be stolen by this attack. 

Alloy (and reaction-extension-alloy) is vulnerable to these attacks because

1. We, or a subdependency, use some of these packages that were hacked[4]
2. Our, or a subdependency, specifies the acceptable version number in a loose fashion
  * Example: `package.json` used to say that we depend on `"chalk": "^5.6.0",`. The malicious version was `5.6.1`. Because the version specifier contains `^`, then any [compatible version](https://github.com/npm/node-semver?tab=readme-ov-file#caret-ranges-123-025-004) greater than `.0` would be allowed, including `5.6.1`.
  * This specific malicious package was guarded against in #1363 (we now depend on `"chalk": "^5.6.2")

We can protect ourselves from this "malicious `postinstall` script attack" a few different ways:
1. Only use `npm ci` in CI actions. (What this PR currently does)
  * This would prevent vulnerability number 2, where the malicious version is silently included. `npm ci` only installs the exact version specified in the `package-lock.json`
  * This does not protect against running `npm install` locally and having local secrets exfiltrated.
2. Disable post-install scripts by putting `ignore-scripts=true` in `.npmrc`. 
  * This would break `puppeteer`
3. Switch to a different package manager that has more security features
  * `bun` [creates a list of trusted packages. Only those packages are allowed to run pre- and post-install scripts](https://bun.sh/docs/cli/add#trusted-dependencies)
  * `pnpm` [disallows running scripts without approval, by default.](https://pnpm.io/settings#dangerouslyallowallbuilds) Additionally, [`pnpm` recently (in response to these recent attacks) allows you to set a minimum age for package versions](https://pnpm.io/settings#minimumreleaseage)
  
**What we do depends on how worried we are about this. The intent of this PR is to start a discussion.**

Footnotes:
<ol>
  <li><a href="https://www.stepsecurity.io/blog/ctrl-tinycolor-and-40-npm-packages-compromised">https://www.stepsecurity.io/blog/ctrl-tinycolor-and-40-npm-packages-compromised</a></li>
  <li><a href="https://orca.security/resources/blog/s1ngularity-supply-chain-attack">https://orca.security/resources/blog/s1ngularity-supply-chain-attack</a>/</li>
  <li><a href="https://www.aikido.dev/blog/npm-debug-and-chalk-packages-compromised">https://www.aikido.dev/blog/npm-debug-and-chalk-packages-compromised</a></li>
<li>
  <details>
    <summary>For a full list of previously-hacked packages that we use, run this <code>npm ls</code> command</summary>
    <code><pre>
npm ls \
  @ahmedhfarag/ngx-perfect-scrollbar \
  @ahmedhfarag/ngx-virtual-scroller \
  @art-ws/common \
  @art-ws/config-eslint \
  @art-ws/config-ts \
  @art-ws/db-context \
  @art-ws/di \
  @art-ws/di-node \
  @art-ws/eslint \
  @art-ws/fastify-http-server \
  @art-ws/http-server \
  @art-ws/openapi \
  @art-ws/package-base \
  @art-ws/prettier \
  @art-ws/slf \
  @art-ws/ssl-info \
  @art-ws/web-app \
  @crowdstrike/commitlint \
  @crowdstrike/falcon-shoelace \
  @crowdstrike/foundry-js \
  @crowdstrike/glide-core \
  @crowdstrike/logscale-dashboard \
  @crowdstrike/logscale-file-editor \
  @crowdstrike/logscale-parser-edit \
  @crowdstrike/logscale-search \
  @crowdstrike/tailwind-toucan-base \
  @ctrl/deluge \
  @ctrl/golang-template \
  @ctrl/magnet-link \
  @ctrl/ngx-codemirror \
  @ctrl/ngx-csv \
  @ctrl/ngx-emoji-mart \
  @ctrl/ngx-rightclick \
  @ctrl/qbittorrent \
  @ctrl/react-adsense \
  @ctrl/shared-torrent \
  @ctrl/tinycolor \
  @ctrl/torrent-file \
  @ctrl/transmission \
  @ctrl/ts-base32 \
  @hestjs/core \
  @hestjs/cqrs \
  @hestjs/demo \
  @hestjs/eslint-config \
  @hestjs/logger \
  @hestjs/scalar \
  @hestjs/validation \
  @nativescript-community/arraybuffers \
  @nativescript-community/gesturehandler \
  @nativescript-community/perms \
  @nativescript-community/sentry \
  @nativescript-community/sqlite \
  @nativescript-community/text \
  @nativescript-community/typeorm \
  @nativescript-community/ui-collectionview \
  @nativescript-community/ui-document-picker \
  @nativescript-community/ui-drawer \
  @nativescript-community/ui-image \
  @nativescript-community/ui-label \
  @nativescript-community/ui-material-bottom-navigation \
  @nativescript-community/ui-material-bottomsheet \
  @nativescript-community/ui-material-core \
  @nativescript-community/ui-material-core-tabs \
  @nativescript-community/ui-material-ripple \
  @nativescript-community/ui-material-tabs \
  @nativescript-community/ui-pager \
  @nativescript-community/ui-pulltorefresh \
  @nexe/config-manager \
  @nexe/eslint-config \
  @nexe/logger \
  @nstudio/angular \
  @nstudio/focus \
  @nstudio/nativescript-checkbox \
  @nstudio/nativescript-loading-indicator \
  @nstudio/ui-collectionview \
  @nstudio/web \
  @nstudio/web-angular \
  @nstudio/xplat \
  @nstudio/xplat-utils \
  @nx/devkit \
  @nx/devkit \
  @nx/enterprise-cloud \
  @nx/js \
  @nx/key \
  @nx/node \
  @nx/workspace\
  @operato/board \
  @operato/data-grist \
  @operato/graphql \
  @operato/headroom \
  @operato/help \
  @operato/i18n \
  @operato/input \
  @operato/layout \
  @operato/popup \
  @operato/pull-to-refresh \
  @operato/shell \
  @operato/styles \
  @operato/utils \
  @teselagen/bounce-loader \
  @teselagen/liquibase-tools \
  @teselagen/range-utils \
  @teselagen/react-list \
  @teselagen/react-table \
  @thangved/callback-window \
  @things-factory/attachment-base \
  @things-factory/auth-base \
  @things-factory/email-base \
  @things-factory/env \
  @things-factory/integration-base \
  @things-factory/integration-marketplace \
  @things-factory/shell \
  @tnf-dev/api \
  @tnf-dev/core \
  @tnf-dev/js \
  @tnf-dev/mui \
  @tnf-dev/react \
  @ui-ux-gang/devextreme-angular-rpk \
  @yoobic/jpeg-camera-es6 \
  @yoobic/yobi \
  airchief \
  airpilot \
  angulartics2 \
  ansi-regex \
  ansi-styles \
  backslash \
  browser-webdriver-downloader \
  capacitor-notificationhandler \
  capacitor-plugin-healthapp \
  capacitor-plugin-ihealth \
  capacitor-plugin-vonage \
  capacitorandroidpermissions \
  chalk \
  chalk-template \
  color \
  color-convert \
  color-name \
  color-string \
  config-cordova \
  cordova-plugin-voxeet2 \
  cordova-voxeet \
  create-hest-app \
  db-evo \
  debug \
  devextreme-angular-rpk \
  ember-browser-services \
  ember-headless-form \
  ember-headless-form-yup \
  ember-headless-table \
  ember-url-hash-polyfill \
  ember-velcro \
  encounter-playground \
  error-ex \
  eslint-config-crowdstrike \
  eslint-config-crowdstrike-node \
  eslint-config-teselagen \
  globalize-rpk \
  graphql-sequelize-teselagen \
  has-ansi \
  html-to-base64-image \
  is-arrayish \
  json-rules-engine-simplified \
  jumpgate \
  koa2-swagger-ui \
  mcfly-semantic-release \
  mcp-knowledge-base \
  mcp-knowledge-graph \
  mobioffice-cli \
  monorepo-next \
  mstate-angular \
  mstate-cli \
  mstate-dev-react \
  mstate-react \
  ng2-file-upload \
  ngx-bootstrap \
  ngx-color \
  ngx-toastr \
  ngx-trend \
  ngx-ws \
  nx \
  oradm-to-gql \
  oradm-to-sqlz \
  ove-auto-annotate \
  pm2-gelf-json \
  printjs-rpk \
  proto-tinker-wc \
  react-complaint-image \
  react-jsonschema-form-conditionals \
  react-jsonschema-form-extras \
  remark-preset-lint-crowdstrike \
  rxnt-authentication \
  rxnt-healthchecks-nestjs \
  rxnt-kue \
  simple-swizzle \
  slice-ansi \
  strip-ansi \
  supports-color \
  supports-hyperlinks \
  swc-plugin-component-annotate \
  tbssnch \
  teselagen-interval-tree \
  tg-client-query-builder \
  tg-redbird \
  tg-seq-gen \
  thangved-react-grid \
  ts-gaussian \
  ts-imports \
  tvi-cli \
  ve-bamreader \
  ve-editor \
  voip-callkit \
  wdio-web-reporter \
  wrap-ansi \
  yargs-help-output \
  yoo-styles 
</pre></code>
  </details>
</li>

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.
