### PR TITLE
Persist ECID reliably and self-heal subscription cache.

### DIFF
--- a/.changeset/quick-melons-guard.md
+++ b/.changeset/quick-melons-guard.md
@@ -1,0 +1,5 @@
+---
+"@adobe/alloy": patch
+---
+
+Fix Push Notifications module so the ECID used to target notifications is persisted reliably: skip sending when no ECID is available, and only cache the subscription details after the ECID is saved so a failed send or storage write self-heals on the next attempt.

--- a/packages/browser/src/components/PushNotifications/helpers/saveToIndexedDb.js
+++ b/packages/browser/src/components/PushNotifications/helpers/saveToIndexedDb.js
@@ -24,7 +24,7 @@ import { DB_NAME, DB_VERSION, STORE_NAME, INDEX_KEY } from "./constants.js";
  * @param {Object} data
  * @param {Logger} logger
  *
- * @returns {Promise<void>}
+ * @returns {Promise<boolean>} Whether the data was successfully saved.
  */
 export default async function saveToIndexedDB(data, logger) {
   try {
@@ -58,7 +58,11 @@ export default async function saveToIndexedDB(data, logger) {
       "Successfully saved web SDK config to IndexedDB",
       updatedConfigData,
     );
+
+    return true;
   } catch (error) {
     logger.error("Failed to save config to IndexedDB", { error });
+
+    return false;
   }
 }

