### PR TITLE
Fixed sendEvent not returning activation:pull (profileLookup) destinations

### DIFF
--- a/.changeset/fresh-papers-send.md
+++ b/.changeset/fresh-papers-send.md
@@ -1,0 +1,6 @@
+---
+"@adobe/alloy": patch
+"@adobe/alloy-core": patch
+---
+
+Fixed an issue where event.destinations were missing for customers using commerce personalization without Adobe Journey Optimizer.

--- a/packages/browser/test/integration/helpers/mocks/pullDestinationsResponse.json
+++ b/packages/browser/test/integration/helpers/mocks/pullDestinationsResponse.json
@@ -1,0 +1,43 @@
+{
+  "requestId": "3931ed0b-d171-45f6-9d3e-29a61113aac2-254b6b357f27442f",
+  "handle": [
+    {
+      "payload": [
+        {
+          "id": "41861666193140161934276845651148876988",
+          "namespace": {
+            "code": "ECID"
+          }
+        }
+      ],
+      "type": "identity:result"
+    },
+    {
+      "payload": [
+        {
+          "id": "ed6a852f-3e99-4cf3-86f7-0027fabeb4fb",
+          "segments": [
+            { "id": "seg-AAA" },
+            { "id": "seg-BBB" }
+          ]
+        },
+        {
+          "id": "d6211043-fb49-45f1-84a9-a56336c1f6fe",
+          "segments": [{ "id": "seg-CCC" }]
+        }
+      ],
+      "type": "activation:pull",
+      "eventIndex": 0
+    },
+    {
+      "payload": [
+        {
+          "key": "kndctr_5BFE274A5F6980A50A495C08_AdobeOrg_cluster",
+          "value": "or2",
+          "maxAge": 1800
+        }
+      ],
+      "type": "state:store"
+    }
+  ]
+}

--- a/packages/browser/test/integration/helpers/mswjs/handlers.js
+++ b/packages/browser/test/integration/helpers/mswjs/handlers.js
@@ -58,6 +58,25 @@ export const sendEventErrorHandler = http.post(
   },
 );
 
