### PR TITLE
Bumped version number to trigger package release

### DIFF
--- a/.changeset/lucky-dragons-call.md
+++ b/.changeset/lucky-dragons-call.md
@@ -1,0 +1,7 @@
+---
+"@adobe/alloy": patch
+"@adobe/alloy-core": patch
+"reactor-extension-alloy": patch
+---
+
+manual bump of version number to trigger package release process


### PR DESCRIPTION
## Changed Packages
- [ ] core
- [ ] reactor-extension 

## Description

Manual bump of the version number via changeset to trigger the package release process for `@adobe/alloy`, `@adobe/alloy-core`, and `reactor-extension-alloy` (patch versions).

## Related Issue

N/A — administrative release trigger.

## Motivation and Context

Manually bumping the version to kick off the release pipeline.

## Types of changes

- [x] Improvement (non-breaking change which does not add functionality)

## Checklist:

- [x] I have added a Changeset file with a consumer-facing description of my changes.
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.