### PR TITLE
Fixed flaky setConsent integration handler

### DIFF
--- a/packages/browser/test/integration/helpers/mswjs/handlers.js
+++ b/packages/browser/test/integration/helpers/mswjs/handlers.js
@@ -159,7 +159,7 @@ export const contentCardsAndEventHistoryOperations = http.post(
 );
 
 export const setConsentHandler = http.post(
-  /https:\/\/edge\.adobedc\.net\/ee\/v1\/privacy\/set-consent/,
+  /https:\/\/edge\.adobedc\.net\/ee\/(?:[^/]+\/)?v1\/privacy\/set-consent/,
 
   async (req) => {
     const url = new URL(req.request.url);
@@ -168,7 +168,18 @@ export const setConsentHandler = http.post(
     if (configId === "bc1a10e0-aee4-4e0e-ac5b-cdbb9abbec83") {
       return HttpResponse.json({
         requestId: "consent-request-id",
-        handle: [],
+        handle: [
+          {
+            type: "state:store",
+            payload: [
+              {
+                key: "kndctr_5BFE274A5F6980A50A495C08_AdobeOrg_consent",
+                value: "general=in",
+                maxAge: 15552000,
+              },
+            ],
+          },
+        ],
       });
     }
 


### PR DESCRIPTION
## Changed Packages
<!--- Indicate which package your changes directly affect. -->
<!--- (i.e., do not choose the extension if it's only change is updating its core version). -->
- [ ] core
- [ ] reactor-extension

(Test-only fixture change in `packages/browser/test/integration`.)

## Description

The shared `setConsentHandler` in `packages/browser/test/integration/helpers/mswjs/handlers.js` had two issues that caused `queueTimeMillis.spec.js`'s "reflects time waiting for consent" test to time out:

- **URL regex too strict.** It required a literal `/ee/v1/`, so once a prior test in the same file populated the `kndctr_..._cluster` cookie via `sendEventResponse.json`'s `state:store` handle, alloy's setConsent URL became `/ee/{locationHint}/v1/privacy/set-consent` and stopped matching. Loosened to `/ee/(?:[^/]+\/)?v1/...`, mirroring the working handler in `consent_gate.spec.js`.
- **Empty handle array.** The Consent component reads consent state from the consent cookie after the request resolves. With `handle: []`, no cookie was set, no consent transition happened, and the queued `sendEvent` stayed suspended until vitest timed out at 15s. Now returns a `state:store` payload that writes `general=in`.

## Related Issue

N/A — internal test infrastructure fix.

## Motivation and Context

`queueTimeMillis reflects time waiting for consent` was failing consistently against `main`, blocking local `pnpm test` runs. The failure is not caused by any product code change; it is a latent bug in the shared MSW handler that surfaces because earlier tests in the same file leave a cluster cookie behind and the handler does not return a consent `state:store` payload.

## Screenshots (if appropriate):

N/A.

## Documentation
<!-- Significant consumer-facing changes should be documented -->

N/A — no consumer-facing change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have added a Changeset file with a consumer-facing description of my changes. (Not needed — test-only change with no consumer impact.)
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass. (`pnpm test`: 2671 passed, 5 skipped, 0 failed.)
- [x] I have run the Sandbox successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)