### PR TITLE
Fixed reactor-extension and browser-sandbox release deploy failures

### DIFF
--- a/packages/reactor-extension/babel.config.json
+++ b/packages/reactor-extension/babel.config.json
@@ -2,11 +2,7 @@
   "plugins": ["version"],
   "env": {
     "production": {
-      "plugins": [
-        "babel-plugin-jsx-remove-data-test-id",
-        "@babel/plugin-transform-nullish-coalescing-operator",
-        "@babel/plugin-transform-optional-chaining"
-      ]
+      "plugins": ["babel-plugin-jsx-remove-data-test-id"]
     }
   }
 }

--- a/packages/reactor-extension/scripts/buildAlloy.mjs
+++ b/packages/reactor-extension/scripts/buildAlloy.mjs
@@ -29,7 +29,13 @@ const execute = (command, options) => {
     spawn(command, options, {
       stdio: "inherit",
     })
-      .on("exit", resolve)
+      .on("exit", (code) => {
+        if (code === 0) {
+          resolve(code);
+        } else {
+          reject(new Error(`${command} exited with code ${code}`));
+        }
+      })
       .on("error", reject);
   });
 };

--- a/packages/reactor-extension/scripts/buildAlloy.mjs
+++ b/packages/reactor-extension/scripts/buildAlloy.mjs
@@ -178,8 +178,10 @@ program.action(async ({ inputFile, outputDir, ...modules }) => {
 
     fs.writeFileSync(entryFile, output);
   } catch (e) {
-    fs.unlinkSync(entryFile);
     console.error(e);
+    if (entryFile && fs.existsSync(entryFile)) {
+      fs.unlinkSync(entryFile);
+    }
     process.exit(1);
   }
 });

--- a/sandboxes/browser/public/routes.json
+++ b/sandboxes/browser/public/routes.json
@@ -1,9 +1,0 @@
-{
-  "routes": [
-    {
-      "route": "/*",
-      "serve": "/index.html",
-      "statusCode": 200
-    }
-  ]
-}

--- a/sandboxes/browser/public/staticwebapp.config.json
+++ b/sandboxes/browser/public/staticwebapp.config.json
@@ -1,0 +1,5 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html"
+  }
+}

--- a/sandboxes/browser/scripts/release.mjs
+++ b/sandboxes/browser/scripts/release.mjs
@@ -56,5 +56,5 @@ run("pnpm", [
   "--deployment-token",
   token,
   "--env",
-  "Production",
+  "production",
 ]);


### PR DESCRIPTION
## Changed Packages
- [ ] core
- [x] reactor-extension
<!-- also affects sandboxes/browser (not a published consumer package) -->

## Description

