### PR TITLE
Registered context (now part of required components) in the browser package

### DIFF
--- a/.changeset/rare-moments-talk.md
+++ b/.changeset/rare-moments-talk.md
@@ -1,0 +1,5 @@
+---
+"@adobe/alloy": patch
+---
+
+Register required components (eg context) in browser package

--- a/packages/browser/src/index.js
+++ b/packages/browser/src/index.js
@@ -11,11 +11,15 @@ governing permissions and limitations under the License.
 */
 import { createCustomInstance } from "@adobe/alloy-core";
 import * as allOptionalComponents from "./allOptionalComponents.js";
+import * as allRequiredComponents from "./components/requiredComponentCreators.js";
 
 export { createCustomInstance };
 export const createInstance = (options = {}) =>
   createCustomInstance({
     ...options,
-    components: Object.values(allOptionalComponents),
+    components: [
+      ...Object.values(allRequiredComponents),
+      ...Object.values(allOptionalComponents),
+    ],
   });
 export { allOptionalComponents as components };


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Changed Packages
<!--- Indicate which package your changes directly affect. -->
<!--- (i.e., do not choose the extension if it's only change is updating its core version). -->
- [ ] core
- [ ] reactor-extension 
- [x] browser

## Description

Context was originally in the optional components (erroneously) when migrated to the browser package, but was moved to required components to correct this. However, required components were not being registered (as previously there weren't any in the package). This change fixes that regression by registering the required components.

## Related Issue

N/A

## Motivation and Context

Fixes a regression (described above)

## Screenshots (if appropriate):

N/A

## Documentation
<!-- Significant consumer-facing changes should be documented -->

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Run `pnpm changeset` if this needs a release with a changelog entry, `pnpm changeset --empty` if it needs a release without one, or push without a changeset if no release is needed. -->
<!--- For more information about the changesets or the release process, see https://github.com/adobe/alloy/wiki/Release-process -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added a Changeset file with a consumer-facing description of my changes.
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
