### PR TITLE
Fix an error in Push Notifications module caused by using an incorrect storage.

### DIFF
--- a/.changeset/tidy-doors-talk.md
+++ b/.changeset/tidy-doors-talk.md
@@ -1,0 +1,5 @@
+---
+"@adobe/alloy": patch
+---
+
+Fix an error triggered by createNamespacedStorage being undefined.

--- a/.changeset/tidy-doors-talk.md
+++ b/.changeset/tidy-doors-talk.md
@@ -2,4 +2,4 @@
 "@adobe/alloy": patch
 ---
 
-Fix an error triggered by createNamespacedStorage being undefined.
+Fix an error in Push notifications module triggered by createNamespacedStorage being undefined.

--- a/packages/browser/src/components/PushNotifications/index.js
+++ b/packages/browser/src/components/PushNotifications/index.js
@@ -10,11 +10,11 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-/** @import { StorageCreator } from '@adobe/alloy-core/utils/types.js' */
 /** @import { EventManager, Logger } from '@adobe/alloy-core/core/types.js' */
 /** @import { IdentityManager } from '@adobe/alloy-core/core/identity/types.js' */
 /** @import { ConsentManager } from '@adobe/alloy-core/core/consent/types.js' */
 /** @import { EdgeRequestExecutor } from '@adobe/alloy-core/core/edgeNetwork/types.js' */
+/** @import { PlatformServices } from '@adobe/alloy-core/services' */
 
 import { objectOf, string } from "@adobe/alloy-core/utils/validation";
 import { sanitizeOrgIdForCookieName } from "@adobe/alloy-core/utils";