Fixes the "Side-effect deploys" step of the release pipeline, which was failing for both `reactor-extension-alloy` and `@adobe/alloy-sandbox-browser` ([failed run](https://github.com/adobe/alloy/actions/runs/27212390521/job/80344716004)). Four independent fixes:

**1. reactor-extension production build — missing babel plugins**
`babel.config.json`'s `production` env referenced `@babel/plugin-transform-nullish-coalescing-operator` and `@babel/plugin-transform-optional-chaining`, neither declared as a dependency. Under pnpm's strict, non-hoisted layout these aren't resolvable from the package, so `babel.transformFileSync` threw during the `NODE_ENV=production` build. Both transforms are already bundled in `@babel/preset-env`, so they were redundant and are removed.
- Babel: [`@babel/preset-env`](https://babeljs.io/docs/babel-preset-env) already includes [transform-nullish-coalescing-operator](https://babeljs.io/docs/babel-plugin-transform-nullish-coalescing-operator) and [transform-optional-chaining](https://babeljs.io/docs/babel-plugin-transform-optional-chaining).
- pnpm: undeclared/transitive deps are intentionally not resolvable — [pnpm node_modules structure](https://pnpm.io/symlinked-node-modules-structure).

**2. buildAlloy.mjs — build errors were hidden two ways**
Two related fixes so a build failure surfaces its real cause instead of a misleading one:
- The `catch` ran `fs.unlinkSync(entryFile)` *before* `console.error(e)`, and `entryFile` is `undefined` if the first step throws — so the real babel error (fix #1) was replaced by a bogus `ERR_INVALID_ARG_TYPE`, which is what we chased in CI. Now it logs first and only unlinks a file that exists.
- The `execute` helper resolved its promise on *any* exit code; only a failed spawn rejected. A non-zero `rollup` exit therefore slipped past the `catch`, and babel ran on partial output instead of surfacing the failure. It now rejects on a non-zero exit so the `catch`/cleanup fires.

(Complements #1528, which made the build stream to the CI log but didn't touch this handler.)
- Node: [`fs.unlinkSync` requires a valid path](https://nodejs.org/api/fs.html#fsunlinksyncpath); [`child_process.spawn` `exit` event](https://nodejs.org/api/child_process.html#event-exit) fires for any exit code.

**3. sandbox SWA deploy — wrong environment name**
The deploy passed `--env Production` (capital P). The SWA CLI is case-sensitive: only lowercase `production` targets the production environment; `Production` is treated as a *named preview* environment, which is rejected (silent non-zero exit). Verified with `swa deploy --dry-run`: `Production` → `Deploying to environment: Production`, `production` → `Deploying to environment: production`. Note the CLI also defaults to `preview` (unlike the old `Azure/static-web-apps-deploy` action that defaulted to production), so the explicit `--env production` is required.
- [`swa deploy` reference](https://azure.github.io/static-web-apps-cli/docs/cli/swa-deploy/) (`--env` default `preview`).
- [Deploy with the SWA CLI](https://learn.microsoft.com/en-us/azure/static-web-apps/static-web-apps-cli-deploy) — production example uses `--env production`.

**4. sandbox routing — migrate deprecated routes.json → staticwebapp.config.json**
`routes.json` is deprecated and silently ignored by SWA (logged on every deploy), meaning the SPA fallback wasn't actually active. Migrated the catch-all to `navigationFallback`, dropping the legacy `"/*"` route as the docs direct. Vite copies `public/` to the build root, so the file lands where SWA expects it.
- [Configure Static Web Apps](https://learn.microsoft.com/en-us/azure/static-web-apps/configuration) — `navigationFallback`; "do not include the legacy fallback route (`"route": "/*"`)"; config must be at the output root.
- [Deprecated routes.json reference](https://github.com/Azure/static-web-apps/wiki/routes.json-reference-%28deprecated%29).

## Related Issue

N/A — surfaced by the failing release run linked above.

## Steps to reproduce

- **reactor-extension build (fixes #1/#2):** from `packages/reactor-extension`, run `NODE_ENV=production node ./scripts/buildAlloy.mjs -i src/lib/alloy.js -o dist/lib` (after `mkdir -p dist/lib`). Before the fix this dies with `ERR_INVALID_ARG_TYPE` at the `unlinkSync` in the catch handler (masking the real `Cannot find module '@babel/plugin-transform-nullish-coalescing-operator'`). After, it exits 0. Note: must be run with plain `node`, not the test runner — vitest sets `NODE_PATH` to pnpm's virtual store, which makes the undeclared plugins resolvable and hides the failure.
- **sandbox deploy (fixes #3/#4):** from `sandboxes/browser`, `pnpm run build` then `pnpm exec swa deploy ./build --deployment-token <token> --env Production --dry-run` reports `Deploying to environment: Production` (a named env) and logs the legacy `routes.json` warning. With the fixes (`production` + `staticwebapp.config.json`) it reports `Deploying to environment: production` and no legacy warning.

## Motivation and Context

The release pipeline reworked in #1523 routes both packages through their own `release.mjs`. This was the first time the `reactor-extension` `NODE_ENV=production` build and the new `swa deploy` CLI invocation ran on every publish, exposing latent bugs.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added a Changeset file with a consumer-facing description of my changes.
- [x] I have signed the Adobe Open Source CLA or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