+export const pullDestinationsHandler = http.post(
+  /https:\/\/edge.adobedc.net\/ee\/.*\/?v1\/interact/,
+
+  async (req) => {
+    const url = new URL(req.request.url);
+    const configId = url.searchParams.get("configId");
+
+    if (configId === "bc1a10e0-aee4-4e0e-ac5b-cdbb9abbec83") {
+      return HttpResponse.text(
+        await readFile(
+          `${server.config.root}/packages/browser/test/integration/helpers/mocks/pullDestinationsResponse.json`,
+        ),
+      );
+    }
+
+    throw new Error("Handler not configured properly");
+  },
+);
+
 export const demdexHandler = http.post(
   "https://adobedc.demdex.net/ee/v1/interact",
 

--- a/packages/browser/test/integration/specs/Audiences/pullDestinations.spec.js
+++ b/packages/browser/test/integration/specs/Audiences/pullDestinations.spec.js
@@ -1,0 +1,37 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { test, expect, describe } from "../../helpers/testsSetup/extend.js";
+import { pullDestinationsHandler } from "../../helpers/mswjs/handlers.js";
+import alloyConfig from "../../helpers/alloy/config.js";
+
+// Regression test for PLATIR-64321: sendEvent must surface activation:pull
+// (profileLookup) destinations in its result so consumers (e.g. Launch rules
+// reading event.destinations) can read returned segment IDs. PR #1475 removed
+// this return value, breaking commerce/audience activation use cases.
+describe("Audiences pull destinations", () => {
+  test("returns activation:pull destinations on the sendEvent result", async ({
+    alloy,
+    worker,
+  }) => {
+    worker.use(...[pullDestinationsHandler]);
+
+    await alloy("configure", structuredClone(alloyConfig));
+
+    const result = await alloy("sendEvent");
+
+    expect(result.destinations).toBeDefined();
+    const segmentIds = result.destinations.flatMap((destination) =>
+      destination.segments.map((segment) => segment.id),
+    );
+    expect(segmentIds).toEqual(["seg-AAA", "seg-BBB", "seg-CCC"]);
+  });
+});

--- a/packages/browser/test/integration/specs/Audiences/pullDestinations.spec.js
+++ b/packages/browser/test/integration/specs/Audiences/pullDestinations.spec.js
@@ -13,10 +13,7 @@ import { test, expect, describe } from "../../helpers/testsSetup/extend.js";
 import { pullDestinationsHandler } from "../../helpers/mswjs/handlers.js";
 import alloyConfig from "../../helpers/alloy/config.js";
 
-// Regression test for PLATIR-64321: sendEvent must surface activation:pull
-// (profileLookup) destinations in its result so consumers (e.g. Launch rules
-// reading event.destinations) can read returned segment IDs. PR #1475 removed
-// this return value, breaking commerce/audience activation use cases.
+// PLATIR-64321: sendEvent must return activation:pull destinations on its result.
 describe("Audiences pull destinations", () => {
   test("returns activation:pull destinations on the sendEvent result", async ({
     alloy,

--- a/packages/core/src/components/Audiences/injectProcessResponse.js
+++ b/packages/core/src/components/Audiences/injectProcessResponse.js
@@ -15,5 +15,10 @@ export default ({ processDestinations }) => {
     const pushDestinations = response.getPayloadsByType("activation:push");
     // fire and forget
     processDestinations(pushDestinations);
+    // Pull destinations (e.g. profileLookup) are surfaced on the sendEvent
+    // result so consumers can read returned segment IDs. (PLATIR-64321)
+    return {
+      destinations: response.getPayloadsByType("activation:pull"),
+    };
   };
 };

--- a/packages/core/src/components/Audiences/injectProcessResponse.js
+++ b/packages/core/src/components/Audiences/injectProcessResponse.js
@@ -15,8 +15,6 @@ export default ({ processDestinations }) => {
     const pushDestinations = response.getPayloadsByType("activation:push");
     // fire and forget
     processDestinations(pushDestinations);
-    // Pull destinations (e.g. profileLookup) are surfaced on the sendEvent
-    // result so consumers can read returned segment IDs. (PLATIR-64321)
     return {
       destinations: response.getPayloadsByType("activation:pull"),
     };

--- a/packages/core/test/unit/specs/components/Audiences/injectProcessResponse.spec.js
+++ b/packages/core/test/unit/specs/components/Audiences/injectProcessResponse.spec.js
@@ -22,13 +22,29 @@ describe("injectProcessResponse", () => {
       processDestinations,
     });
     response = {
-      getPayloadsByType: vi.fn().mockReturnValue(["An Edge Destination"]),
+      getPayloadsByType: vi.fn().mockImplementation((type) => {
+        if (type === "activation:push") {
+          return ["A Push Destination"];
+        }
+        if (type === "activation:pull") {
+          return ["A Pull Destination"];
+        }
+        return [];
+      }),
     };
   });
-  it("processes push destinations and does not return a value", () => {
+  it("processes push destinations", () => {
     processResponse({
       response,
     });
-    expect(processDestinations).toHaveBeenCalled();
+    expect(processDestinations).toHaveBeenCalledWith(["A Push Destination"]);
+  });
+  it("returns pull destinations on the result", () => {
+    const result = processResponse({
+      response,
+    });
+    expect(result).toEqual({
+      destinations: ["A Pull Destination"],
+    });
   });
 });


### PR DESCRIPTION
## Changed Packages
- [x] core
- [ ] reactor-extension

## Description

PR #1475 removed the `retrievePullDestinations` return value from the Audiences `onResponse` handler, believing it was dead code. It was not: component `onResponse` return values are merged (via `mergeLifecycleResponses` → `assignConcatArrayValues`) into the object the `sendEvent` promise resolves with. Removing it dropped `result.destinations`, which breaks consumers that read returned segment IDs — e.g. Launch rules reading `event.destinations` from the "Send event complete" event for profileLookup / commerce-activation use cases.

This restores the pull-destinations return while keeping push destinations fire-and-forget, preserving the latency improvement from #1475.

## Related Issue

[PLATIR-64321 — AEP Segments not returned after Web SDK extension upgrade.](https://jira.corp.adobe.com/browse/PLATIR-64321) Regression introduced by #1475 (PDCL-15412), shipped in `@adobe/alloy@2.33.0` / extension v2.35.x–2.36.0.

## Motivation and Context

A customer (commerce personalization, not using AJO) stopped receiving segment IDs after upgrading the Web SDK extension. Their Launch rule reads `event.destinations` from the `sendEvent` result to populate a segment-membership cookie; with `result.destinations` undefined post-#1475, that cookie was wiped.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added a Changeset file with a consumer-facing description of my changes.
- [x] I have signed the Adobe Open Source CLA or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
