### PR TITLE
Fixed swallowed release build errors and serialized side-effect deploys

### DIFF
--- a/.github/workflows/version-and-publish.yml
+++ b/.github/workflows/version-and-publish.yml
@@ -92,11 +92,14 @@ jobs:
       # @adobe/alloy → CDN + 'next' dist-tag (when prerelease)
       # reactor-extension → Reactor upload
       # sandboxes/browser → Azure deploy
+      #
+      # --workspace-concurrency=1 runs the deploys serially, which is less resource intensive
+      # on small GitHub CI runners.
       - name: Side-effect deploys
         env:
           REACTOR_IO_INTEGRATION_CLIENT_SECRET: ${{ secrets.REACTOR_IO_INTEGRATION_CLIENT_SECRET }}
           AZURE_STATIC_WEB_APPS_API_TOKEN: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_AGREEABLE_RIVER_0EC96991E }}
-        run: pnpm -r --if-present run release
+        run: pnpm -r --workspace-concurrency=1 --if-present run release
 
       # Iterates git tags at HEAD; skips existing releases.
       - name: GitHub Releases

--- a/packages/reactor-extension/package.json
+++ b/packages/reactor-extension/package.json
@@ -17,7 +17,7 @@
     "build:extensionManifest": "./scripts/buildExtensionManifest.mjs --verbose",
     "build:lib": "./scripts/buildLib.mjs",
     "build:views": "./scripts/buildViews.mjs",
-    "build": "conc --pad-prefix --names \"alloy,alloy-preinstalled,fixtures,manifest,lib,views\" \"pnpm run build:alloy\" \"pnpm run build:alloy:preinstalled\" \"pnpm run build:componentFixtures\" \"pnpm run build:extensionManifest\" \"pnpm run build:lib\" \"pnpm run build:views\"",
+    "build": "pnpm run \"/^build:/\"",
     "watch:lib": "./scripts/buildLib.mjs --watch",
     "watch:views": "./scripts/buildViews.mjs --watch",
     "watch": "conc --pad-prefix --names \"alloy,fixtures,manifest,lib,views\" \"pnpm run build:alloy\" \"pnpm run build:componentFixtures\" \"pnpm run build:extensionManifest\" \"pnpm run watch:lib\" \"pnpm run watch:views\"",

--- a/packages/reactor-extension/scripts/createExtensionPackage.mjs
+++ b/packages/reactor-extension/scripts/createExtensionPackage.mjs
@@ -59,14 +59,16 @@ const execute = (
   );
 
   if (r.status !== 0) {
-    if (r.stderr) {
-      const error = r.stderr.toString().trim();
-      throw new Error(error);
-    } else {
-      throw new Error(
-        `An error occurred while executing the command: ${command}.`,
-      );
-    }
+    // When stdio is captured (non-verbose), surface BOTH streams. Tools like
+    // `concurrently` write sub-process build errors to stdout, not stderr, so
+    // looking at stderr alone yields only the bare command echo and hides the
+    // real failure.
+    const stdout = r.stdout ? r.stdout.toString().trim() : "";
+    const stderr = r.stderr ? r.stderr.toString().trim() : "";
+    const details = [stdout, stderr].filter(Boolean).join("\n");
+    throw new Error(
+      details || `An error occurred while executing the command: ${command}.`,
+    );
   }
 };
 