--- a/packages/browser/src/components/PushNotifications/request/makeSendPushSubscriptionRequest.js
+++ b/packages/browser/src/components/PushNotifications/request/makeSendPushSubscriptionRequest.js
@@ -79,7 +79,7 @@ export default async ({
   const cacheValue = `${ecid}${serializedPushSubscriptionDetails}`;
   const storedValue = await storage.getItem(SUBSCRIPTION_DETAILS);
 
-  if (cacheValue && storedValue && cacheValue === storedValue) {
+  if (storedValue && cacheValue === storedValue) {
     logger.info(
       "Subscription details have not changed. Not sending to the server.",
     );

--- a/packages/browser/src/components/PushNotifications/request/makeSendPushSubscriptionRequest.js
+++ b/packages/browser/src/components/PushNotifications/request/makeSendPushSubscriptionRequest.js
@@ -59,6 +59,14 @@ export default async ({
   await identity.awaitIdentity();
   const ecid = identity.getEcidFromCookie();
 
+  if (!ecid) {
+    logger.info(
+      "No ECID is available. Not sending push subscription details to the server.",
+    );
+
+    return;
+  }
+
   const pushSubscriptionDetails = await getPushSubscriptionDetails({
     vapidPublicKey,
     window,
@@ -71,7 +79,7 @@ export default async ({
   const cacheValue = `${ecid}${serializedPushSubscriptionDetails}`;
   const storedValue = await storage.getItem(SUBSCRIPTION_DETAILS);
 
-  if (cacheValue === storedValue) {
+  if (cacheValue && storedValue && cacheValue === storedValue) {
     logger.info(
       "Subscription details have not changed. Not sending to the server.",
     );

--- a/packages/browser/src/components/PushNotifications/request/makeSendPushSubscriptionRequest.js
+++ b/packages/browser/src/components/PushNotifications/request/makeSendPushSubscriptionRequest.js
@@ -87,8 +87,6 @@ export default async ({
     return;
   }
 
-  storage.setItem(SUBSCRIPTION_DETAILS, cacheValue);
-
   const payload = await createSendPushSubscriptionPayload({
     eventManager,
     ecid,
@@ -103,5 +101,13 @@ export default async ({
   await consent.awaitConsent();
   await sendEdgeNetworkRequest({ request });
 
-  await saveToIndexedDb({ ecid }, logger);
+  const savedToIndexedDb = await saveToIndexedDb({ ecid }, logger);
+
+  // Only cache the subscription details once the ECID has been persisted, so
+  // that a failed send or a failed IndexedDB write does not short-circuit the
+  // dedupe check on the next call. This lets a subsequent sendPushSubscription
+  // self-heal instead of getting stuck with a cached subscription but no ECID.
+  if (savedToIndexedDb) {
+    storage.setItem(SUBSCRIPTION_DETAILS, cacheValue);
+  }
 };

--- a/packages/browser/test/unit/specs/components/PushNotifications/request/makeSendPushSubscriptionRequest.spec.js
+++ b/packages/browser/test/unit/specs/components/PushNotifications/request/makeSendPushSubscriptionRequest.spec.js
@@ -13,6 +13,12 @@ governing permissions and limitations under the License.
 import { vi, beforeEach, describe, it, expect } from "vitest";
 
 import makeSendPushSubscriptionRequest from "../../../../../../src/components/PushNotifications/request/makeSendPushSubscriptionRequest.js";
+import saveToIndexedDb from "../../../../../../src/components/PushNotifications/helpers/saveToIndexedDb.js";
+
+vi.mock(
+  "../../../../../../src/components/PushNotifications/helpers/saveToIndexedDb.js",
+  () => ({ default: vi.fn() }),
+);
 
 describe("makeSendPushSubscriptionRequest", () => {
   let mockStorage;
@@ -24,6 +30,9 @@ describe("makeSendPushSubscriptionRequest", () => {
 
   beforeEach(() => {
     mockNoEcid = false;
+
+    saveToIndexedDb.mockReset();
+    saveToIndexedDb.mockResolvedValue(true);
 
     mockStorage = {
       cache: {},
@@ -86,6 +95,41 @@ describe("makeSendPushSubscriptionRequest", () => {
     expect(
       mockSetUserData.mock.calls[0][0].pushNotificationDetails[0].token,
     ).not.toContain("ecid");
+  });
+
+  it("caches the subscription details after the ECID is saved to IndexedDB", async () => {
+    await callMakeSendPushSubscriptionRequest();
+
+    expect(saveToIndexedDb).toHaveBeenCalledWith({ ecid: "ecid" }, mockLogger);
+    expect(mockStorage.cache.subscriptionDetails).toBe(
+      'ecid{"endpoint":"test"}',
+    );
+  });
+
+  it("does not cache the subscription details when the IndexedDB save fails", async () => {
+    saveToIndexedDb.mockResolvedValue(false);
+
+    await callMakeSendPushSubscriptionRequest();
+
+    expect(mockSendEdgeNetworkRequest).toHaveBeenCalledTimes(1);
+    expect(mockStorage.cache.subscriptionDetails).toBeUndefined();
+  });
+
+  it("self-heals on the next call after a failed IndexedDB save", async () => {
+    saveToIndexedDb.mockResolvedValueOnce(false);
+
+    // First call: send succeeds but the ECID save fails, so nothing is cached.
+    await callMakeSendPushSubscriptionRequest();
+    expect(mockStorage.cache.subscriptionDetails).toBeUndefined();
+
+    // Second call: the dedupe check does not short-circuit, so it sends again
+    // and, now that the save succeeds, caches the subscription details.
+    await callMakeSendPushSubscriptionRequest();
+
+    expect(mockSendEdgeNetworkRequest).toHaveBeenCalledTimes(2);
+    expect(mockStorage.cache.subscriptionDetails).toBe(
+      'ecid{"endpoint":"test"}',
+    );
   });
 
   it("does not make an edge call if the subscription details are not changed", async () => {

--- a/packages/browser/test/unit/specs/components/PushNotifications/request/makeSendPushSubscriptionRequest.spec.js
+++ b/packages/browser/test/unit/specs/components/PushNotifications/request/makeSendPushSubscriptionRequest.spec.js
@@ -20,8 +20,11 @@ describe("makeSendPushSubscriptionRequest", () => {
   let mockSendEdgeNetworkRequest;
   let mockSetUserData;
   let mockGetPushSubscriptionDetails;
+  let mockNoEcid;
 
   beforeEach(() => {
+    mockNoEcid = false;
+
     mockStorage = {
       cache: {},
       // eslint-disable-next-line func-names
@@ -66,7 +69,9 @@ describe("makeSendPushSubscriptionRequest", () => {
       },
       identity: {
         awaitIdentity: vi.fn().mockResolvedValue(),
-        getEcidFromCookie: vi.fn().mockReturnValue("ecid"),
+        getEcidFromCookie: vi
+          .fn()
+          .mockReturnValue(mockNoEcid ? undefined : "ecid"),
       },
       window: { location: { host: "somehost" } },
       getPushSubscriptionDetails: mockGetPushSubscriptionDetails,
@@ -89,6 +94,17 @@ describe("makeSendPushSubscriptionRequest", () => {
 
     expect(mockLogger.info).toHaveBeenCalledWith(
       "Subscription details have not changed. Not sending to the server.",
+    );
+    expect(mockSendEdgeNetworkRequest).not.toHaveBeenCalled();
+  });
+
+  it("does not make an edge call when no ECID is available", async () => {
+    mockNoEcid = true;
+
+    await callMakeSendPushSubscriptionRequest();
+
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      "No ECID is available. Not sending push subscription details to the server.",
     );
     expect(mockSendEdgeNetworkRequest).not.toHaveBeenCalled();
   });

--- a/packages/core/src/components/Identity/createComponent.js
+++ b/packages/core/src/components/Identity/createComponent.js
@@ -56,7 +56,9 @@ export default ({
         // so that sendBeacon requests don't override the edge info from before.
         edge = { ...edge, ...response.getEdge() };
 
-        identity.setIdentityAcquired();
+        if (identity.getEcidFromCookie()) {
+          identity.setIdentityAcquired();
+        }
 
         return handleResponseForIdSyncs(response);
       },

--- a/packages/core/test/unit/specs/components/Identity/createComponent.spec.js
+++ b/packages/core/test/unit/specs/components/Identity/createComponent.spec.js
@@ -162,6 +162,24 @@ describe("Identity::createComponent", () => {
     expect(setLegacyEcid).toHaveBeenCalledTimes(1);
   });
 
+  it("marks identity as acquired when an ECID cookie is present", () => {
+    handleResponseForIdSyncs.mockReturnValue(Promise.resolve());
+    identity.getEcidFromCookie.mockReturnValue("user@adobe");
+
+    component.lifecycle.onResponse({ response });
+
+    expect(identity.setIdentityAcquired).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not mark identity as acquired when no ECID cookie is present", () => {
+    handleResponseForIdSyncs.mockReturnValue(Promise.resolve());
+    identity.getEcidFromCookie.mockReturnValue(undefined);
+
+    component.lifecycle.onResponse({ response });
+
+    expect(identity.setIdentityAcquired).not.toHaveBeenCalled();
+  });
+
   it("handles ID syncs", () => {
     const idSyncsPromise = Promise.resolve();
     handleResponseForIdSyncs.mockReturnValue(idSyncsPromise);


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Changed Packages
<!--- Indicate which package your changes directly affect. -->
<!--- (i.e., do not choose the extension if it's only change is updating its core version). -->
- [ ] core
- [x] browser
- [ ] reactor-extension 

## Description

This PR fixes a few edge case that were not that important until now. More specifically, it was possible to store an ECID as undefined in the Index DB that was used then in the push notification service worker. Also the value is stored in the guard cache only if the index db operation succeeds.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

There will be some changes in the push notifications backend service. They will start sending an ECID in the notification payload an we need to check that value against the one we store in the IndexDB. If those values don't match, we won't show the notification. This is why it is more important now to have a correct ECID stored in the Index DB. 

## Screenshots (if appropriate):

## Documentation
<!-- Significant consumer-facing changes should be documented -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Run `pnpm changeset` if this needs a release with a changelog entry, `pnpm changeset --empty` if it needs a release without one, or push without a changeset if no release is needed. -->
<!--- For more information about the changesets or the release process, see https://github.com/adobe/alloy/wiki/Release-process -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added a Changeset file with a consumer-facing description of my changes.
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
