### PR TITLE
Do not send advertising data when advertising is unconfigured

### DIFF
--- a/.changeset/quiet-trackers-skip.md
+++ b/.changeset/quiet-trackers-skip.md
@@ -1,0 +1,5 @@
+---
+"@adobe/alloy-core": patch
+---
+
+Skip advertising identity resolution (Surfer ID, ID5, RampID) on `sendEvent` when no enabled `advertiserSettings` are configured. Previously, every event would load third-party scripts and inject iframes even when there was no advertiser to stitch identities to.

--- a/packages/core/src/components/Advertising/handlers/createOnBeforeSendEventHandler.js
+++ b/packages/core/src/components/Advertising/handlers/createOnBeforeSendEventHandler.js
@@ -39,6 +39,7 @@ const waitForAdvertisingId = (advertising) => {
  * @param {Function} dependencies.appendAdvertisingIdQueryToEvent
  * @param {Function} dependencies.getUrlParams
  * @param {Function} dependencies.isThrottled
+ * @param {Function} dependencies.normalizeAdvertiser
  */
 export default ({
   cookieManager,
@@ -52,6 +53,7 @@ export default ({
   appendAdvertisingIdQueryToEvent,
   getUrlParams,
   isThrottled,
+  normalizeAdvertiser,
 }) => {
   /**
    * Appends advertising identity IDs to AEP event query if not already added.
@@ -68,9 +70,15 @@ export default ({
     }
     const { skwcid, efid } = getUrlParams();
     const isClickThru = !!(skwcid && efid);
+    // Skip identity resolution when no enabled advertiser IDs are configured —
+    // there is nothing meaningful to enrich the event with downstream.
+    const activeAdvertiserIds = normalizeAdvertiser(
+      componentConfig?.advertiserSettings,
+    );
     if (
       isAdvertisingDisabled(advertising) ||
       isClickThru ||
+      !activeAdvertiserIds ||
       (isThrottled(SURFER_ID, cookieManager) &&
         isThrottled(ID5_ID, cookieManager) &&
         isThrottled(RAMP_ID, cookieManager))

--- a/packages/core/src/components/Advertising/handlers/createOnBeforeSendEventHandler.js
+++ b/packages/core/src/components/Advertising/handlers/createOnBeforeSendEventHandler.js
@@ -75,10 +75,11 @@ export default ({
     const activeAdvertiserIds = normalizeAdvertiser(
       componentConfig?.advertiserSettings,
     );
+    const hasAdvertiserIds = activeAdvertiserIds.length > 0;
     if (
       isAdvertisingDisabled(advertising) ||
       isClickThru ||
-      !activeAdvertiserIds ||
+      !hasAdvertiserIds ||
       (isThrottled(SURFER_ID, cookieManager) &&
         isThrottled(ID5_ID, cookieManager) &&
         isThrottled(RAMP_ID, cookieManager))

--- a/packages/core/src/components/Advertising/index.js
+++ b/packages/core/src/components/Advertising/index.js
@@ -27,6 +27,7 @@ import {
   appendAdvertisingIdQueryToEvent,
   getUrlParams,
   isThrottled,
+  normalizeAdvertiser,
 } from "./utils/helpers.js";
 
 const createAdvertising = ({
@@ -62,6 +63,7 @@ const createAdvertising = ({
     appendAdvertisingIdQueryToEvent,
     getUrlParams,
     isThrottled,
+    normalizeAdvertiser,
   });
   const sendAdConversionHandler = createSendAdConversion({
     eventManager,

--- a/packages/core/test/unit/specs/components/Advertising/handlers/createOnBeforeSendEventHandler.spec.js
+++ b/packages/core/test/unit/specs/components/Advertising/handlers/createOnBeforeSendEventHandler.spec.js
@@ -28,6 +28,7 @@ describe("Advertising::createOnBeforeSendEventHandler", () => {
   let appendAdvertisingIdQueryToEventFn;
   let getUrlParamsFn;
   let isThrottledFn;
+  let normalizeAdvertiserFn;
 
   beforeEach(() => {
     cookieManager = {
@@ -84,6 +85,10 @@ describe("Advertising::createOnBeforeSendEventHandler", () => {
     });
     getUrlParamsFn = vi.fn().mockReturnValue({ skwcid: null, efid: null });
     isThrottledFn = vi.fn().mockReturnValue(false);
+    // Default to a truthy advertiser id so the new "no advertiser" gate
+    // does not short-circuit the existing tests. Individual tests can
+    // override this via `normalizeAdvertiserFn.mockReturnValueOnce("")`.
+    normalizeAdvertiserFn = vi.fn().mockReturnValue("adv-1");
 
     onBeforeEvent = createOnBeforeSendEventHandler({
       cookieManager,
@@ -97,6 +102,7 @@ describe("Advertising::createOnBeforeSendEventHandler", () => {
       appendAdvertisingIdQueryToEvent: appendAdvertisingIdQueryToEventFn,
       getUrlParams: getUrlParamsFn,
       isThrottled: isThrottledFn,
+      normalizeAdvertiser: normalizeAdvertiserFn,
     });
   });
 
@@ -207,6 +213,67 @@ describe("Advertising::createOnBeforeSendEventHandler", () => {
     expect(collectSurferIdFn).not.toHaveBeenCalled();
     expect(getID5IdFn).not.toHaveBeenCalled();
     expect(getRampIdFn).not.toHaveBeenCalled();
+  });
+
+  describe("activeAdvertiserIds gate", () => {
+    it("returns early when advertiserSettings is missing", async () => {
+      normalizeAdvertiserFn.mockReturnValueOnce("");
+
+      await onBeforeEvent({
+        event,
+        advertising: { handleAdvertisingData: "auto" },
+      });
+
+      expect(collectSurferIdFn).not.toHaveBeenCalled();
+      expect(getID5IdFn).not.toHaveBeenCalled();
+      expect(getRampIdFn).not.toHaveBeenCalled();
+      expect(event.mergeQuery).not.toHaveBeenCalled();
+    });
+
+    it("returns early when advertiserSettings is an empty array", async () => {
+      normalizeAdvertiserFn.mockReturnValueOnce("");
+
+      await onBeforeEvent({
+        event,
+        advertising: { handleAdvertisingData: "auto" },
+      });
+
+      expect(collectSurferIdFn).not.toHaveBeenCalled();
+      expect(getID5IdFn).not.toHaveBeenCalled();
+      expect(getRampIdFn).not.toHaveBeenCalled();
+      expect(event.mergeQuery).not.toHaveBeenCalled();
+    });
+
+    it("returns early when all advertiser entries are disabled", async () => {
+      normalizeAdvertiserFn.mockReturnValueOnce("");
+
+      await onBeforeEvent({
+        event,
+        advertising: { handleAdvertisingData: "auto" },
+      });
+
+      expect(collectSurferIdFn).not.toHaveBeenCalled();
+      expect(getID5IdFn).not.toHaveBeenCalled();
+      expect(getRampIdFn).not.toHaveBeenCalled();
+      expect(event.mergeQuery).not.toHaveBeenCalled();
+    });
+
+    it("proceeds with identity resolution when at least one advertiser is enabled", async () => {
+      normalizeAdvertiserFn.mockReturnValueOnce("adv-1");
+      collectSurferIdFn.mockResolvedValue("test-surfer-id");
+      getID5IdFn.mockResolvedValue("test-id5-id");
+      getRampIdFn.mockResolvedValue("test-ramp-id");
+
+      await onBeforeEvent({
+        event,
+        advertising: { handleAdvertisingData: "auto" },
+      });
+
+      expect(collectSurferIdFn).toHaveBeenCalled();
+      expect(getID5IdFn).toHaveBeenCalled();
+      expect(getRampIdFn).toHaveBeenCalled();
+      expect(event.mergeQuery).toHaveBeenCalled();
+    });
   });
 
   it("logs when unexpected errors are thrown", async () => {

--- a/packages/core/test/unit/specs/components/Advertising/handlers/createOnBeforeSendEventHandler.spec.js
+++ b/packages/core/test/unit/specs/components/Advertising/handlers/createOnBeforeSendEventHandler.spec.js
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import { vi, beforeEach, describe, it, expect } from "vitest";
 import { CHROME } from "../../../../../../src/constants/browser.js";
 import createOnBeforeSendEventHandler from "../../../../../../src/components/Advertising/handlers/createOnBeforeSendEventHandler.js";
+import { normalizeAdvertiser as realNormalizeAdvertiser } from "../../../../../../src/components/Advertising/utils/helpers.js";
 
 describe("Advertising::createOnBeforeSendEventHandler", () => {
   let cookieManager;
@@ -216,10 +217,31 @@ describe("Advertising::createOnBeforeSendEventHandler", () => {
   });
 
   describe("activeAdvertiserIds gate", () => {
-    it("returns early when advertiserSettings is missing", async () => {
-      normalizeAdvertiserFn.mockReturnValueOnce("");
+    // Build a handler that uses the real normalizeAdvertiser so each test
+    // exercises a genuinely different advertiserSettings shape end-to-end.
+    const buildHandlerWith = (componentConfigOverride) =>
+      createOnBeforeSendEventHandler({
+        cookieManager,
+        logger,
+        componentConfig: componentConfigOverride,
+        getBrowser,
+        consent,
+        collectSurferId: collectSurferIdFn,
+        getID5Id: getID5IdFn,
+        getRampId: getRampIdFn,
+        appendAdvertisingIdQueryToEvent: appendAdvertisingIdQueryToEventFn,
+        getUrlParams: getUrlParamsFn,
+        isThrottled: isThrottledFn,
+        normalizeAdvertiser: realNormalizeAdvertiser,
+      });
 
-      await onBeforeEvent({
+    it("returns early when advertiserSettings is missing", async () => {
+      const handler = buildHandlerWith({
+        id5PartnerId: "test-partner",
+        rampIdJSPath: "/test-path",
+      });
+
+      await handler({
         event,
         advertising: { handleAdvertisingData: "auto" },
       });
@@ -231,9 +253,13 @@ describe("Advertising::createOnBeforeSendEventHandler", () => {
     });
 
     it("returns early when advertiserSettings is an empty array", async () => {
-      normalizeAdvertiserFn.mockReturnValueOnce("");
+      const handler = buildHandlerWith({
+        id5PartnerId: "test-partner",
+        rampIdJSPath: "/test-path",
+        advertiserSettings: [],
+      });
 
-      await onBeforeEvent({
+      await handler({
         event,
         advertising: { handleAdvertisingData: "auto" },
       });
@@ -245,9 +271,16 @@ describe("Advertising::createOnBeforeSendEventHandler", () => {
     });
 
     it("returns early when all advertiser entries are disabled", async () => {
-      normalizeAdvertiserFn.mockReturnValueOnce("");
+      const handler = buildHandlerWith({
+        id5PartnerId: "test-partner",
+        rampIdJSPath: "/test-path",
+        advertiserSettings: [
+          { advertiserId: "adv-1", enabled: false },
+          { advertiserId: "adv-2", enabled: false },
+        ],
+      });
 
-      await onBeforeEvent({
+      await handler({
         event,
         advertising: { handleAdvertisingData: "auto" },
       });
@@ -259,12 +292,20 @@ describe("Advertising::createOnBeforeSendEventHandler", () => {
     });
 
     it("proceeds with identity resolution when at least one advertiser is enabled", async () => {
-      normalizeAdvertiserFn.mockReturnValueOnce("adv-1");
       collectSurferIdFn.mockResolvedValue("test-surfer-id");
       getID5IdFn.mockResolvedValue("test-id5-id");
       getRampIdFn.mockResolvedValue("test-ramp-id");
 
-      await onBeforeEvent({
+      const handler = buildHandlerWith({
+        id5PartnerId: "test-partner",
+        rampIdJSPath: "/test-path",
+        advertiserSettings: [
+          { advertiserId: "adv-1", enabled: true },
+          { advertiserId: "adv-2", enabled: false },
+        ],
+      });
+
+      await handler({
         event,
         advertising: { handleAdvertisingData: "auto" },
       });


### PR DESCRIPTION
## Changed Packages
- [x] core
- [ ] reactor-extension

## Description

Adds an early-exit guard to `createOnBeforeSendEventHandler` so that advertising
identity resolution (Surfer ID, ID5, RampID) is **skipped** when no enabled
`advertiserSettings` are configured. Without this guard, every customer
`sendEvent` was loading third-party scripts and injecting iframes even though
there was nothing meaningful to attach to the outgoing event downstream.

The new gate uses the existing `normalizeAdvertiser` helper from
`utils/helpers.js` and is wired through the factory's dependency injection, so:

- `componentConfig.advertiserSettings` is `undefined`, `[]`, or has all entries
  with `enabled: false` → handler returns immediately.
- At least one `{ advertiserId, enabled: true }` is present → handler proceeds
  exactly as before.

This mirrors the equivalent gate already present in `sendAdConversion.js` for
the view-through code path, so both surfaces now have consistent behavior.

### Files changed
- `packages/core/src/components/Advertising/handlers/createOnBeforeSendEventHandler.js`
  — added `normalizeAdvertiser` to the destructured deps + new `!activeAdvertiserIds`
  short-circuit in the early-return condition.
- `packages/core/src/components/Advertising/index.js` — imports
  `normalizeAdvertiser` from `./utils/helpers.js` and passes it into the factory.
- `packages/core/test/unit/specs/components/Advertising/handlers/createOnBeforeSendEventHandler.spec.js`
  — passes a `normalizeAdvertiser` mock through DI; adds 4 new test cases for
  the gate (missing settings / empty array / all-disabled / at least one
  enabled).

## Related Issue

[<!-- Link the JIRA / GitHub issue for the CJA advertising integration bug here -->
<!-- e.g. CJA-XXXX or #1234 -->](https://jira.corp.adobe.com/browse/AMO-181188)

## Motivation and Context

When Alloy is configured with the Advertising component but no enabled
`advertiserSettings` (for example, the customer has enabled the component but
not yet configured advertisers, or has disabled all of them), every
`sendEvent` was triggering:

- A hidden iframe to `pixel.everestjs.net` for Surfer ID resolution.
- Loading the `id5-api.js` script for ID5.
- Loading the configured ATS script for RampID.

These calls produced no useful data because `appendAdvertisingIdQueryToEvent`
relies on `advertiserSettings` to populate the `advIds` field, and there are no
advertisers to stitch identities to. The result was wasted network requests,
unnecessary third-party script execution, additional latency on the
`sendEvent` lifecycle, and noise in the consent / cookie surface for users
who effectively aren't using the advertising features.

This PR aligns the `onBeforeEvent` lifecycle with the already-shipped behavior
of the view-through conversion path in `sendAdConversion.js`, where the same
gate (`activeAdvertiserIds`) is already used to skip work when no advertiser
is configured.

## Screenshots (if appropriate):

N/A — code-only change. Verified in the sandbox at `/advertising` with both
`?advertiserSettings=on` and `?advertiserSettings=off`:
- **off** → no `[Advertising]` log lines, no third-party network requests.
- **on**  → identity collectors run as before.

## Documentation

No consumer-facing documentation update required. The new gate is a no-op for
any customer that has properly configured `advertiserSettings` (which is the
documented usage); only customers in the "Advertising component enabled but
no advertisers configured" state are affected, and the new behavior is the
correct one for that state.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have added a Changeset file with a consumer-facing description of my changes.
- [x ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
      - Unit: `core/unit` → `createOnBeforeSendEventHandler.spec.js` 12/12 passing.
      - Integration: `browser/integration` → all 7 `Advertising/*.spec.js` files, 12/12 passing.
- [x] I have run the Sandbox successfully.
      - Verified at `http://localhost:3000/advertising` with both
        `?advertiserSettings=on` and `?advertiserSettings=off`; no third-party
        network calls in the "off" case.