@@ -35,17 +35,16 @@ const isComponentConfigured = ({
  *
  * @param {Object} options
  * @param {{ orgId: string, datastreamId: string, edgeDomain: string, edgeBasePath: string, pushNotifications: { vapidPublicKey: string, appId: string, trackingDatasetId: string }}} options.config
- * @param {StorageCreator} options.createNamespacedStorage
  * @param {EventManager} options.eventManager
  * @param {Logger} options.logger
  * @param {ConsentManager} options.consent
  * @param {IdentityManager} options.identity
  * @param {function(): string} options.getBrowser
  * @param {EdgeRequestExecutor} options.sendEdgeNetworkRequest
+ * @param {PlatformServices} options.platformServices
  * @returns {{ lifecycle: object, commands: { sendPushSubscription: object } }}
  */
 const createPushNotifications = ({
-  createNamespacedStorage,
   eventManager,
   config,
   logger,
@@ -53,6 +52,7 @@ const createPushNotifications = ({
   identity,
   getBrowser,
   sendEdgeNetworkRequest,
+  platformServices,
 }) => {
   return {
     lifecycle: {
@@ -92,7 +92,7 @@ const createPushNotifications = ({
             },
           } = config || {};
 
-          const storage = createNamespacedStorage(
+          const storage = platformServices.storage.createNamespacedStorage(
             `${sanitizeOrgIdForCookieName(orgId)}.pushNotifications.`,
           );
 

--- a/packages/browser/src/components/PushNotifications/request/makeSendPushSubscriptionRequest.js
+++ b/packages/browser/src/components/PushNotifications/request/makeSendPushSubscriptionRequest.js
@@ -69,8 +69,9 @@ export default async ({
   );
 
   const cacheValue = `${ecid}${serializedPushSubscriptionDetails}`;
+  const storedValue = await storage.getItem(SUBSCRIPTION_DETAILS);
 
-  if (cacheValue === storage.getItem(SUBSCRIPTION_DETAILS)) {
+  if (cacheValue === storedValue) {
     logger.info(
       "Subscription details have not changed. Not sending to the server.",
     );

--- a/packages/browser/test/unit/specs/components/PushNotifications/index.spec.js
+++ b/packages/browser/test/unit/specs/components/PushNotifications/index.spec.js
@@ -1,0 +1,116 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { vi, beforeEach, describe, it, expect } from "vitest";
+
+// The only true external boundary here is the browser's push subscription
+// API, which isn't available/deterministic in a test environment. Everything
+// else (storage, payload/request building, dedup logic) runs for real so the
+// test exercises the actual integration between index.js and platformServices.
+vi.mock(
+  "../../../../../src/components/PushNotifications/helpers/getPushSubscriptionDetails.js",
+  () => ({
+    default: vi.fn(),
+  }),
+);
+
+import createPushNotifications from "../../../../../src/components/PushNotifications/index.js";
+import getPushSubscriptionDetails from "../../../../../src/components/PushNotifications/helpers/getPushSubscriptionDetails.js";
+
+// Mirrors the real contract from createBrowserStorageService.js, where
+// getItem/setItem are async (backed by localStorage/sessionStorage).
+const createFakeAsyncStorage = () => {
+  const cache = new Map();
+  return {
+    getItem: (name) =>
+      Promise.resolve(cache.has(name) ? cache.get(name) : null),
+    setItem: (name, value) => {
+      cache.set(name, value);
+      return Promise.resolve(true);
+    },
+  };
+};
+
+describe("PushNotifications::index", () => {
+  let config;
+  let persistentStorage;
+  let platformServices;
+  let sendEdgeNetworkRequest;
+
+  beforeEach(() => {
+    getPushSubscriptionDetails.mockReset().mockResolvedValue({
+      endpoint: "https://push.example.com/subscription/abc",
+      keys: { p256dh: "p256dh-key", auth: "auth-key" },
+    });
+
+    config = {
+      orgId: "ABC123@AdobeOrg",
+      datastreamId: "datastream-id",
+      edgeDomain: "edge.adobedc.net",
+      edgeBasePath: "ee",
+      pushNotifications: {
+        vapidPublicKey: "test-vapid-key",
+        appId: "test-app-id",
+        trackingDatasetId: "test-dataset-id",
+      },
+    };
+
+    persistentStorage = createFakeAsyncStorage();
+    platformServices = {
+      storage: {
+        createNamespacedStorage: vi.fn().mockReturnValue({
+          persistent: persistentStorage,
+          session: createFakeAsyncStorage(),
+        }),
+      },
+    };
+
+    sendEdgeNetworkRequest = vi.fn().mockResolvedValue();
+  });
+
+  const buildPushNotifications = () =>
+    createPushNotifications({
+      eventManager: {
+        createEvent: () => ({ setUserData: vi.fn(), finalize: vi.fn() }),
+      },
+      config,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      consent: { awaitConsent: vi.fn().mockResolvedValue() },
+      identity: {
+        awaitIdentity: vi.fn().mockResolvedValue(),
+        getEcidFromCookie: vi.fn().mockReturnValue("test-ecid"),
+      },
+      getBrowser: vi.fn().mockReturnValue("Chrome"),
+      sendEdgeNetworkRequest,
+      platformServices,
+    });
+
+  it("persists the subscription fingerprint in that storage and sends it to the edge network", async () => {
+    const pushNotifications = buildPushNotifications();
+
+    await pushNotifications.commands.sendPushSubscription.run();
+
+    await expect(
+      persistentStorage.getItem("subscriptionDetails"),
+    ).resolves.toContain("test-ecid");
+    expect(sendEdgeNetworkRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not resend to the edge network when the subscription hasn't changed", async () => {
+    const pushNotifications = buildPushNotifications();
+
+    await pushNotifications.commands.sendPushSubscription.run();
+    await pushNotifications.commands.sendPushSubscription.run();
+
+    expect(sendEdgeNetworkRequest).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/browser/vitest.projects.js
+++ b/packages/browser/vitest.projects.js
@@ -45,10 +45,8 @@ export const browserTestProjects = [
     extends: false,
     test: {
       name: "browser/unit",
-      include: [
-        "packages/browser/test/unit/**/*.{test,spec}.?(c|m)[jt]s?(x)",
-      ],
-      isolate: false,
+      include: ["packages/browser/test/unit/**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+      isolate: true,
       browser: createBrowserMode(),
       coverage: packageCoverage,
     },


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Changed Packages
<!--- Indicate which package your changes directly affect. -->
<!--- (i.e., do not choose the extension if it's only change is updating its core version). -->
- [ ] core
- [ ] reactor-extension 
- [x] browser

## Description

<!--- Describe your changes in detail -->
Undefined createNamespacedStorage was triggering an errors when calling the send push subscription command.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Documentation
<!-- Significant consumer-facing changes should be documented -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Run `pnpm changeset` if this needs a release with a changelog entry, `pnpm changeset --empty` if it needs a release without one, or push without a changeset if no release is needed. -->
<!--- For more information about the changesets or the release process, see https://github.com/adobe/alloy/wiki/Release-process -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added a Changeset file with a consumer-facing description of my changes.
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
