### PR TITLE
Hardened the release pipeline: staging order, non-bailing deploys, and louder child-process errors

### DIFF
--- a/.github/workflows/version-and-publish.yml
+++ b/.github/workflows/version-and-publish.yml
@@ -87,19 +87,12 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.CDN_PRIVATE_KEY }}
 
-      # Each package owns its deploy via a `release` script that's idempotent:
-      # read pkg.version, check the target, exit 0 if already at that version.
-      # @adobe/alloy → CDN + 'next' dist-tag (when prerelease)
-      # reactor-extension → Reactor upload
-      # sandboxes/browser → Azure deploy
-      #
-      # --workspace-concurrency=1 runs the deploys serially, which is less resource intensive
-      # on small GitHub CI runners.
+      # Each package owns its deploy via a `release` script that's idempotent
       - name: Side-effect deploys
         env:
           REACTOR_IO_INTEGRATION_CLIENT_SECRET: ${{ secrets.REACTOR_IO_INTEGRATION_CLIENT_SECRET }}
           AZURE_STATIC_WEB_APPS_API_TOKEN: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_AGREEABLE_RIVER_0EC96991E }}
-        run: pnpm -r --workspace-concurrency=1 --if-present run release
+        run: pnpm --recursive --workspace-concurrency=1 --no-bail --if-present run release
 
       # Iterates git tags at HEAD; skips existing releases.
       - name: GitHub Releases

--- a/packages/browser/test/integration/specs/Advertising/viewthrough_ids.spec.js
+++ b/packages/browser/test/integration/specs/Advertising/viewthrough_ids.spec.js
@@ -19,7 +19,6 @@ import {
   validateViewThroughCall,
   ADVERTISING_CONSTANTS,
 } from "../../helpers/advertising.js";
