### PR TITLE
Fixed release publish crashing on EBADDEVENGINES from devEngines.packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "packageManager": {
       "name": "pnpm",
       "version": "^11.4.0",
-      "onFail": "download"
+      "onFail": "warn"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
## Changed Packages
<!--- Root release tooling only — no core or extension code touched. -->
- [ ] core
- [ ] reactor-extension

## Description

Softened `devEngines.packageManager.onFail` from `download` → `warn` in the root
`package.json`. That's the whole change.

The publish step runs `pnpm changeset publish`, and changesets shells out to a
literal `npm info` regardless of what package manager we use. npm 11 enforces
`devEngines.packageManager` on *every* command, so that npm call saw "required
pnpm vs running npm" and hard-aborted.

[The `download` onFail action is only a pnpm thing](https://pnpm.io/package_json#devenginespackagemanager) — [npm/corepack doesn't implement it](https://github.com/nodejs/corepack#devenginespackagemanager),
so under npm it just falls back to `error`. `warn` keeps the guard that yells at
you if you accidentally `npm install` or `yarn install`, or in this case, `npm info`, locally, without blowing
up the publish.

## Related Issue

Tracked upstream in changesets/changesets#965 — I left a comment with our exact repro:
https://github.com/changesets/changesets/issues/965#issuecomment-4635375759

The real fix is changesets PR changesets/changesets#2047 (makes `changeset publish`
use the project's package manager for the info query instead of hardcoding `npm info`).
Once that ships we can bump `onFail` back to `download` if we want the hard guard.

## Motivation and Context

The release publish job died here:
https://github.com/adobe/alloy/actions/runs/27036637287/job/79802227079

with:

```
🦋  error Received an unknown error code: EBADDEVENGINES for npm info "@adobe/alloy"
🦋  error The developer of this package has specified the following through devEngines
🦋  error Invalid devEngines.packageManager
🦋  error Invalid name "pnpm" does not match "npm" for "packageManager"
```

This regressed in #1523, which swapped `packageManager: pnpm@10.33.2` for the
`devEngines.packageManager` block. The old corepack field wasn't validated by npm;
the new one is.

apify/proxy-chain hit the identical wall and fixed it the same way (error → warn):
https://github.com/apify/proxy-chain/pull/662

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have added a Changeset file — N/A, release-tooling change, nothing consumer-facing.
- [x] I have signed the Adobe Open Source CLA or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully — N/A for this change.
