### PR TITLE
Fixed incorrect Azure Static Website CLI arg

### DIFF
--- a/sandboxes/browser/scripts/release.mjs
+++ b/sandboxes/browser/scripts/release.mjs
@@ -53,7 +53,7 @@ run("pnpm", [
   "swa", // from @azure/static-web-apps-cli
   "deploy",
   buildDir,
-  "--api-key",
+  "--deployment-token",
   token,
   "--env",
   "Production",


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->

## Changed Packages
- [ ] core
- [ ] reactor-extension

## Description

Changed `--api-key` to `--deployment-token` in the browser sandbox release script (`sandboxes/browser/scripts/release.mjs`), which is the correct CLI argument for the Azure Static Web Apps CLI.

## Related Issue

N/A

## Motivation and Context

The Azure Static Web Apps CLI uses `--deployment-token`, not `--api-key`. Using the wrong argument would cause the browser SDK release deployment to fail.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added a Changeset file with a consumer-facing description of my changes.
- [x] I have signed the Adobe Open Source CLA or I'm an Adobe employee.
- [ ] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully.