### PR TITLE
Routed beta and stable releases to separate GitHub environments

### DIFF
--- a/.github/workflows/version-and-publish.yml
+++ b/.github/workflows/version-and-publish.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       proceed: ${{ steps.check.outputs.proceed }}
+      environment: ${{ steps.check.outputs.environment }}
     steps:
       - uses: actions/checkout@v5
       - id: check
@@ -31,11 +32,20 @@ jobs:
             echo "proceed=false" >> "$GITHUB_OUTPUT"
           fi
 
+          # Route by changesets prerelease mode (the signal exit-prerelease.yml
+          # guards on, so both workflows agree). "pre" => beta channel; exiting
+          # or absent => stable. Emit the target environment name so `publish`
+          # references it verbatim with no branching in the workflow.
+          case "$(jq -r '.mode // "none"' .changeset/pre.json 2>/dev/null)" in
+            pre) echo "environment=Beta" >> "$GITHUB_OUTPUT" ;;
+            *)   echo "environment=Production" >> "$GITHUB_OUTPUT" ;;
+          esac
+
   publish:
     needs: detect
     if: needs.detect.outputs.proceed == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    environment: Production
+    environment: ${{ needs.detect.outputs.environment }}
     permissions:
       contents: write
       pull-requests: read


### PR DESCRIPTION
## Changed Packages

_None — CI/release infrastructure only._

- [ ] core
- [ ] reactor-extension

## Description

The `publish` job in `version-and-publish.yml` hardcoded `environment: Production`. Because the `Production` environment carries a required-reviewer protection rule (reviewers: `carterworks`, `jonsnyder`, `dompuiu`, `Spencer-Smith`), **every** release — beta and stable alike — pauses for manual approval.

Beta releases fire on every changeset merge to `main` and don't need that gate. This change routes them to a separate, ungated `Beta` environment while keeping stable releases gated on `Production`.

How it works:
- The existing `detect` job reads the changesets prerelease mode from `.changeset/pre.json` and emits the **target environment name** as an output (`Beta` when `mode == "pre"`, `Production` when exiting/absent). This is the same signal `exit-prerelease.yml` already guards on, so the two workflows stay consistent.
- `publish` references that output verbatim: `environment: ${{ needs.detect.outputs.environment }}` — no branching in the workflow, and adding a future channel is one more `case` arm.

`Production` holds no environment-scoped secrets (all `secrets.*` resolve at repo/org level), so `Beta` needs none — the only thing that differs between the two environments is the approval gate.

## Post-merge steps (required)

Referencing a nonexistent environment does **not** fail the job — GitHub [auto-creates it with no protection rules](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments) on first use. So the first beta release after merge will auto-create an ungated `Beta` (the desired end state) even if these steps haven't run yet; they exist to pin the branch policy so `Beta` matches `Production`'s `main`-only restriction. Run once, after merge, as a repo admin:

```bash
# Create/configure the Beta environment (idempotent). No reviewers = no gate.
gh api --method PUT repos/adobe/alloy/environments/Beta --input - <<'JSON'
{
  "deployment_branch_policy": {
    "protected_branches": false,
    "custom_branch_policies": true
  }
}
JSON

# Restrict deploys to main, matching Production.
gh api --method POST repos/adobe/alloy/environments/Beta/deployment-branch-policies \
  -f name=main -f type=branch

# Verify: expect no required_reviewers and a single `main` branch policy.
gh api repos/adobe/alloy/environments/Beta \
  --jq '{name, reviewers: [.protection_rules[]? | select(.type=="required_reviewers") | .reviewers[].reviewer.login], branch_policy: .deployment_branch_policy}'
```

## Related Issue

_n/a_

## Motivation and Context

Beta releases are frequent and low-risk; the manual approval on every one adds friction with no benefit. Stable releases remain gated.

## Types of changes

- [x] Improvement (non-breaking change which does not add functionality)

## Checklist:

- [x] I have added a Changeset file with a consumer-facing description of my changes. _(intentionally omitted — infra-only, no package release)_
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [ ] I have run the Sandbox successfully. _(n/a — workflow change)_
