### PR TITLE
Added @adobe/alloy-node package scaffold

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -16,6 +16,7 @@ jobs:
           - build
           - lint
           - "format:check"
+          - typecheck
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,7 +28,7 @@ import license from "./scripts/eslint/licenseRule.js";
 const allComponentPaths = glob.sync("packages/core/src/components/*/");
 
 const sharedIgnores = [
-  "sandboxes/**",
+  "sandboxes/browser/**",
   "dist/**",
   "distTest/**",
   "packages/**/dist/**",
@@ -44,7 +44,7 @@ export default defineConfig([
   pluginJs.configs.recommended,
   eslintPluginPrettierRecommended,
   globalIgnores([
-    "sandboxes/**",
+    "sandboxes/browser/**",
     "node_modules/",
     "launch*.js",
     "packages/reactor-extension/dist/**",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -349,6 +349,21 @@ export default defineConfig([
     },
   },
   {
+    name: "alloy/node-sandbox",
+    files: ["sandboxes/node/src/**/*.{cjs,js,mjs}"],
+    settings: {
+      "import/core-modules": ["@adobe/alloy-node"],
+    },
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+    rules: {
+      "no-console": "off",
+    },
+  },
+  {
     name: "alloy/browser-sandbox",
     files: ["sandboxes/browser/src/**/*.{js,jsx}"],
     settings: {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write \"*.{html,js,cjs,mjs,jsx}\" \"{sandboxes/*/src,packages/*/{src,test,scripts},scripts}/**/*.{html,js,cjs,mjs,jsx}\"",
     "format:check": "prettier --check \"*.{html,js,cjs,mjs,jsx}\" \"{sandboxes/*/src,packages/*/{src,test,scripts},scripts}/**/*.{html,js,cjs,mjs,jsx}\"",
     "types": "tsc",
+    "typecheck": "pnpm --recursive --if-present run typecheck",
     "test": "pnpm exec playwright install chromium && vitest run",
     "test:coverage": "rimraf coverage && pnpm exec playwright install chromium && vitest run --coverage",
     "test:unit": "pnpm exec playwright install chromium && vitest run --project=core/unit --project=browser/unit --project=reactor-extension/unit",

--- a/packages/browser/UNIVERSAL_JS_MIGRATION.md
+++ b/packages/browser/UNIVERSAL_JS_MIGRATION.md
@@ -1,7 +1,7 @@
 This is the rough plan to migrate into the "Universal JavaScript SDK"
 
 - [x] create two packages - a `core` package for shared business logic and primatives, and a `browser` package for browser-specific functionality and APIs
-- [ ] Initialize nodejs sdk, with the understanding that it will not function until all the migrations are done
+- [x] Initialize nodejs sdk, with the understanding that it will not function until all the migrations are done
 - [ ] Migrate components whose purpose and functionality are entirely browser dependent. Ask "does this functionality work on a server?"
   - [x] `ActivityCollector`
   - [ ] `Context` -> rename to `BrowserContext`

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -1,0 +1,18 @@
+# @adobe/alloy-node
+
+> [!WARNING]
+> **Pre-alpha scaffold. Not functional. Do not use.**
+>
+> This package exists as a placeholder for the Universal JS migration.
+> It currently throws on import because `@adobe/alloy-core` still
+> references browser globals (`window`, `document`, `navigator`, etc.)
+> at module scope.
+>
+> Once the migration is complete, this package will provide a
+> `createInstance` that accepts platform services (network, storage,
+> cookie, runtime) and runs in Node.js.
+>
+> See [`packages/browser/UNIVERSAL_JS_MIGRATION.md`](../browser/UNIVERSAL_JS_MIGRATION.md)
+> for the migration plan and progress.
+
+Node.js entrypoint for the Adobe Experience Platform Web SDK.

--- a/packages/node/jsconfig.json
+++ b/packages/node/jsconfig.json
@@ -1,10 +1,15 @@
 {
   "extends": "../../jsconfig.base.json",
   "compilerOptions": {
-    "paths": {
-      "@adobe/alloy-core": ["../core/src/index.js"],
-      "@adobe/alloy-core/*": ["../core/src/*"]
-    }
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "maxNodeModuleJsDepth": 0,
+    "noEmit": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]

--- a/packages/node/jsconfig.json
+++ b/packages/node/jsconfig.json
@@ -9,7 +9,10 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "maxNodeModuleJsDepth": 0,
-    "noEmit": true
+    "noEmit": true,
+    "paths": {
+      "@adobe/alloy-core": ["./src/alloy-core.d.ts"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]

--- a/packages/node/jsconfig.json
+++ b/packages/node/jsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../jsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@adobe/alloy-core": ["../core/src/index.js"],
+      "@adobe/alloy-core/*": ["../core/src/*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -11,6 +11,9 @@
   },
   "author": "Adobe Inc.",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=18"
+  },
   "files": [
     "src",
     "README.md"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@adobe/alloy-node",
+  "version": "0.0.0",
+  "description": "Adobe Experience Platform Web SDK - Node.js entrypoint",
+  "type": "module",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adobe/alloy.git",
+    "directory": "packages/node"
+  },
+  "author": "Adobe Inc.",
+  "license": "Apache-2.0",
+  "files": [
+    "src"
+  ],
+  "exports": {
+    ".": {
+      "types": "./src/index.js",
+      "default": "./src/index.js"
+    }
+  },
+  "dependencies": {
+    "@adobe/alloy-core": "workspace:^"
+  }
+}

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -12,7 +12,8 @@
   "author": "Adobe Inc.",
   "license": "Apache-2.0",
   "files": [
-    "src"
+    "src",
+    "README.md"
   ],
   "exports": {
     ".": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -21,6 +21,9 @@
       "default": "./src/index.js"
     }
   },
+  "scripts": {
+    "typecheck": "tsc -p jsconfig.json"
+  },
   "dependencies": {
     "@adobe/alloy-core": "workspace:^"
   }

--- a/packages/node/src/alloy-core.d.ts
+++ b/packages/node/src/alloy-core.d.ts
@@ -1,0 +1,3 @@
+declare module "@adobe/alloy-core" {
+  export function createCustomInstance(options: Record<string, unknown>): unknown;
+}

--- a/packages/node/src/alloy-core.d.ts
+++ b/packages/node/src/alloy-core.d.ts
@@ -1,3 +1,6 @@
+// placeholder until @adobe/alloy-core passes a typecheck.
 declare module "@adobe/alloy-core" {
-  export function createCustomInstance(options: Record<string, unknown>): unknown;
+  export function createCustomInstance(
+    options: Record<string, unknown>,
+  ): unknown;
 }

--- a/packages/node/src/index.js
+++ b/packages/node/src/index.js
@@ -11,10 +11,20 @@ governing permissions and limitations under the License.
 */
 import { createCustomInstance } from "@adobe/alloy-core";
 
-export { createCustomInstance };
-
+/**
+ * @alpha
+ *
+ * Node.js entrypoint for the Adobe Experience Platform Web SDK.
+ *
+ * NOT FUNCTIONAL. This package is a scaffold for the Universal JS
+ * migration. Importing it currently throws because `@adobe/alloy-core`
+ * still references browser globals (`window`, `document`, etc.) at
+ * module scope. See packages/browser/UNIVERSAL_JS_MIGRATION.md.
+ */
 export const createInstance = (options = {}) =>
   createCustomInstance({
     ...options,
     components: [],
   });
+
+export { createCustomInstance };

--- a/packages/node/src/index.js
+++ b/packages/node/src/index.js
@@ -14,24 +14,10 @@ import { createCustomInstance } from "@adobe/alloy-core";
 /**
  * @alpha
  *
- * Node.js entrypoint for the Adobe Experience Platform Web SDK.
+ * Node.js entrypoint for the Adobe Experience Platform Node SDK.
  *
- * NOT FUNCTIONAL. This package is a scaffold for the Universal JS
- * migration. Importing it currently throws because `@adobe/alloy-core`
- * still references browser globals (`window`, `document`, etc.) at
- * module scope. See packages/browser/UNIVERSAL_JS_MIGRATION.md.
- *
- * Current signature: `createInstance(options)` — forwards to
- * `createCustomInstance` with an empty components array. Core today does
- * not accept any second argument.
- *
- * Anticipated signature drift: the migration plan (UNIVERSAL_JS_MIGRATION.md
- * §"Core entry points") has core entry points growing a second
- * `platformServices` parameter (`network`, `storage`, `cookie`, `runtime`,
- * `legacy`, `globals`). Once that lands, this wrapper will construct and
- * inject node-flavored services and a node context component here. The
- * exported shape (`createInstance(options)`) is expected to stay stable
- * for consumers.
+ * NOT FUNCTIONAL. Because @adobe/alloy-core still references browser globals
+ * and APIs, this package will throw errors at runtime.
  */
 export const createInstance = (options = {}) =>
   createCustomInstance({

--- a/packages/node/src/index.js
+++ b/packages/node/src/index.js
@@ -20,6 +20,18 @@ import { createCustomInstance } from "@adobe/alloy-core";
  * migration. Importing it currently throws because `@adobe/alloy-core`
  * still references browser globals (`window`, `document`, etc.) at
  * module scope. See packages/browser/UNIVERSAL_JS_MIGRATION.md.
+ *
+ * Current signature: `createInstance(options)` — forwards to
+ * `createCustomInstance` with an empty components array. Core today does
+ * not accept any second argument.
+ *
+ * Anticipated signature drift: the migration plan (UNIVERSAL_JS_MIGRATION.md
+ * §"Core entry points") has core entry points growing a second
+ * `platformServices` parameter (`network`, `storage`, `cookie`, `runtime`,
+ * `legacy`, `globals`). Once that lands, this wrapper will construct and
+ * inject node-flavored services and a node context component here. The
+ * exported shape (`createInstance(options)`) is expected to stay stable
+ * for consumers.
  */
 export const createInstance = (options = {}) =>
   createCustomInstance({

--- a/packages/node/src/index.js
+++ b/packages/node/src/index.js
@@ -1,0 +1,20 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { createCustomInstance } from "@adobe/alloy-core";
+
+export { createCustomInstance };
+
+export const createInstance = (options = {}) =>
+  createCustomInstance({
+    ...options,
+    components: [],
+  });

--- a/packages/node/test/integration/nodeConsumer.spec.js
+++ b/packages/node/test/integration/nodeConsumer.spec.js
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { describe, it, expect } from "vitest";
+
+// These tests simulate a Node.js application consuming @adobe/alloy-core
+// via the @adobe/alloy-node wrapper. They are skipped until the Universal
+// JS migration is complete — see packages/browser/UNIVERSAL_JS_MIGRATION.md.
+// Today they fail at module load because @adobe/alloy-core references
+// `window`, `document`, etc. at module scope.
+// eslint-disable-next-line vitest/no-disabled-tests -- skipped until Universal JS migration completes
+describe.skip("Node consumer integration", () => {
+  const config = {
+    orgId: "5BFE274A5F6980A50A495C08@AdobeOrg",
+    datastreamId: "bc1a10e0-aee4-4e0e-ac5b-cdbb9abbec83",
+    edgeDomain: "edge.adobedc.net",
+    edgeBasePath: "ee",
+    thirdPartyCookiesEnabled: false,
+    debugEnabled: false,
+  };
+
+  it("imports @adobe/alloy-core without throwing", async () => {
+    const mod = await import("@adobe/alloy-core");
+    expect(mod.createCustomInstance).toBeTypeOf("function");
+  });
+
+  it("imports @adobe/alloy-node without throwing", async () => {
+    const mod = await import("../../src/index.js");
+    expect(mod.createInstance).toBeTypeOf("function");
+  });
+
+  it("creates an instance", async () => {
+    const { createInstance } = await import("../../src/index.js");
+    const alloy = createInstance();
+    expect(alloy).toBeTypeOf("function");
+  });
+
+  it("configures an instance", async () => {
+    const { createInstance } = await import("../../src/index.js");
+    const alloy = createInstance();
+    await expect(alloy("configure", config)).resolves.toBeDefined();
+  });
+
+  it("sends an event", async () => {
+    const { createInstance } = await import("../../src/index.js");
+    const alloy = createInstance();
+    await alloy("configure", config);
+
+    const result = await alloy("sendEvent", {
+      xdm: {
+        eventType: "test.nodeConsumer",
+        _id: "00000000-0000-0000-0000-000000000000",
+      },
+    });
+
+    expect(result).toBeDefined();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,6 +353,12 @@ importers:
         specifier: ^2.3.2
         version: 2.16.4(@parcel/core@2.16.4(@swc/helpers@0.5.21))
 
+  packages/node:
+    dependencies:
+      '@adobe/alloy-core':
+        specifier: workspace:^
+        version: link:../core
+
   sandboxes/browser:
     dependencies:
       '@adobe/alloy':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,7 +188,7 @@ importers:
     dependencies:
       '@adobe/aep-rules-engine':
         specifier: ^3.1.1
-        version: 3.1.1(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(vitest@4.1.4(@types/node@24.10.4)(@vitest/browser-playwright@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(playwright@1.57.0)(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(@vitest/coverage-v8@4.1.2(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(vitest@4.1.2))(happy-dom@20.8.9)(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2)))
+        version: 3.1.1(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(vitest@3.2.4(@types/node@24.10.4)(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(happy-dom@20.8.9)(lightningcss@1.32.0)(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.2))
       '@adobe/reactor-query-string':
         specifier: ^2.0.0
         version: 2.0.0
@@ -198,6 +198,12 @@ importers:
       uuid:
         specifier: ^14.0.0
         version: 14.0.0
+
+  packages/node:
+    dependencies:
+      '@adobe/alloy-core':
+        specifier: workspace:^
+        version: link:../core
 
   packages/reactor-extension:
     dependencies:
@@ -353,12 +359,6 @@ importers:
         specifier: ^2.3.2
         version: 2.16.4(@parcel/core@2.16.4(@swc/helpers@0.5.21))
 
-  packages/node:
-    dependencies:
-      '@adobe/alloy-core':
-        specifier: workspace:^
-        version: link:../core
-
   sandboxes/browser:
     dependencies:
       '@adobe/alloy':
@@ -386,6 +386,12 @@ importers:
       vite:
         specifier: ^7.3.2
         version: 7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2)
+
+  sandboxes/node:
+    dependencies:
+      '@adobe/alloy-node':
+        specifier: workspace:*
+        version: link:../../packages/node
 
 packages:
 
@@ -4256,14 +4262,25 @@ packages:
       vitest:
         optional: true
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
   '@vitest/expect@4.0.6':
     resolution: {integrity: sha512-5j8UUlBVhOjhj4lR2Nt9sEV8b4WtbcYh8vnfhTNA2Kn5+smtevzjNq+xlBuVhnFGXiyPPNzGrOVvmyHWkS5QGg==}
 
   '@vitest/expect@4.1.2':
     resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
 
-  '@vitest/expect@4.1.4':
-    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   '@vitest/mocker@4.0.6':
     resolution: {integrity: sha512-3COEIew5HqdzBFEYN9+u0dT3i/NCwppLnO1HkjGfAP1Vs3vti1Hxm/MvcbC4DAn3Szo1M7M3otiAaT83jvqIjA==}
@@ -4287,16 +4304,8 @@ packages:
       vite:
         optional: true
 
-  '@vitest/mocker@4.1.4':
-    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
   '@vitest/pretty-format@4.0.6':
     resolution: {integrity: sha512-4vptgNkLIA1W1Nn5X4x8rLJBzPiJwnPc+awKtfBE5hNMVsoAl/JCCPPzNrbf+L4NKgklsis5Yp2gYa+XAS442g==}
@@ -4304,8 +4313,8 @@ packages:
   '@vitest/pretty-format@4.1.2':
     resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
 
-  '@vitest/pretty-format@4.1.4':
-    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
   '@vitest/runner@4.0.6':
     resolution: {integrity: sha512-trPk5qpd7Jj+AiLZbV/e+KiiaGXZ8ECsRxtnPnCrJr9OW2mLB72Cb824IXgxVz/mVU3Aj4VebY+tDTPn++j1Og==}
@@ -4313,8 +4322,8 @@ packages:
   '@vitest/runner@4.1.2':
     resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
 
-  '@vitest/runner@4.1.4':
-    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
   '@vitest/snapshot@4.0.6':
     resolution: {integrity: sha512-PaYLt7n2YzuvxhulDDu6c9EosiRuIE+FI2ECKs6yvHyhoga+2TBWI8dwBjs+IeuQaMtZTfioa9tj3uZb7nev1g==}
@@ -4322,8 +4331,8 @@ packages:
   '@vitest/snapshot@4.1.2':
     resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
 
-  '@vitest/snapshot@4.1.4':
-    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
   '@vitest/spy@4.0.6':
     resolution: {integrity: sha512-g9jTUYPV1LtRPRCQfhbMintW7BTQz1n6WXYQYRQ25qkyffA4bjVXjkROokZnv7t07OqfaFKw1lPzqKGk1hmNuQ==}
@@ -4331,17 +4340,14 @@ packages:
   '@vitest/spy@4.1.2':
     resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
 
-  '@vitest/spy@4.1.4':
-    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vitest/utils@4.0.6':
     resolution: {integrity: sha512-bG43VS3iYKrMIZXBo+y8Pti0O7uNju3KvNn6DrQWhQQKcLavMB+0NZfO1/QBAEbq0MaQ3QjNsnnXlGQvsh0Z6A==}
 
   '@vitest/utils@4.1.2':
     resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
-
-  '@vitest/utils@4.1.4':
-    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
   '@zeit/schemas@2.36.0':
     resolution: {integrity: sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==}
@@ -4773,6 +4779,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -4803,6 +4813,10 @@ packages:
     resolution: {integrity: sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==}
     engines: {node: '>=4'}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -4832,6 +4846,10 @@ packages:
 
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -5138,6 +5156,10 @@ packages:
   deep-eql@3.0.1:
     resolution: {integrity: sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==}
     engines: {node: '>=0.12'}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-equal@2.2.3:
     resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
@@ -6565,6 +6587,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -7097,6 +7122,10 @@ packages:
 
   pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -8126,9 +8155,6 @@ packages:
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
-  std-env@4.1.0:
-    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
-
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -8215,6 +8241,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
@@ -8338,10 +8367,6 @@ packages:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
 
-  tinyexec@1.1.1:
-    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
-    engines: {node: '>=18'}
-
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -8349,6 +8374,10 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
@@ -8360,6 +8389,10 @@ packages:
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.14:
@@ -8628,6 +8661,11 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite@7.1.12:
     resolution: {integrity: sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -8722,6 +8760,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vitest@4.0.6:
     resolution: {integrity: sha512-gR7INfiVRwnEOkCk47faros/9McCZMp5LM+OMNWGLaDBSvJxIzwjgNFufkuePBNaesGRnLmNfW+ddbUJRZn0nQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -8783,47 +8849,6 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-
-  vitest@4.1.4:
-    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.4
-      '@vitest/browser-preview': 4.1.4
-      '@vitest/browser-webdriverio': 4.1.4
-      '@vitest/coverage-istanbul': 4.1.4
-      '@vitest/coverage-v8': 4.1.4
-      '@vitest/ui': 4.1.4
-      happy-dom: '*'
-      jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@opentelemetry/api':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser-playwright':
-        optional: true
-      '@vitest/browser-preview':
-        optional: true
-      '@vitest/browser-webdriverio':
-        optional: true
-      '@vitest/coverage-istanbul':
-        optional: true
-      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -8984,9 +9009,9 @@ packages:
 
 snapshots:
 
-  '@adobe/aep-rules-engine@3.1.1(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(vitest@4.1.4(@types/node@24.10.4)(@vitest/browser-playwright@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(playwright@1.57.0)(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(@vitest/coverage-v8@4.1.2(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(vitest@4.1.2))(happy-dom@20.8.9)(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2)))':
+  '@adobe/aep-rules-engine@3.1.1(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(vitest@3.2.4(@types/node@24.10.4)(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(happy-dom@20.8.9)(lightningcss@1.32.0)(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.2))':
     dependencies:
-      '@vitest/coverage-v8': 3.2.4(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(vitest@4.1.4(@types/node@24.10.4)(@vitest/browser-playwright@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(playwright@1.57.0)(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(@vitest/coverage-v8@4.1.2(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(vitest@4.1.2))(happy-dom@20.8.9)(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2)))
+      '@vitest/coverage-v8': 3.2.4(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(vitest@3.2.4(@types/node@24.10.4)(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(happy-dom@20.8.9)(lightningcss@1.32.0)(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - '@vitest/browser'
       - supports-color
@@ -18862,7 +18887,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@3.2.4(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(vitest@4.1.4(@types/node@24.10.4)(@vitest/browser-playwright@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(playwright@1.57.0)(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(@vitest/coverage-v8@4.1.2(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(vitest@4.1.2))(happy-dom@20.8.9)(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2)))':
+  '@vitest/coverage-v8@3.2.4(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(vitest@3.2.4(@types/node@24.10.4)(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(happy-dom@20.8.9)(lightningcss@1.32.0)(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -18877,7 +18902,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 4.1.4(@types/node@24.10.4)(@vitest/browser-playwright@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(playwright@1.57.0)(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(@vitest/coverage-v8@4.1.2(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(vitest@4.1.2))(happy-dom@20.8.9)(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))
+      vitest: 3.2.4(@types/node@24.10.4)(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(happy-dom@20.8.9)(lightningcss@1.32.0)(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.2)
     optionalDependencies:
       '@vitest/browser': 4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2)
     transitivePeerDependencies:
@@ -18910,6 +18935,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
   '@vitest/expect@4.0.6':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -18928,14 +18961,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/expect@4.1.4':
+  '@vitest/mocker@3.2.4(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))':
     dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.4
-      '@vitest/utils': 4.1.4
-      chai: 6.2.2
-      tinyrainbow: 3.1.0
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.13.2(@types/node@24.10.4)(typescript@5.9.3)
+      vite: 7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2)
 
   '@vitest/mocker@4.0.6(msw@2.11.6(@types/node@24.10.4)(typescript@5.9.3))(vite@7.1.12(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))':
     dependencies:
@@ -18955,14 +18988,9 @@ snapshots:
       msw: 2.13.2(@types/node@24.10.4)(typescript@5.9.3)
       vite: 7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2)
 
-  '@vitest/mocker@4.1.4(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))':
+  '@vitest/pretty-format@3.2.4':
     dependencies:
-      '@vitest/spy': 4.1.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.13.2(@types/node@24.10.4)(typescript@5.9.3)
-      vite: 7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2)
+      tinyrainbow: 2.0.0
 
   '@vitest/pretty-format@4.0.6':
     dependencies:
@@ -18972,9 +19000,11 @@ snapshots:
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/pretty-format@4.1.4':
+  '@vitest/runner@3.2.4':
     dependencies:
-      tinyrainbow: 3.1.0
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
 
   '@vitest/runner@4.0.6':
     dependencies:
@@ -18986,9 +19016,10 @@ snapshots:
       '@vitest/utils': 4.1.2
       pathe: 2.0.3
 
-  '@vitest/runner@4.1.4':
+  '@vitest/snapshot@3.2.4':
     dependencies:
-      '@vitest/utils': 4.1.4
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/snapshot@4.0.6':
@@ -19004,18 +19035,19 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.4':
+  '@vitest/spy@3.2.4':
     dependencies:
-      '@vitest/pretty-format': 4.1.4
-      '@vitest/utils': 4.1.4
-      magic-string: 0.30.21
-      pathe: 2.0.3
+      tinyspy: 4.0.4
 
   '@vitest/spy@4.0.6': {}
 
   '@vitest/spy@4.1.2': {}
 
-  '@vitest/spy@4.1.4': {}
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vitest/utils@4.0.6':
     dependencies:
@@ -19025,12 +19057,6 @@ snapshots:
   '@vitest/utils@4.1.2':
     dependencies:
       '@vitest/pretty-format': 4.1.2
-      convert-source-map: 2.0.0
-      tinyrainbow: 3.1.0
-
-  '@vitest/utils@4.1.4':
-    dependencies:
-      '@vitest/pretty-format': 4.1.4
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -19525,6 +19551,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -19559,6 +19587,14 @@ snapshots:
       pathval: 1.1.1
       type-detect: 4.1.0
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chai@6.2.2: {}
 
   chalk-template@0.4.0:
@@ -19585,6 +19621,8 @@ snapshots:
   check-error@1.0.3:
     dependencies:
       get-func-name: 2.0.2
+
+  check-error@2.1.3: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -19846,6 +19884,8 @@ snapshots:
   deep-eql@3.0.1:
     dependencies:
       type-detect: 4.1.0
+
+  deep-eql@5.0.2: {}
 
   deep-equal@2.2.3:
     dependencies:
@@ -21558,6 +21598,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lru-cache@10.4.3: {}
 
   lru-cache@11.0.2: {}
@@ -22089,6 +22131,8 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@1.1.1: {}
+
+  pathval@2.0.1: {}
 
   pend@1.2.0: {}
 
@@ -23677,8 +23721,6 @@ snapshots:
 
   std-env@4.0.0: {}
 
-  std-env@4.1.0: {}
-
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -23791,6 +23833,10 @@ snapshots:
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   style-mod@4.1.3: {}
 
@@ -24077,8 +24123,6 @@ snapshots:
 
   tinyexec@1.0.2: {}
 
-  tinyexec@1.1.1: {}
-
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
@@ -24089,11 +24133,15 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinypool@1.1.1: {}
+
   tinyrainbow@2.0.0: {}
 
   tinyrainbow@3.0.3: {}
 
   tinyrainbow@3.1.0: {}
+
+  tinyspy@4.0.4: {}
 
   tldts-core@7.0.14: {}
 
@@ -24328,6 +24376,27 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite-node@3.2.4(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite@7.1.12(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.11
@@ -24365,6 +24434,49 @@ snapshots:
       vitest: 4.1.2(@types/node@24.10.4)(@vitest/browser-playwright@4.1.2)(happy-dom@20.8.9)(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))
     optionalDependencies:
       '@types/react': 19.2.14
+
+  vitest@3.2.4(@types/node@24.10.4)(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(happy-dom@20.8.9)(lightningcss@1.32.0)(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.2):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.10.4
+      '@vitest/browser': 4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2)
+      happy-dom: 20.8.9
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@4.0.6(@types/node@24.10.4)(@vitest/browser-playwright@4.0.6)(happy-dom@20.8.9)(lightningcss@1.32.0)(msw@2.11.6(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.2):
     dependencies:
@@ -24431,36 +24543,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.4
       '@vitest/browser-playwright': 4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(playwright@1.57.0)(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2)
-      happy-dom: 20.8.9
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.4(@types/node@24.10.4)(@vitest/browser-playwright@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(playwright@1.57.0)(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(@vitest/coverage-v8@4.1.2(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(vitest@4.1.2))(happy-dom@20.8.9)(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2)):
-    dependencies:
-      '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))
-      '@vitest/pretty-format': 4.1.4
-      '@vitest/runner': 4.1.4
-      '@vitest/snapshot': 4.1.4
-      '@vitest/spy': 4.1.4
-      '@vitest/utils': 4.1.4
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.1
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 24.10.4
-      '@vitest/browser-playwright': 4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(playwright@1.57.0)(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2)
-      '@vitest/coverage-v8': 4.1.2(@vitest/browser@4.1.2(msw@2.13.2(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))(vitest@4.1.2))(vitest@4.1.2)
       happy-dom: 20.8.9
     transitivePeerDependencies:
       - msw

--- a/sandboxes/node/README.md
+++ b/sandboxes/node/README.md
@@ -1,0 +1,20 @@
+# @adobe/alloy-sandbox-node
+
+> [!WARNING]
+> **Does not run today.** `@adobe/alloy-node` re-exports from
+> `@adobe/alloy-core`, which still references browser globals (`window`,
+> `document`, `navigator`, etc.) at module scope. Running `pnpm start`
+> currently throws at import. This sandbox exists to prove out the
+> consumer API shape and become the first working smoke test once the
+> [Universal JS migration](../../packages/browser/UNIVERSAL_JS_MIGRATION.md)
+> lands.
+
+Bare-bones Node.js example for `@adobe/alloy-node`. Mirrors the skipped
+integration suite in `packages/node/test/integration/nodeConsumer.spec.js`.
+
+## Run
+
+```sh
+pnpm install
+pnpm --filter @adobe/alloy-sandbox-node start
+```

--- a/sandboxes/node/package.json
+++ b/sandboxes/node/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@adobe/alloy-sandbox-node",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@10.20.0",
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "start": "node src/index.js"
+  },
+  "dependencies": {
+    "@adobe/alloy-node": "workspace:*"
+  }
+}

--- a/sandboxes/node/src/index.js
+++ b/sandboxes/node/src/index.js
@@ -1,3 +1,14 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
 import { createInstance } from "@adobe/alloy-node";
 
 const alloy = createInstance();

--- a/sandboxes/node/src/index.js
+++ b/sandboxes/node/src/index.js
@@ -1,0 +1,20 @@
+import { createInstance } from "@adobe/alloy-node";
+
+const alloy = createInstance();
+
+await alloy("configure", {
+  orgId: "5BFE274A5F6980A50A495C08@AdobeOrg",
+  datastreamId: "bc1a10e0-aee4-4e0e-ac5b-cdbb9abbec83",
+  edgeDomain: "edge.adobedc.net",
+  edgeBasePath: "ee",
+  thirdPartyCookiesEnabled: false,
+  debugEnabled: true,
+});
+
+const result = await alloy("sendEvent", {
+  xdm: {
+    eventType: "demo.nodeSandbox",
+  },
+});
+
+console.log(JSON.stringify(result, null, 2));

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -25,6 +25,18 @@ export default defineConfig({
       {
         extends: false,
         test: {
+          name: "node-integration",
+          include: [
+            "packages/node/test/integration/**/*.{test,spec}.?(c|m)[jt]s?(x)",
+          ],
+          isolate: false,
+          pool: "threads",
+          environment: "node",
+        },
+      },
+      {
+        extends: false,
+        test: {
           name: "scripts",
           include: [
             "scripts/**/*.{test,spec}.?(c|m)[jt]s?(x)",


### PR DESCRIPTION
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Description

Scaffolds a new `@adobe/alloy-node` workspace package as the eventual Node.js entrypoint for the Web SDK, plus a matching bare-bones sandbox at `sandboxes/node`. The package is marked **pre-alpha / non-functional**: importing it today throws because `@adobe/alloy-core` still references browser globals (`window`, `document`, `navigator`, etc.) at module scope. This PR is purely the starting point — no component moves, no service abstractions, no core refactors.

What's here:

- `packages/node/` — ESM package, `engines.node: ">=18"`, `createInstance(options)` forwarding to `createCustomInstance` with an empty components array.
- README + JSDoc warn it's non-functional and document the anticipated `(options, platformServices)` signature drift per `UNIVERSAL_JS_MIGRATION.md`.
- Ambient `alloy-core.d.ts` type shim + `jsconfig.json` with `paths` mapping so `tsc` doesn't walk into the real core sources (avoids hundreds of unrelated TS errors).
- `sandboxes/node/` — minimal consumer example mirroring the skipped integration suite (`configure` + `sendEvent` + log). Throws today; unblocks the moment core becomes import-safe.
- Node integration vitest project (`environment: "node"`, `pool: "threads"`) with a `describe.skip` consumer suite.
- `typecheck` added to the Alloy Dev GitHub workflow so regressions in the new `jsconfig.json` don't sneak through.

## Related Issue

N/A — scaffolding work; follows the "Node SDK package" future-phase item in `packages/browser/UNIVERSAL_JS_MIGRATION.md`.

## Motivation and Context

The Universal JS migration plan calls out a Node SDK package as a future phase blocked on core portability + async storage. Landing the empty package + sandbox now gives the migration a concrete consumer target to validate against (and a first working smoke test the moment core stops touching `window` at module scope). It also forces us to stake out the public shape (`createInstance(options)`) and the test harness before the substantive work starts.

## Screenshots (if appropriate):

N/A — no runtime behavior yet.

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully. (The new Node sandbox throws at import by design — same blocker as the skipped integration tests, documented in its README.)
- [x] I have added a Changeset (`pnpm changeset`) or it is not necessary because this PR is not consumer-facing. (Package is `"private": true` and pre-alpha; no consumer-facing change.)