### PR TITLE
Do not show errors on push notifications fields when shown for the first time after validation.

### DIFF
--- a/.changeset/lazy-comics-sniff.md
+++ b/.changeset/lazy-comics-sniff.md
@@ -1,0 +1,5 @@
+---
+"reactor-extension-alloy": patch
+---
+
+Do not show errors on push notifications fields when shown for the first time after validation.

--- a/packages/reactor-extension/src/view/configuration/pushNotificationsSection.jsx
+++ b/packages/reactor-extension/src/view/configuration/pushNotificationsSection.jsx
@@ -12,7 +12,8 @@ governing permissions and limitations under the License.
 
 import PropTypes from "prop-types";
 import { object, string } from "yup";
-import { useField } from "formik";
+import { useEffect, useRef } from "react";
+import { useField, useFormikContext } from "formik";
 import { View, InlineAlert, Content, Link } from "@adobe/react-spectrum";
 import SectionHeader from "../components/sectionHeader";
 import FormElementContainer from "../components/formElementContainer";
@@ -84,10 +85,31 @@ export const bridge = {
   }),
 };
 
+const PUSH_NOTIFICATIONS_FIELDS = [
+  "vapidPublicKey",
+  "appId",
+  "trackingDatasetId",
+];
+
 const PushNotificationsSection = ({ instanceFieldName }) => {
   const [{ value: pushNotificationsComponentEnabled }] = useField(
     "components.pushNotifications",
   );
+  const { setFieldTouched } = useFormikContext();
+  const prevEnabled = useRef(pushNotificationsComponentEnabled);
+
+  useEffect(() => {
+    if (pushNotificationsComponentEnabled && !prevEnabled.current) {
+      PUSH_NOTIFICATIONS_FIELDS.forEach((field) => {
+        setFieldTouched(
+          `${instanceFieldName}.pushNotifications.${field}`,
+          false,
+          false,
+        );
+      });
+    }
+    prevEnabled.current = pushNotificationsComponentEnabled;
+  }, [pushNotificationsComponentEnabled]);
 
   if (!pushNotificationsComponentEnabled) {
     return (

--- a/packages/reactor-extension/test/integration/configuration/pushNotificationsSection.spec.jsx
+++ b/packages/reactor-extension/test/integration/configuration/pushNotificationsSection.spec.jsx
@@ -200,5 +200,21 @@ describe("Config push notifications section", () => {
         /please provide a tracking dataset id/i,
       );
     });
+
+    it("does not show field errors when component is enabled after validation", async () => {
+      await driver.init(buildSettings());
+
+      // Validate while push notifications is disabled — marks all fields as touched
+      await driver.expectValidate().toBe(true);
+
+      // Enable push notifications; fields become visible
+      await ui.expand("Build options");
+      await pushNotificationsComponentCheckbox.click();
+
+      // Fields are visible but touched state was reset — no errors should appear yet
+      await vapidPublicKeyField.expectValid();
+      await appIdField.expectValid();
+      await trackingDatasetIdField.expectValid();
+    });
   });
 });


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Changed Packages
<!--- Indicate which package your changes directly affect. -->
<!--- (i.e., do not choose the extension if it's only change is updating its core version). -->
- [ ] core
- [x] reactor-extension 

## Description

Push notification fields were showing validation errors when first enabled after the form was previously validated while the component was disabled.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Documentation
<!-- Significant consumer-facing changes should be documented -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Run `pnpm changeset` if this needs a release with a changelog entry, `pnpm changeset --empty` if it needs a release without one, or push without a changeset if no release is needed. -->
<!--- For more information about the changesets or the release process, see https://github.com/adobe/alloy/wiki/Release-process -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added a Changeset file with a consumer-facing description of my changes.
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
