### PR TITLE
Fixed pnpm filter name in reactor extension deploy script

### DIFF
--- a/scripts/deployExtensionToReactor.mjs
+++ b/scripts/deployExtensionToReactor.mjs
@@ -47,7 +47,7 @@ if (!version) {
 const zipName = `package-adobe-alloy-${version}.zip`;
 const zipPath = path.join(extensionDir, zipName);
 
-run("pnpm", ["--filter", "reactor-extension", "run", "package"], {
+run("pnpm", ["--filter", "reactor-extension-alloy", "run", "package"], {
   cwd: rootDir,
 });
 


### PR DESCRIPTION
## Changed Packages
- [ ] core
- [x] reactor-extension

## Description

Fixes the pnpm filter name used in `scripts/deployExtensionToReactor.mjs`. The script previously filtered on `reactor-extension`, which does not match any workspace project. The actual package name (in `packages/reactor-extension/package.json`) is `reactor-extension-alloy`.

## Related Issue

Publish job failure: https://github.com/adobe/alloy/actions/runs/25223068660/job/73959962098

The job log shows:

```
No projects matched the filters in "/home/runner/work/alloy/alloy"
Expected zip at /home/runner/work/alloy/alloy/packages/reactor-extension/package-adobe-alloy-2.35.0-beta.1.zip
##[error]Process completed with exit code 1.
```

## Motivation and Context

Because the filter did not match, the `package` script never ran, the expected zip was never produced, and the deploy script exited 1 — breaking the Reactor extension publish step. The same workflow already uses `--filter reactor-extension-alloy` correctly elsewhere; this aligns the deploy script with that name.

## Screenshots (if appropriate):

## Documentation

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have added a Changeset file with a consumer-facing description of my changes.
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)