@@ -284,12 +286,14 @@ const buildExtensionZip = async ({
 };
 
 /**
- * @param {{ verbose?: boolean }} [options]
  * @returns {Promise<string>} Absolute path to the produced zip file.
  */
-export const createExtensionPackage = async ({ verbose } = {}) => {
+export const createExtensionPackage = async () => {
   console.log("Running the build process (`pnpm run build`)...");
-  execute("pnpm", ["run", "build"], { cwd, verbose });
+  // Always stream the build live. It's the longest, noisiest step and the one
+  // most likely to fail; inheriting stdio guarantees the underlying error
+  // (e.g. a killed concurrently sub-build) lands in the CI log.
+  execute("pnpm", ["run", "build"], { cwd, verbose: true });
 
   const packagePath = getExtensionPackagePath(getExtensionJson());
 
@@ -316,8 +320,6 @@ if (invokedAsCli) {
   program
     .name("createExtensionPackage")
     .description("Tool for generating the alloy extension package for Tags.");
-
-  program.option("-v, --verbose", "verbose mode", false);
 
   program.action(createExtensionPackage);
 

--- a/packages/reactor-extension/scripts/createExtensionPackage.mjs
+++ b/packages/reactor-extension/scripts/createExtensionPackage.mjs
@@ -58,16 +58,24 @@ const execute = (
     Object.assign(options, verbose ? { stdio: "inherit" } : {}),
   );
 
-  if (r.status !== 0) {
-    // When stdio is captured (non-verbose), surface BOTH streams. Tools like
-    // `concurrently` write sub-process build errors to stdout, not stderr, so
-    // looking at stderr alone yields only the bare command echo and hides the
-    // real failure.
-    const stdout = r.stdout ? r.stdout.toString().trim() : "";
-    const stderr = r.stderr ? r.stderr.toString().trim() : "";
-    const details = [stdout, stderr].filter(Boolean).join("\n");
+  if (r.status !== 0 || r.error) {
+    // Surface every failure mode:
+    //  - r.error: the command couldn't be spawned at all (e.g. ENOENT).
+    //  - r.signal: the process was killed by a signal (e.g. SIGKILL from an
+    //    OOM kill) — status is null in that case, and it's the failure we most
+    //    want to catch on small CI runners.
+    //  - stdout/stderr: when captured (non-verbose). Tools like `concurrently`
+    //    write sub-process build errors to stdout, not stderr, so stderr alone
+    //    yields only the bare command echo and hides the real failure.
+    const parts = [
+      r.error && r.error.message,
+      r.signal && `Killed by signal ${r.signal}`,
+      r.stdout && r.stdout.toString().trim(),
+      r.stderr && r.stderr.toString().trim(),
+    ].filter(Boolean);
     throw new Error(
-      details || `An error occurred while executing the command: ${command}.`,
+      parts.join("\n") ||
+        `An error occurred while executing the command: ${command}.`,
     );
   }
 };

--- a/packages/reactor-extension/scripts/createExtensionPackage.mjs
+++ b/packages/reactor-extension/scripts/createExtensionPackage.mjs
@@ -59,14 +59,10 @@ const execute = (
   );
 
   if (r.status !== 0 || r.error) {
-    // Surface every failure mode:
-    //  - r.error: the command couldn't be spawned at all (e.g. ENOENT).
-    //  - r.signal: the process was killed by a signal (e.g. SIGKILL from an
-    //    OOM kill) — status is null in that case, and it's the failure we most
-    //    want to catch on small CI runners.
-    //  - stdout/stderr: when captured (non-verbose). Tools like `concurrently`
-    //    write sub-process build errors to stdout, not stderr, so stderr alone
-    //    yields only the bare command echo and hides the real failure.
+    // concurrently/pnpm write sub-build errors to stdout, not stderr, so report
+    // both streams. r.error covers a failed spawn (e.g. ENOENT) and r.signal a
+    // kill (e.g. an OOM SIGKILL, which leaves status null) — the failure we most
+    // want to surface on small CI runners.
     const parts = [
       r.error && r.error.message,
       r.signal && `Killed by signal ${r.signal}`,

--- a/packages/reactor-extension/scripts/extensionBuild.spec.js
+++ b/packages/reactor-extension/scripts/extensionBuild.spec.js
@@ -56,7 +56,7 @@ const buildAndRead = async (forgeDir, { env, flags = "", signal } = {}) => {
 const test = baseTest
   // eslint-disable-next-line no-empty-pattern
   .extend("extensionPackage", { scope: "file" }, async ({}, { onCleanup }) => {
-    const extensionPackage = await createExtensionPackage({ verbose: false });
+    const extensionPackage = await createExtensionPackage();
     onCleanup(() => fs.rmSync(extensionPackage, { force: true }));
     return extensionPackage;
   })


### PR DESCRIPTION
## Changed Packages
- [ ] core
- [x] reactor-extension

## Description

Follow-up hardening to the release pipeline after the recent reworks (#1523, #1527).

- **Surface the real build error.** `createExtensionPackage.mjs`'s `execute()` threw only `r.stderr` on failure, but `concurrently` writes its sub-build errors to **stdout** — so a failed build surfaced as a bare `Error: $ conc --pad-prefix ...` echo with no cause. It now includes both stdout and stderr, and the `build` step always inherits stdio so its output streams live into the CI log. (The now-dead `--verbose` flag/param was removed.)
- **Replace `concurrently` with native pnpm in the `build` script.** `pnpm run "/^build:/"` runs the six `build:*` scripts in parallel with per-script output labels and proper exit-code propagation, so the `conc` wrapper added nothing. `concurrently` remains a devDependency because `watch`/`dev`/`test:functional*` still need its `--kill-others` semantics.
- **Serialize the side-effect deploys.** The workflow now runs `pnpm -r --workspace-concurrency=1 --if-present run release` so the heavy per-package builds don't race (and OOM) on small GitHub runners, and logs stay readable.

## Related Issue

N/A — operational follow-up to #1523 / #1527.

## Motivation and Context

A release run failed with only `Error: $ conc --pad-prefix ...` and no diagnosable cause. The root cause was the swallowed stdout; the parallel deploys were the likely trigger. These changes make any future failure self-explanatory in the logs and reduce the contention that caused it.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which does not add functionality)

## Checklist:

- [ ] Changeset — **not needed**; CI/release tooling only, no consumer-facing change.
- [x] I have signed the Adobe Open Source CLA or I'm an Adobe employee.
- [x] Verified the extension build locally via both paths (exit 0, identical `dist/` output).
- [ ] N/A — no sandbox-affecting change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)