### PR TITLE
Enhancements to read adobe_mc from malformed URIs

### DIFF
--- a/.changeset/lemon-snails-chew.md
+++ b/.changeset/lemon-snails-chew.md
@@ -1,0 +1,5 @@
+---
+"@adobe/alloy-core": patch
+---
+
+Added enhancements for detecting and decoding adobe_mc in the URI

--- a/packages/core/src/components/Identity/index.js
+++ b/packages/core/src/components/Identity/index.js
@@ -88,6 +88,7 @@ const createIdentity = ({
   const addQueryStringIdentityToPayload = injectAddQueryStringIdentityToPayload(
     {
       locationSearch: window.document.location.search,
+      locationHash: window.document.location.hash,
       dateProvider: () => new Date(),
       orgId,
       logger,

--- a/packages/core/src/components/Identity/injectAddQueryStringIdentityToPayload.js
+++ b/packages/core/src/components/Identity/injectAddQueryStringIdentityToPayload.js
@@ -18,25 +18,41 @@ import ecidNamespace from "../../constants/ecidNamespace.js";
 import decodeUriComponentSafely from "../../utils/decodeUriComponentSafely.js";
 
 const LINK_TTL_SECONDS = 300; // 5 minute link time to live
+const QUERY_TOKEN = "?";
 
-export default ({ locationSearch, dateProvider, orgId, logger }) =>
+export default ({
+    locationSearch,
+    locationHash,
+    dateProvider,
+    orgId,
+    logger,
+  }) =>
   (payload) => {
     if (payload.hasIdentity(ecidNamespace)) {
       // don't overwrite a user provided ecid identity
       return;
     }
 
-    const parsedQueryString = queryString.parse(locationSearch);
-    let queryStringValue = parsedQueryString[queryStringIdentityParam];
+    let queryStringValue =
+      queryString.parse(locationSearch)[queryStringIdentityParam] ??
+      queryString.parse(locationHash.slice(locationHash.indexOf(QUERY_TOKEN)))[
+        queryStringIdentityParam
+      ];
 
     if (queryStringValue === undefined) {
       return;
     }
     if (Array.isArray(queryStringValue)) {
       logger.warn(
-        "Found multiple adobe_mc query string paramters, only using the last one.",
+        "Found multiple adobe_mc query string parameters, only using the last one.",
       );
       queryStringValue = queryStringValue[queryStringValue.length - 1];
+    }
+
+    let prev = "";
+    while (prev !== queryStringValue) {
+      prev = queryStringValue;
+      queryStringValue = decodeUriComponentSafely(queryStringValue);
     }
 
     const properties = queryStringValue.split("|").reduce((memo, keyValue) => {

--- a/packages/core/test/unit/specs/components/Identity/injectAddQueryStringIdentityToPayload.spec.js
+++ b/packages/core/test/unit/specs/components/Identity/injectAddQueryStringIdentityToPayload.spec.js
@@ -18,6 +18,7 @@ import createConsentRequestPayload from "../../../../../src/components/Consent/c
 
 describe("Identity::injectAddQueryStringIdentityToPayload", () => {
   let locationSearch;
+  let locationHash;
   let dateProvider;
   let orgId;
   let logger;
@@ -27,6 +28,7 @@ describe("Identity::injectAddQueryStringIdentityToPayload", () => {
     dateProvider = () => date;
     locationSearch =
       "?foo=bar&adobe_mc=TS%3D1641432103%7CMCMID%3D77094828402023918047117570965393734545%7CMCORGID%3DFAF554945B90342F0A495E2C%40AdobeOrg&a=b";
+    locationHash = "";
     date = new Date(1641432103 * 1000);
     orgId = "FAF554945B90342F0A495E2C@AdobeOrg";
     logger = {
@@ -37,6 +39,7 @@ describe("Identity::injectAddQueryStringIdentityToPayload", () => {
   const run = () => {
     injectAddQueryStringIdentityToPayload({
       locationSearch,
+      locationHash,
       dateProvider,
       orgId,
       logger,
@@ -172,6 +175,52 @@ describe("Identity::injectAddQueryStringIdentityToPayload", () => {
       expect(payload.addIdentity).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalled();
       expect(logger.info).toHaveBeenCalled();
+    });
+    it("reads an identity from the hash when not present in search", () => {
+      locationSearch = "";
+      locationHash = `#/some/path?adobe_mc=${encodeURIComponent("TS=1641432103|MCMID=77094828402023918047117570965393734545|MCORGID=FAF554945B90342F0A495E2C@AdobeOrg")}`;
+      run();
+      expect(payload.addIdentity).toHaveBeenNthCalledWith(1, "ECID", {
+        id: "77094828402023918047117570965393734545",
+      });
+    });
+    it("prefers the identity from search over the hash", () => {
+      locationHash = `#/some/path?adobe_mc=${encodeURIComponent("TS=1641432103|MCMID=identity-from-hash|MCORGID=FAF554945B90342F0A495E2C@AdobeOrg")}`;
+      run();
+      expect(payload.addIdentity).toHaveBeenNthCalledWith(1, "ECID", {
+        id: "77094828402023918047117570965393734545",
+      });
+    });
+    it("does not find identity when hash has no query string", () => {
+      locationSearch = "";
+      locationHash = "#/some/path-without-query-string";
+      run();
+      expect(payload.addIdentity).not.toHaveBeenCalled();
+    });
+    it("reads a double-encoded identity", () => {
+      const doubleEncoded = encodeURIComponent(
+        encodeURIComponent(
+          "TS=1641432103|MCMID=77094828402023918047117570965393734545|MCORGID=FAF554945B90342F0A495E2C@AdobeOrg",
+        ),
+      );
+      locationSearch = `?adobe_mc=${doubleEncoded}`;
+      run();
+      expect(payload.addIdentity).toHaveBeenNthCalledWith(1, "ECID", {
+        id: "77094828402023918047117570965393734545",
+      });
+    });
+    it("reads a double-encoded identity from the hash", () => {
+      const doubleEncoded = encodeURIComponent(
+        encodeURIComponent(
+          "TS=1641432103|MCMID=77094828402023918047117570965393734545|MCORGID=FAF554945B90342F0A495E2C@AdobeOrg",
+        ),
+      );
+      locationSearch = "";
+      locationHash = `#/some/path?adobe_mc=${doubleEncoded}`;
+      run();
+      expect(payload.addIdentity).toHaveBeenNthCalledWith(1, "ECID", {
+        id: "77094828402023918047117570965393734545",
+      });
     });
   });
 });


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Changed Packages
<!--- Indicate which package your changes directly affect. -->
<!--- (i.e., do not choose the extension if it's only change is updating its core version). -->
- [x] core
- [ ] reactor-extension 

## Description

Implemented two "enhancements" for reading identity (`adobe_mc`) from URI query parameters:
1. Attempts to read when query parameter in location.hash (only when parameter does not exist in location.search)
2. Attempts to read when the value is "over-encoded" (been encoded more than once)

## Related Issue

[Jira 1](https://jira.corp.adobe.com/browse/PDCL-15610)
[Jira 2](https://jira.corp.adobe.com/browse/PDCL-15611)

## Motivation and Context

Issue 1 seems to be an issue for some SPA implemented in React, 

## Screenshots (if appropriate):
N/A

## Documentation
No. Arguably this fixes a regression (at least for issue 1) because this "used to work" with a previous feature.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- A changeset file is required for the PR. To add a changeset file, run `pnpm changset` and follow the prompts. -->
<!--- If your changes are not consumer facing, use `pnpm changeset --empty` to add an empty changeset file. -->
<!--- For more information about the changesets or the release process, see https://github.com/adobe/alloy/wiki/Release-process -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added a Changeset file with a consumer-facing description of my changes.
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
