### PR TITLE
ci: retry Reactor extension deploy on transient timeout

### DIFF
--- a/.github/workflows/changeset-publish.yml
+++ b/.github/workflows/changeset-publish.yml
@@ -238,17 +238,27 @@ jobs:
         run: node scripts/uploadToCDN.js
 
       - name: Package and deploy extension to Reactor (when @adobe/alloy was released)
+        # Wrapped in a retry because @adobe/reactor-uploader@6.0.0-beta.12 hardcodes
+        # MAX_RETRIES=50 with 1s polls (~50s) for post-upload processing, which
+        # occasionally exceeds Reactor's actual processing time. Re-uploading the
+        # same version is idempotent: the uploader updates the existing development
+        # extension package by name.
         if: hashFiles('packages/reactor-extension/package.json') != ''
+        uses: nick-fields/retry@v3
         env:
           REACTOR_IO_INTEGRATION_CLIENT_SECRET: ${{ secrets.REACTOR_IO_INTEGRATION_CLIENT_SECRET }}
-        run: |
-          if ! jq -e '.releases[] | select(.name=="reactor-extension-alloy")' changeset-status.json >/dev/null; then
-            echo "reactor-extension-alloy was not in this release; skipping extension deploy."
-            exit 0
-          fi
-          EXT_VERSION=$(node -p "require('./packages/reactor-extension/package.json').version")
-          pnpm --filter reactor-extension-alloy run build
-          node scripts/deployExtensionToReactor.mjs "${EXT_VERSION}"
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            if ! jq -e '.releases[] | select(.name=="reactor-extension-alloy")' changeset-status.json >/dev/null; then
+              echo "reactor-extension-alloy was not in this release; skipping extension deploy."
+              exit 0
+            fi
+            EXT_VERSION=$(node -p "require('./packages/reactor-extension/package.json').version")
+            pnpm --filter reactor-extension-alloy run build
+            node scripts/deployExtensionToReactor.mjs "${EXT_VERSION}"
 
       - name: Restore extension workspace protocol for @adobe/alloy
         if: hashFiles('packages/reactor-extension/package.json') != ''


### PR DESCRIPTION
## Summary
- Wraps the Reactor extension deploy step in `.github/workflows/changeset-publish.yml` with `nick-fields/retry@v3` (3 attempts, 30s wait, 10 min cap per attempt) so the publish job survives transient slowness on Reactor's side.
- The underlying cause: `@adobe/reactor-uploader@6.0.0-beta.12` hardcodes `MAX_RETRIES=50` × 1s polls in `bin/monitorStatus.js` (~50s ceiling on post-upload processing). The `--upload-timeout` flag we pass in `scripts/deployExtensionToReactor.mjs` is silently ignored by this version. See run https://github.com/adobe/alloy/actions/runs/25393405614/job/74473840982 — npm publish + CDN upload had already succeeded; only the post-upload status poll timed out (~52s in).
- Re-uploading the same version is idempotent: the uploader looks up the development extension package by name and updates it in place rather than creating a duplicate. `scripts/createGithubReleases.js` is already idempotent (checks `gh release view` and skips existing tags), so a full job re-run after a Reactor flake is safe end-to-end.

## Test plan
- [ ] Trigger the workflow on a release with a `reactor-extension-alloy` changeset and confirm the deploy step succeeds on first attempt
- [ ] Simulate a transient Reactor timeout (or wait for one to recur) and verify the retry recovers without re-publishing to npm
- [ ] Confirm the skip path still works when `reactor-extension-alloy` is not in the release plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)