-import waitFor from "../../helpers/utils/waitFor.js";
 
 describe("Advertising - Viewthrough with advertising IDs", () => {
   test("should send conversion query with advertising IDs in view-through", async ({
@@ -38,16 +37,21 @@ describe("Advertising - Viewthrough with advertising IDs", () => {
       advertising: { handleAdvertisingData: "auto" },
     });
 
-    await waitFor(200);
+    // Poll for a *complete* view-through call rather than waiting a fixed time
+    // then checking once: findCalls resolves on the first completed edge call,
+    // which can precede the advertising enrichment call on a slow runner.
+    const getFirstViewThrough = async () => {
+      const calls = await networkRecorder.findCalls(/edge\.adobedc\.net/, {
+        retries: 1,
+      });
+      return findViewThroughCalls(calls)[0];
+    };
 
-    const calls = await networkRecorder.findCalls(/edge\.adobedc\.net/, {
-      retries: 20,
-      delayMs: 100,
-    });
-    const [firstView] = findViewThroughCalls(calls);
-    expect(firstView).toBeTruthy();
+    await expect
+      .poll(getFirstViewThrough, { timeout: 5000, interval: 100 })
+      .toBeTruthy();
 
-    validateViewThroughCall(firstView, {
+    validateViewThroughCall(await getFirstViewThrough(), {
       advIds: ADVERTISING_CONSTANTS.DEFAULT_ADVERTISER_IDS_STRING,
       requireIds: false,
     });

--- a/packages/reactor-extension/scripts/buildAlloy.mjs
+++ b/packages/reactor-extension/scripts/buildAlloy.mjs
@@ -29,9 +29,11 @@ const execute = (command, options) => {
     spawn(command, options, {
       stdio: "inherit",
     })
-      .on("exit", (code) => {
+      .on("exit", (code, signal) => {
         if (code === 0) {
           resolve(code);
+        } else if (signal) {
+          reject(new Error(`${command} killed by signal ${signal}`));
         } else {
           reject(new Error(`${command} exited with code ${code}`));
         }

--- a/packages/reactor-extension/scripts/buildAlloyPreinstalled.mjs
+++ b/packages/reactor-extension/scripts/buildAlloyPreinstalled.mjs
@@ -30,7 +30,13 @@ const execute = (command, options) => {
     spawn(command, options, {
       stdio: "inherit",
     })
-      .on("exit", resolve)
+      .on("exit", (code) => {
+        if (code === 0) {
+          resolve(code);
+        } else {
+          reject(new Error(`${command} exited with code ${code}`));
+        }
+      })
       .on("error", reject);
   });
 };

--- a/packages/reactor-extension/scripts/buildAlloyPreinstalled.mjs
+++ b/packages/reactor-extension/scripts/buildAlloyPreinstalled.mjs
@@ -30,9 +30,11 @@ const execute = (command, options) => {
     spawn(command, options, {
       stdio: "inherit",
     })
-      .on("exit", (code) => {
+      .on("exit", (code, signal) => {
         if (code === 0) {
           resolve(code);
+        } else if (signal) {
+          reject(new Error(`${command} killed by signal ${signal}`));
         } else {
           reject(new Error(`${command} exited with code ${code}`));
         }

--- a/packages/reactor-extension/scripts/buildLib.mjs
+++ b/packages/reactor-extension/scripts/buildLib.mjs
@@ -29,14 +29,19 @@ const libOutDir = path.join(outputDir, "lib");
 const alloyInFile = path.join(libInDir, "alloy.js");
 
 // ignore alloy.js because it will be built separately in buildAlloy.js
-run("babel", [
-  libInDir,
-  "--out-dir",
-  libOutDir,
-  "--ignore",
-  alloyInFile,
-  "--presets=@babel/preset-env",
-]);
+try {
+  await run("babel", [
+    libInDir,
+    "--out-dir",
+    libOutDir,
+    "--ignore",
+    alloyInFile,
+    "--presets=@babel/preset-env",
+  ]);
+} catch (error) {
+  console.error(error);
+  process.exit(1);
+}
 
 if (watch) {
   const babelWatchSubprocess = spawn(

--- a/packages/reactor-extension/scripts/createExtensionPackage.mjs
+++ b/packages/reactor-extension/scripts/createExtensionPackage.mjs
@@ -247,8 +247,16 @@ const getManifestFilepaths = () => {
     ],
     { cwd, encoding: "utf8" },
   );
-  if (r.status !== 0) {
-    throw new Error(`getPackagePaths failed: ${r.stderr || r.stdout}`);
+  if (r.status !== 0 || r.error) {
+    const parts = [
+      r.error && r.error.message,
+      r.signal && `Killed by signal ${r.signal}`,
+      r.stderr && r.stderr.toString().trim(),
+      r.stdout && r.stdout.toString().trim(),
+    ].filter(Boolean);
+    throw new Error(
+      `getPackagePaths failed: ${parts.join("\n") || "(no output)"}`,
+    );
   }
   return JSON.parse(r.stdout);
 };

--- a/packages/reactor-extension/scripts/createExtensionPackage.mjs
+++ b/packages/reactor-extension/scripts/createExtensionPackage.mjs
@@ -161,9 +161,19 @@ const packVendoredWorkspacePackages = (destDir) => {
   fs.mkdirSync(vendorDir, { recursive: true });
   return VENDORED_PACKAGES.map(({ name, dir }) => {
     console.log(`Packing ${name}...`);
-    execute("pnpm", ["pack", "--pack-destination", vendorDir], { cwd: dir });
     const pkg = JSON.parse(
       fs.readFileSync(path.join(dir, "package.json"), "utf8"),
+    );
+    // Pack (with scripts off) so prepack (a full build that deletes distTest)
+    // can't race the browser integration tests reading it; build first only
+    // if the package isn't already built.
+    if (pkg.scripts?.build && !fs.existsSync(path.join(dir, "dist"))) {
+      execute("pnpm", ["run", "--if-present", "build"], { cwd: dir });
+    }
+    execute(
+      "pnpm",
+      ["pack", "--config.ignore-scripts=true", "--pack-destination", vendorDir],
+      { cwd: dir },
     );
     const tgzName = `${name.replace(/^@/, "").replace("/", "-")}-${pkg.version}.tgz`;
     if (!fs.existsSync(path.join(vendorDir, tgzName))) {

--- a/packages/reactor-extension/scripts/createExtensionPackage.mjs
+++ b/packages/reactor-extension/scripts/createExtensionPackage.mjs
@@ -293,6 +293,9 @@ const buildExtensionZip = async ({
  * @returns {Promise<string>} Absolute path to the produced zip file.
  */
 export const createExtensionPackage = async () => {
+  const { packageJson, packageLockJson, vendoredPackages } =
+    stageInstallablePackages();
+
   console.log("Running the build process (`pnpm run build`)...");
   // Always stream the build live. It's the longest, noisiest step and the one
   // most likely to fail; inheriting stdio guarantees the underlying error
@@ -300,9 +303,6 @@ export const createExtensionPackage = async () => {
   execute("pnpm", ["run", "build"], { cwd, verbose: true });
 
   const packagePath = getExtensionPackagePath(getExtensionJson());
-
-  const { packageJson, packageLockJson, vendoredPackages } =
-    stageInstallablePackages();
 
   console.log("Building the extension zip...");
   await buildExtensionZip({

--- a/packages/reactor-extension/scripts/helpers/run.mjs
+++ b/packages/reactor-extension/scripts/helpers/run.mjs
@@ -3,9 +3,11 @@ import { spawn } from "child_process";
 export default (command, args) =>
   new Promise((resolve, reject) => {
     spawn(command, args, { stdio: "inherit" })
-      .on("exit", (code) => {
+      .on("exit", (code, signal) => {
         if (code === 0) {
           resolve(code);
+        } else if (signal) {
+          reject(new Error(`${command} killed by signal ${signal}`));
         } else {
           reject(new Error(`${command} exited with code ${code}`));
         }

--- a/packages/reactor-extension/scripts/helpers/run.mjs
+++ b/packages/reactor-extension/scripts/helpers/run.mjs
@@ -1,20 +1,14 @@
 import { spawn } from "child_process";
 
-const toPromise = (func) => {
-  return new Promise((resolve, reject) => {
-    const callback = (error) => {
-      if (error) {
-        reject(error);
-      } else {
-        resolve();
-      }
-    };
-    func(callback);
+export default (command, args) =>
+  new Promise((resolve, reject) => {
+    spawn(command, args, { stdio: "inherit" })
+      .on("exit", (code) => {
+        if (code === 0) {
+          resolve(code);
+        } else {
+          reject(new Error(`${command} exited with code ${code}`));
+        }
+      })
+      .on("error", reject);
   });
-};
-
-export default (command, options) => {
-  return toPromise((callback) =>
-    spawn(command, options, { stdio: "inherit" }).on("exit", callback),
-  );
-};

--- a/packages/reactor-extension/scripts/release.mjs
+++ b/packages/reactor-extension/scripts/release.mjs
@@ -31,6 +31,14 @@ const run = (cmd, args, opts = {}) => {
     cwd: opts.cwd || pkgDir,
     env: { ...process.env, ...opts.env },
   });
+  if (result.error) {
+    console.error(`Failed to spawn "${cmd}": ${result.error.message}`);
+    process.exit(1);
+  }
+  if (result.signal) {
+    console.error(`"${cmd}" killed by signal ${result.signal}`);
+    process.exit(1);
+  }
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
   }

--- a/sandboxes/browser/scripts/release.mjs
+++ b/sandboxes/browser/scripts/release.mjs
@@ -37,6 +37,14 @@ const run = (cmd, args, opts = {}) => {
     cwd: opts.cwd || pkgDir,
     env: { ...process.env, ...opts.env },
   });
+  if (r.error) {
+    console.error(`Failed to spawn "${cmd}": ${r.error.message}`);
+    process.exit(1);
+  }
+  if (r.signal) {
+    console.error(`"${cmd}" killed by signal ${r.signal}`);
+    process.exit(1);
+  }
   if (r.status !== 0) process.exit(r.status ?? 1);
 };
 

--- a/scripts/deployExtensionToReactor.mjs
+++ b/scripts/deployExtensionToReactor.mjs
@@ -31,6 +31,14 @@ const run = (cmd, args, opts = {}) => {
     cwd: opts.cwd || rootDir,
     env: { ...process.env, ...opts.env },
   });
+  if (result.error) {
+    console.error(`Failed to spawn "${cmd}": ${result.error.message}`);
+    process.exit(1);
+  }
+  if (result.signal) {
+    console.error(`"${cmd}" killed by signal ${result.signal}`);
+    process.exit(1);
+  }
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
   }
@@ -87,4 +95,12 @@ const releaser = spawnSync(
     },
   },
 );
+if (releaser.error) {
+  console.error(`Failed to spawn reactor-releaser: ${releaser.error.message}`);
+  process.exit(1);
+}
+if (releaser.signal) {
+  console.error(`reactor-releaser killed by signal ${releaser.signal}`);
+  process.exit(1);
+}
 if (releaser.status !== 0) process.exit(releaser.status ?? 1);


### PR DESCRIPTION
## Changed Packages
- [ ] core
- [x] reactor-extension
<!-- also affects sandboxes/browser + root release tooling — not consumer-facing -->

## Description

Three follow-up hardening changes to the release pipeline reworked in #1523 (and patched in #1528 / #1529). Theme: when a release step fails, fail **loudly and completely** instead of dying silently, masking the cause, or stopping at the first of several broken deploys.

1. **Stage vendored packages before the extension build** (`createExtensionPackage.mjs`). `stageInstallablePackages()` (`pnpm pack` of `@adobe/alloy` + `@adobe/alloy-core`, then `npm i` for the lockfile) now runs *before* `pnpm run build` rather than after. Packing `@adobe/alloy` runs its `prepack` build, so staging first guarantees the extension build bundles a freshly-built browser package.

2. **`--no-bail` on the side-effect deploys** (`version-and-publish.yml`). `pnpm --recursive --workspace-concurrency=1 --no-bail --if-present run release` runs every package's deploy even when an earlier one fails, so a single release surfaces *all* broken deploys at once instead of one-per-rerun. Per the pnpm recursive docs, `--no-bail` doesn't affect the exit code — the step still fails if any deploy failed (deploys are idempotent, so the next run safely retries the rest).

3. **Surface child-process failures in the release/build wrappers.** An audit of every spawn/exec wrapper found several that swallowed failures:
   - `buildAlloyPreinstalled.mjs`'s `execute()` resolved on *any* exit code — the exact bug #1529 fixed in `buildAlloy.mjs`, missed in the sibling — so a non-zero rollup exit was invisible and babel ran on partial output. Now rejects on non-zero/`null`.
   - `helpers/run.mjs` had no `error` listener (ENOENT crashed via an unhandled event) and silently resolved on a signal kill; it now rejects with an `Error`, and `buildLib.mjs` `await`s it.
   - The `run()` helpers in the deploy scripts (`release.mjs` ×2, `deployExtensionToReactor.mjs`) and the inline `reactor-releaser` spawn exited `1` with no diagnostic on a failed spawn (ENOENT) or an OOM `SIGKILL` (`status === null`); they now print the cause first.
   - `getManifestFilepaths()` produced a blank `getPackagePaths failed: undefined` on those cases; it now reuses `execute()`'s error/signal/both-streams reporting.

## Related Issue

Operational follow-up to #1523 / #1528 / #1529.

## Motivation and Context

The #1523 rework surfaced a string of latent bugs that only appeared on a real `main` release run, each costing a merge→fail→fix cycle (#1525–#1529). These changes shrink that loop: deploys report every failure in one run (item 2), and the spawn wrappers no longer swallow or mask a failure's cause (item 3), so the next failure is diagnosable from the log instead of a bare exit code.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which does not add functionality)

## Checklist:

- [ ] Changeset — **N/A**; release tooling only, no consumer-facing change (apply `ignore-for-release`).
- [x] I have signed the Adobe Open Source CLA or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass (`extensionBuild.spec.js` + scripts suite green locally).
- [ ] I have run the Sandbox successfully — N/A.
