### PR TITLE
FIX: Updated variableStore to use name only to lookup ID key

### DIFF
--- a/.changeset/yummy-words-sink.md
+++ b/.changeset/yummy-words-sink.md
@@ -1,0 +1,5 @@
+---
+"reactor-extension-alloy": patch
+---
+
+Fix variablestore key confusion

--- a/packages/browser/bundlesize.json
+++ b/packages/browser/bundlesize.json
@@ -1,22 +1,22 @@
 {
   "dist/alloy.js": {
-    "uncompressedSize": 765533,
-    "gzippedSize": 126350,
-    "brotiliSize": 97112
+    "uncompressedSize": 765626,
+    "gzippedSize": 126448,
+    "brotiliSize": 97204
   },
   "dist/alloy.min.js": {
-    "uncompressedSize": 157549,
-    "gzippedSize": 52700,
-    "brotiliSize": 45353
+    "uncompressedSize": 157610,
+    "gzippedSize": 52763,
+    "brotiliSize": 45368
   },
   "dist/alloyServiceWorker.js": {
     "uncompressedSize": 19625,
-    "gzippedSize": 4504,
+    "gzippedSize": 4498,
     "brotiliSize": 3823
   },
   "dist/alloyServiceWorker.min.js": {
     "uncompressedSize": 5514,
-    "gzippedSize": 2588,
+    "gzippedSize": 2579,
     "brotiliSize": 2165
   },
   "distTest/baseCode.min.js": {
@@ -26,12 +26,12 @@
   },
   "dist/utils/deepAssign.js": {
     "uncompressedSize": 3829,
-    "gzippedSize": 1041,
+    "gzippedSize": 1044,
     "brotiliSize": 810
   },
   "dist/utils/createEventMergeId.js": {
     "uncompressedSize": 2734,
-    "gzippedSize": 930,
+    "gzippedSize": 934,
     "brotiliSize": 718
   }
 }

--- a/packages/reactor-extension/src/lib/actions/updateVariable/createUpdateVariable.js
+++ b/packages/reactor-extension/src/lib/actions/updateVariable/createUpdateVariable.js
@@ -15,29 +15,34 @@ const { deletePath } = require("../../utils/pathUtils");
 module.exports =
   ({ variableStore, deepAssign }) =>
   ({ data, dataElementId, dataElementName, transforms, customCode }, event) => {
-    const storeKey = dataElementName || dataElementId;
+    variableStore.registerName(dataElementId, dataElementName);
+    const storeKey = variableStore.resolveKey(dataElementId, dataElementName);
 
-    const existingValue = Object.keys(transforms || {}).reduce((memo, path) => {
-      const { clear } = transforms[path];
-      return clear ? deletePath(memo, path) : memo;
-    }, variableStore[storeKey] || {});
+    const existingValue = Object.keys(transforms || {}).reduce(
+      (memo, path) => {
+        const { clear } = transforms[path];
+        return clear ? deletePath(memo, path) : memo;
+      },
+      variableStore.get(storeKey) || {},
+    );
 
     const previousEvents = existingValue?.__adobe?.analytics?.events || "";
 
-    variableStore[storeKey] = deepAssign({}, existingValue, data);
+    variableStore.set(storeKey, deepAssign({}, existingValue, data));
 
-    const newEvents = variableStore[storeKey]?.__adobe?.analytics?.events || "";
+    const newEvents =
+      variableStore.get(storeKey)?.__adobe?.analytics?.events || "";
     if (previousEvents && newEvents && previousEvents !== newEvents) {
-      variableStore[storeKey].__adobe.analytics.events =
+      variableStore.get(storeKey).__adobe.analytics.events =
         `${previousEvents},${newEvents}`;
     }
 
     if (customCode) {
-      customCode(variableStore[storeKey], event);
+      customCode(variableStore.get(storeKey), event);
     }
 
     // This is a temporary fix to support the 'audienceManager' property that should be lowercased.
-    const adobe = variableStore[storeKey]?.__adobe || {};
+    const adobe = variableStore.get(storeKey)?.__adobe || {};
     if (adobe.audienceManager) {
       adobe.audiencemanager = adobe.audienceManager;
       delete adobe.audienceManager;

--- a/packages/reactor-extension/src/lib/createVariableStore.js
+++ b/packages/reactor-extension/src/lib/createVariableStore.js
@@ -37,8 +37,9 @@ module.exports = () => {
     },
 
     findByName(dataElementName) {
-      const key = dataElementName && nameToKey[dataElementName];
-      return key !== undefined ? entries[key] : undefined;
+      if (!dataElementName) return undefined;
+      const key = nameToKey[dataElementName] ?? dataElementName;
+      return entries[key];
     },
   };
 };

--- a/packages/reactor-extension/src/lib/createVariableStore.js
+++ b/packages/reactor-extension/src/lib/createVariableStore.js
@@ -9,6 +9,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+const { deepAssign } = require("./alloy");
+
 module.exports = () => {
   const entries = {};
   const nameToKey = {};

--- a/packages/reactor-extension/src/lib/createVariableStore.js
+++ b/packages/reactor-extension/src/lib/createVariableStore.js
@@ -9,6 +9,36 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-// This is just a store of variables indexed by their cacheId
+module.exports = () => {
+  const entries = {};
+  const nameToKey = {};
 
-module.exports = () => ({});
+  return {
+    registerName(dataElementId, dataElementName) {
+      if (dataElementId && dataElementName) {
+        nameToKey[dataElementName] = dataElementId;
+      }
+    },
+
+    resolveKey(dataElementId, dataElementName) {
+      if (dataElementId) return dataElementId;
+      if (dataElementName && nameToKey[dataElementName] !== undefined) {
+        return nameToKey[dataElementName];
+      }
+      return dataElementName;
+    },
+
+    get(key) {
+      return entries[key];
+    },
+
+    set(key, value) {
+      entries[key] = value;
+    },
+
+    findByName(dataElementName) {
+      const key = dataElementName && nameToKey[dataElementName];
+      return key !== undefined ? entries[key] : undefined;
+    },
+  };
+};

--- a/packages/reactor-extension/src/lib/createVariableStore.js
+++ b/packages/reactor-extension/src/lib/createVariableStore.js
@@ -20,7 +20,7 @@ module.exports = () => {
         nameToKey[dataElementName] === undefined &&
         entries[dataElementName] !== undefined
       ) {
-        entries[dataElementId] = Object.assign(
+        entries[dataElementId] = deepAssign(
           {},
           entries[dataElementId],
           entries[dataElementName],

--- a/packages/reactor-extension/src/lib/createVariableStore.js
+++ b/packages/reactor-extension/src/lib/createVariableStore.js
@@ -15,9 +15,15 @@ module.exports = () => {
 
   return {
     registerName(dataElementId, dataElementName) {
-      if (dataElementId && dataElementName) {
-        nameToKey[dataElementName] = dataElementId;
+      if (!dataElementId || !dataElementName) return;
+      if (
+        nameToKey[dataElementName] === undefined &&
+        entries[dataElementName] !== undefined
+      ) {
+        entries[dataElementId] = entries[dataElementName];
+        delete entries[dataElementName];
       }
+      nameToKey[dataElementName] = dataElementId;
     },
 
     resolveKey(dataElementId, dataElementName) {

--- a/packages/reactor-extension/src/lib/createVariableStore.js
+++ b/packages/reactor-extension/src/lib/createVariableStore.js
@@ -20,7 +20,11 @@ module.exports = () => {
         nameToKey[dataElementName] === undefined &&
         entries[dataElementName] !== undefined
       ) {
-        entries[dataElementId] = entries[dataElementName];
+        entries[dataElementId] = Object.assign(
+          {},
+          entries[dataElementId],
+          entries[dataElementName],
+        );
         delete entries[dataElementName];
       }
       nameToKey[dataElementName] = dataElementId;

--- a/packages/reactor-extension/src/lib/dataElements/variable/createGetVariable.js
+++ b/packages/reactor-extension/src/lib/dataElements/variable/createGetVariable.js
@@ -11,7 +11,14 @@ governing permissions and limitations under the License.
 
 module.exports =
   ({ variableStore }) =>
-  (settings) => {
-    const { dataElementId, dataElementName } = settings;
-    return variableStore[dataElementName] || variableStore[dataElementId] || {};
+  ({ dataElementId, dataElementName }) => {
+    if (dataElementId) {
+      const value = variableStore.get(dataElementId);
+      if (value !== undefined) return value;
+    }
+    if (dataElementName) {
+      const value = variableStore.findByName(dataElementName);
+      if (value !== undefined) return value;
+    }
+    return {};
   };

--- a/packages/reactor-extension/test/unit/lib/actions/updateVariable/createUpdateVariable.spec.js
+++ b/packages/reactor-extension/test/unit/lib/actions/updateVariable/createUpdateVariable.spec.js
@@ -213,6 +213,29 @@ describe("Update variable", () => {
       expect(variableStore.get("DE123")).toEqual({ a: 1, b: 2 });
       expect(variableStore.get("myVariable")).toBeUndefined();
     });
+
+    it("migration merges name-keyed data with existing id-keyed data rather than overwriting", () => {
+      // Id-only rule and name-only rule both fire before any id+name rule is seen.
+      updateVariable({
+        data: { a: 1 },
+        dataElementId: "DE123",
+        transforms: {},
+      });
+      updateVariable({
+        data: { b: 2 },
+        dataElementName: "myVariable",
+        transforms: {},
+      });
+      // Id+name rule fires — migration must deepAssign name-keyed data into the existing id-keyed entry.
+      updateVariable({
+        data: { c: 3 },
+        dataElementName: "myVariable",
+        dataElementId: "DE123",
+        transforms: {},
+      });
+      expect(variableStore.get("DE123")).toEqual({ a: 1, b: 2, c: 3 });
+      expect(variableStore.get("myVariable")).toBeUndefined();
+    });
   });
 
   describe("updates existing variable using dataElementId when both id and name provided", () => {

--- a/packages/reactor-extension/test/unit/lib/actions/updateVariable/createUpdateVariable.spec.js
+++ b/packages/reactor-extension/test/unit/lib/actions/updateVariable/createUpdateVariable.spec.js
@@ -12,62 +12,65 @@ governing permissions and limitations under the License.
 import { describe, it, expect, beforeEach } from "vitest";
 import deepAssign from "../../../helpers/deepAssign";
 import createUpdateVariable from "../../../../../src/lib/actions/updateVariable/createUpdateVariable";
+import createVariableStore from "../../../../../src/lib/createVariableStore";
 
 describe("Update variable", () => {
   let variableStore;
   let updateVariable;
 
   beforeEach(() => {
-    variableStore = {};
+    variableStore = createVariableStore();
     updateVariable = createUpdateVariable({ variableStore, deepAssign });
   });
 
   it("handles an empty update", () => {
     updateVariable({ data: {}, dataElementId: "a", transforms: {} });
-    expect(variableStore).toEqual({ a: {} });
+    expect(variableStore.get("a")).toEqual({});
   });
 
   it("updates a variable", () => {
-    variableStore.var1 = { a: 1, b: 2 };
+    variableStore.set("var1", { a: 1, b: 2 });
     updateVariable({
       data: { a: 3, d: 4 },
       dataElementId: "var1",
       transforms: {},
     });
-    expect(variableStore).toEqual({ var1: { a: 3, b: 2, d: 4 } });
+    expect(variableStore.get("var1")).toEqual({ a: 3, b: 2, d: 4 });
   });
 
   it("leaves other variables alone", () => {
-    variableStore.var1 = { a: 1 };
+    variableStore.set("var1", { a: 1 });
     updateVariable({
       data: { b: 2 },
       dataElementId: "var2",
       transforms: {},
     });
-    expect(variableStore).toEqual({ var1: { a: 1 }, var2: { b: 2 } });
+    expect(variableStore.get("var1")).toEqual({ a: 1 });
+    expect(variableStore.get("var2")).toEqual({ b: 2 });
   });
 
   it("applies a clear transform", () => {
-    variableStore.var1 = { a: { b: { c: 3 } } };
+    variableStore.set("var1", { a: { b: { c: 3 } } });
     updateVariable({
       data: {},
       dataElementId: "var1",
       transforms: { "a.b": { clear: true } },
     });
-    expect(variableStore).toEqual({ var1: { a: {} } });
+    expect(variableStore.get("var1")).toEqual({ a: {} });
   });
 
   it("clears before setting values", () => {
-    variableStore.var1 = { a: { b: { c: 3 } }, e: 5 };
+    variableStore.set("var1", { a: { b: { c: 3 } }, e: 5 });
     updateVariable({
       data: { a: { b: { d: 4 } } },
       dataElementId: "var1",
       transforms: { "a.b": { clear: true } },
     });
-    expect(variableStore).toEqual({ var1: { a: { b: { d: 4 } }, e: 5 } });
+    expect(variableStore.get("var1")).toEqual({ a: { b: { d: 4 } }, e: 5 });
   });
+
   it("applies multiple clear transforms", () => {
-    variableStore.var1 = { a: 1, b: 2, c: 3, d: [1, 2, 3] };
+    variableStore.set("var1", { a: 1, b: 2, c: 3, d: [1, 2, 3] });
     updateVariable({
       data: {},
       dataElementId: "var1",
@@ -77,69 +80,145 @@ describe("Update variable", () => {
         "d.1": { clear: true },
       },
     });
-    expect(variableStore).toEqual({ var1: { b: 2, d: [1, 3] } });
+    expect(variableStore.get("var1")).toEqual({ b: 2, d: [1, 3] });
   });
 
   it("clears the entire variable", () => {
-    variableStore.var1 = { a: 1 };
+    variableStore.set("var1", { a: 1 });
     updateVariable({
       data: {},
       dataElementId: "var1",
       transforms: { "": { clear: true } },
     });
-    expect(variableStore).toEqual({ var1: {} });
+    expect(variableStore.get("var1")).toEqual({});
   });
 
   it("updates a variable after clearing the entire variable", () => {
-    variableStore.var1 = { a: 1 };
+    variableStore.set("var1", { a: 1 });
     updateVariable({
       data: { b: 2 },
       dataElementId: "var1",
       transforms: { "": { clear: true } },
     });
-    expect(variableStore).toEqual({ var1: { b: 2 } });
+    expect(variableStore.get("var1")).toEqual({ b: 2 });
   });
 
-  it("uses dataElementName as the store key when provided", () => {
+  it("uses dataElementId as the store key when both id and name are provided", () => {
     updateVariable({
       data: { a: 1 },
       dataElementName: "myVariable",
       dataElementId: "DE123",
       transforms: {},
     });
-    expect(variableStore).toEqual({ myVariable: { a: 1 } });
-    expect(variableStore.DE123).toBeUndefined();
+    expect(variableStore.get("DE123")).toEqual({ a: 1 });
+    expect(variableStore.get("myVariable")).toBeUndefined();
   });
 
-  it("falls back to dataElementId when dataElementName is not provided", () => {
+  it("falls back to dataElementName as the store key when no id is provided", () => {
     updateVariable({
       data: { a: 1 },
-      dataElementId: "DE123",
+      dataElementName: "myVariable",
       transforms: {},
     });
-    expect(variableStore).toEqual({ DE123: { a: 1 } });
+    expect(variableStore.get("myVariable")).toEqual({ a: 1 });
   });
 
-  it("updates existing variable using dataElementName", () => {
-    variableStore.myVariable = { a: 1, b: 2 };
-    updateVariable({
-      data: { a: 3, c: 4 },
-      dataElementName: "myVariable",
-      dataElementId: "DE123",
-      transforms: {},
+  describe("store key consistency across rule configurations", () => {
+    it("Case 1+2: old rules (id-only) and new rules (id+name) with the same id merge into the same entry", () => {
+      updateVariable({
+        data: { a: 1, b: 2 },
+        dataElementId: "DE123",
+        transforms: {},
+      });
+      updateVariable({
+        data: { c: 3 },
+        dataElementName: "myVariable",
+        dataElementId: "DE123",
+        transforms: {},
+      });
+      expect(variableStore.get("DE123")).toEqual({ a: 1, b: 2, c: 3 });
+      expect(variableStore.get("myVariable")).toBeUndefined();
     });
-    expect(variableStore).toEqual({ myVariable: { a: 3, b: 2, c: 4 } });
+
+    it("Case 3: all rules on a copied property share the same (outdated) id — data remains consistent", () => {
+      // After a property copy, all rules still have the original id until re-saved.
+      updateVariable({
+        data: { page: "home" },
+        dataElementName: "MyVar",
+        dataElementId: "DE-original",
+        transforms: {},
+      });
+      updateVariable({
+        data: { user: "guest" },
+        dataElementName: "MyVar",
+        dataElementId: "DE-original",
+        transforms: {},
+      });
+      expect(variableStore.get("DE-original")).toEqual({
+        page: "home",
+        user: "guest",
+      });
+      expect(variableStore.get("MyVar")).toBeUndefined();
+    });
+
+    it("edge case: partially re-saved rules on a copied property write to separate entries when ids differ", () => {
+      // Known limitation: data splits until all rules are re-saved on the copied property.
+      updateVariable({
+        data: { a: 1 },
+        dataElementName: "MyVar",
+        dataElementId: "DE-original",
+        transforms: {},
+      });
+      updateVariable({
+        data: { b: 2 },
+        dataElementName: "MyVar",
+        dataElementId: "DE-copy",
+        transforms: {},
+      });
+      expect(variableStore.get("DE-original")).toEqual({ a: 1 });
+      expect(variableStore.get("DE-copy")).toEqual({ b: 2 });
+    });
+
+    it("name-only fallback reuses an existing id-keyed entry if the name was previously registered", () => {
+      updateVariable({
+        data: { a: 1 },
+        dataElementName: "myVariable",
+        dataElementId: "DE123",
+        transforms: {},
+      });
+      // No id — should find the existing id-keyed entry via the name index, not create a separate name-keyed one.
+      updateVariable({
+        data: { b: 2 },
+        dataElementName: "myVariable",
+        transforms: {},
+      });
+      expect(variableStore.get("DE123")).toEqual({ a: 1, b: 2 });
+      expect(variableStore.get("myVariable")).toBeUndefined();
+    });
   });
 
-  it("applies clear transform using dataElementName", () => {
-    variableStore.myVariable = { a: { b: { c: 3 } } };
-    updateVariable({
-      data: {},
-      dataElementName: "myVariable",
-      dataElementId: "DE123",
-      transforms: { "a.b": { clear: true } },
+  describe("updates existing variable using dataElementId when both id and name provided", () => {
+    it("merges into the id-keyed entry", () => {
+      variableStore.set("DE123", { a: 1, b: 2 });
+      updateVariable({
+        data: { a: 3, c: 4 },
+        dataElementName: "myVariable",
+        dataElementId: "DE123",
+        transforms: {},
+      });
+      expect(variableStore.get("DE123")).toEqual({ a: 3, b: 2, c: 4 });
     });
-    expect(variableStore).toEqual({ myVariable: { a: {} } });
+
+    it("applies clear transform to the id-keyed entry", () => {
+      variableStore.set("DE123", { a: { b: { c: 3 } } });
+      updateVariable({
+        data: {},
+        dataElementName: "myVariable",
+        dataElementId: "DE123",
+        transforms: { "a.b": { clear: true } },
+      });
+      expect(variableStore.get("DE123")).toEqual({ a: {} });
+    });
   });
 
   describe("sequential updates should merge analytics events", () => {
@@ -155,7 +234,9 @@ describe("Update variable", () => {
         transforms: {},
       });
 
-      expect(variableStore.v.__adobe.analytics.events).toBe("event99,event9");
+      expect(variableStore.get("v").__adobe.analytics.events).toBe(
+        "event99,event9",
+      );
     });
 
     it("merges events while preserving other analytics properties", () => {
@@ -170,8 +251,10 @@ describe("Update variable", () => {
         transforms: {},
       });
 
-      expect(variableStore.v.__adobe.analytics.events).toBe("event99,event1");
-      expect(variableStore.v.__adobe.analytics.eVar1).toBe("value");
+      expect(variableStore.get("v").__adobe.analytics.events).toBe(
+        "event99,event1",
+      );
+      expect(variableStore.get("v").__adobe.analytics.eVar1).toBe("value");
     });
 
     it("preserves serialized event syntax when merging", () => {
@@ -188,7 +271,7 @@ describe("Update variable", () => {
         transforms: {},
       });
 
-      expect(variableStore.v.__adobe.analytics.events).toBe(
+      expect(variableStore.get("v").__adobe.analytics.events).toBe(
         "event1:abc123=5,event9",
       );
     });
@@ -210,7 +293,7 @@ describe("Update variable", () => {
         transforms: {},
       });
 
-      expect(variableStore.v.__adobe.analytics.events).toBe(
+      expect(variableStore.get("v").__adobe.analytics.events).toBe(
         "event99,event4,event9",
       );
     });
@@ -227,7 +310,7 @@ describe("Update variable", () => {
         transforms: { "__adobe.analytics.events": { clear: true } },
       });
 
-      expect(variableStore.v.__adobe.analytics.events).toBe("event1");
+      expect(variableStore.get("v").__adobe.analytics.events).toBe("event1");
     });
   });
 });

--- a/packages/reactor-extension/test/unit/lib/actions/updateVariable/createUpdateVariable.spec.js
+++ b/packages/reactor-extension/test/unit/lib/actions/updateVariable/createUpdateVariable.spec.js
@@ -195,6 +195,24 @@ describe("Update variable", () => {
       expect(variableStore.get("DE123")).toEqual({ a: 1, b: 2 });
       expect(variableStore.get("myVariable")).toBeUndefined();
     });
+
+    it("name-only write before id+name write: earlier data is migrated and not orphaned", () => {
+      // Name-only rule fires first — no id available yet.
+      updateVariable({
+        data: { a: 1 },
+        dataElementName: "myVariable",
+        transforms: {},
+      });
+      // Id+name rule fires second — registerName migrates the name-keyed entry to the id key.
+      updateVariable({
+        data: { b: 2 },
+        dataElementName: "myVariable",
+        dataElementId: "DE123",
+        transforms: {},
+      });
+      expect(variableStore.get("DE123")).toEqual({ a: 1, b: 2 });
+      expect(variableStore.get("myVariable")).toBeUndefined();
+    });
   });
 
   describe("updates existing variable using dataElementId when both id and name provided", () => {

--- a/packages/reactor-extension/test/unit/lib/dataElements/variable/createGetVariable.spec.js
+++ b/packages/reactor-extension/test/unit/lib/dataElements/variable/createGetVariable.spec.js
@@ -71,6 +71,16 @@ describe("Variable data element", () => {
       updateVariable = createUpdateVariable({ variableStore, deepAssign });
     });
 
+    it("name-only round-trip: get retrieves data written without an id", () => {
+      updateVariable({
+        data: { page: "home" },
+        dataElementName: "MyVar",
+        transforms: {},
+      });
+      const result = getVariable({ dataElementName: "MyVar" });
+      expect(result).toEqual({ page: "home" });
+    });
+
     it("Case 1: old rule (id-only) — get with same id retrieves the data", () => {
       updateVariable({
         data: { page: "home" },

--- a/packages/reactor-extension/test/unit/lib/dataElements/variable/createGetVariable.spec.js
+++ b/packages/reactor-extension/test/unit/lib/dataElements/variable/createGetVariable.spec.js
@@ -3,7 +3,6 @@ Copyright 2023 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software distributed under
 the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 OF ANY KIND, either express or implied. See the License for the specific language
@@ -12,13 +11,16 @@ governing permissions and limitations under the License.
 
 import { describe, it, expect, beforeEach } from "vitest";
 import createGetVariable from "../../../../../src/lib/dataElements/variable/createGetVariable";
+import createUpdateVariable from "../../../../../src/lib/actions/updateVariable/createUpdateVariable";
+import createVariableStore from "../../../../../src/lib/createVariableStore";
+import deepAssign from "../../../helpers/deepAssign";
 
 describe("Variable data element", () => {
   let variableStore;
   let getVariable;
 
   beforeEach(() => {
-    variableStore = {};
+    variableStore = createVariableStore();
     getVariable = createGetVariable({ variableStore });
   });
 
@@ -27,8 +29,8 @@ describe("Variable data element", () => {
     expect(result).toEqual({});
   });
 
-  it("returns variable by dataElementName when it exists", () => {
-    variableStore.myVariable = { a: 1, b: 2 };
+  it("returns variable by dataElementId when it exists", () => {
+    variableStore.set("DE123", { a: 1, b: 2 });
     const result = getVariable({
       dataElementName: "myVariable",
       dataElementId: "DE123",
@@ -36,38 +38,115 @@ describe("Variable data element", () => {
     expect(result).toEqual({ a: 1, b: 2 });
   });
 
-  it("falls back to dataElementId when dataElementName is not in store", () => {
-    variableStore.DE123 = { c: 3, d: 4 };
-    const result = getVariable({
-      dataElementName: "nonexistent",
-      dataElementId: "DE123",
-    });
-    expect(result).toEqual({ c: 3, d: 4 });
-  });
-
-  it("falls back to dataElementId when dataElementName is not provided", () => {
-    variableStore.DE123 = { e: 5 };
-    const result = getVariable({
-      dataElementId: "DE123",
-    });
+  it("returns variable by dataElementId when only id is provided", () => {
+    variableStore.set("DE123", { e: 5 });
+    const result = getVariable({ dataElementId: "DE123" });
     expect(result).toEqual({ e: 5 });
   });
 
-  it("prefers dataElementName over dataElementId when both exist in store", () => {
-    variableStore.myVariable = { fromName: true };
-    variableStore.DE123 = { fromId: true };
+  it("searches by name index when id is not in the store — does not treat name as a key", () => {
+    variableStore.set("DE123", { c: 3, d: 4 });
+    variableStore.registerName("DE123", "myVariable");
     const result = getVariable({
       dataElementName: "myVariable",
-      dataElementId: "DE123",
+      dataElementId: "nonexistent",
     });
-    expect(result).toEqual({ fromName: true });
+    expect(result).toEqual({ c: 3, d: 4 });
+    // Confirm no name-keyed entry was created.
+    expect(variableStore.get("myVariable")).toBeUndefined();
   });
 
-  it("returns empty object when neither name nor id exist in store", () => {
+  it("returns empty object when neither id nor registered name exist in store", () => {
     const result = getVariable({
       dataElementName: "nonexistent",
       dataElementId: "alsoNonexistent",
     });
     expect(result).toEqual({});
+  });
+
+  describe("round-trip: get reads what update writes", () => {
+    let updateVariable;
+
+    beforeEach(() => {
+      updateVariable = createUpdateVariable({ variableStore, deepAssign });
+    });
+
+    it("Case 1: old rule (id-only) — get with same id retrieves the data", () => {
+      updateVariable({
+        data: { page: "home" },
+        dataElementId: "DE123",
+        transforms: {},
+      });
+      const result = getVariable({ dataElementId: "DE123" });
+      expect(result).toEqual({ page: "home" });
+    });
+
+    it("Case 2: new rule (id+name) — get with same id+name retrieves the data", () => {
+      updateVariable({
+        data: { page: "home" },
+        dataElementId: "DE123",
+        dataElementName: "MyVar",
+        transforms: {},
+      });
+      const result = getVariable({
+        dataElementId: "DE123",
+        dataElementName: "MyVar",
+      });
+      expect(result).toEqual({ page: "home" });
+    });
+
+    it("Case 1+2 mixed: get retrieves data accumulated by both old (id-only) and new (id+name) rules", () => {
+      updateVariable({
+        data: { page: "home" },
+        dataElementId: "DE123",
+        transforms: {},
+      });
+      updateVariable({
+        data: { user: "guest" },
+        dataElementId: "DE123",
+        dataElementName: "MyVar",
+        transforms: {},
+      });
+      const result = getVariable({
+        dataElementId: "DE123",
+        dataElementName: "MyVar",
+      });
+      expect(result).toEqual({ page: "home", user: "guest" });
+    });
+
+    it("Case 3: all rules on copied property use same outdated id — get retrieves all accumulated data", () => {
+      updateVariable({
+        data: { page: "home" },
+        dataElementId: "DE-original",
+        dataElementName: "MyVar",
+        transforms: {},
+      });
+      updateVariable({
+        data: { user: "guest" },
+        dataElementId: "DE-original",
+        dataElementName: "MyVar",
+        transforms: {},
+      });
+      const result = getVariable({
+        dataElementId: "DE-original",
+        dataElementName: "MyVar",
+      });
+      expect(result).toEqual({ page: "home", user: "guest" });
+    });
+
+    it("get finds data via name index when its own id is stale but updates registered a name mapping", () => {
+      // Update rules re-saved on copied property (new id), but Variable DE not yet re-saved (old id).
+      updateVariable({
+        data: { page: "home" },
+        dataElementId: "DE-copy",
+        dataElementName: "MyVar",
+        transforms: {},
+      });
+      const result = getVariable({
+        dataElementId: "DE-original",
+        dataElementName: "MyVar",
+      });
+      expect(result).toEqual({ page: "home" });
+    });
   });
 });

--- a/packages/reactor-extension/test/unit/lib/dataElements/variable/createGetVariable.spec.js
+++ b/packages/reactor-extension/test/unit/lib/dataElements/variable/createGetVariable.spec.js
@@ -77,8 +77,26 @@ describe("Variable data element", () => {
         dataElementName: "MyVar",
         transforms: {},
       });
-      const result = getVariable({ dataElementName: "MyVar" });
-      expect(result).toEqual({ page: "home" });
+      expect(getVariable({ dataElementName: "MyVar" })).toEqual({
+        page: "home",
+      });
+    });
+
+    it("name-only write before id+name write: get retrieves all accumulated data", () => {
+      updateVariable({
+        data: { a: 1 },
+        dataElementName: "MyVar",
+        transforms: {},
+      });
+      updateVariable({
+        data: { b: 2 },
+        dataElementId: "DE123",
+        dataElementName: "MyVar",
+        transforms: {},
+      });
+      expect(
+        getVariable({ dataElementId: "DE123", dataElementName: "MyVar" }),
+      ).toEqual({ a: 1, b: 2 });
     });
 
     it("Case 1: old rule (id-only) — get with same id retrieves the data", () => {


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Changed Packages
<!--- Indicate which package your changes directly affect. -->
<!--- (i.e., do not choose the extension if it's only change is updating its core version). -->
- [ ] core
- [x] reactor-extension 

## Description

createVariableStore was refactored into an encapsulated store that maintains a nameToKey index. createUpdateVariable now calls registerName on every write to keep that index current. On read it calls resolveKey, first looking up entries by  dataElementId, falling back to a name-indexed lookup, and only using dataElementName as a raw key as a last resort. createGetVariable mirrors this: it tries a direct id lookup first, then searches via findByName through the name index rather than treating the name as a literal key.

## Related Issue

[JIRA](https://jira.corp.adobe.com/browse/PLATIR-64357)

## Motivation and Context

A flaw in our 're-save to update' solution to dataElementId drift after copying is that the user must re-save ALL actions referring to the property. The built script wants to refer to data elements in the variable store by their name when it can, so some actions have been resaved (now bearing a dataElementName) and others haven't (only have a dataElementId), the SDK will not know they are referring to the same data element. This change addresses that issue by always keying data elements by ID, even when the name is present (unless only the name is present). To mitigate some issues when a user does not re-save their actions, logic is included to fallback to the dataElementName to look up the dataElement only when the ID is not present (This does not retrieve from the store using the name as the index, it uses a mapping to determine the entry in the store with a matching name).

## Screenshots (if appropriate):

N/A

## Documentation

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Run `pnpm changeset` if this needs a release with a changelog entry, `pnpm changeset --empty` if it needs a release without one, or push without a changeset if no release is needed. -->
<!--- For more information about the changesets or the release process, see https://github.com/adobe/alloy/wiki/Release-process -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added a Changeset file with a consumer-facing description of my changes.
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
