### PR TITLE
Fixed reactor-extension release retrying an already-released version

### DIFF
--- a/packages/reactor-extension/scripts/release.mjs
+++ b/packages/reactor-extension/scripts/release.mjs
@@ -65,7 +65,7 @@ export const isAlreadyReleasedError = (output) => {
 const invokedAsCli =
   process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 
-const main = () => {
+export const main = () => {
   const { name, version } = JSON.parse(
     fs.readFileSync(path.join(pkgDir, "package.json"), "utf8"),
   );

--- a/packages/reactor-extension/scripts/release.mjs
+++ b/packages/reactor-extension/scripts/release.mjs
@@ -14,16 +14,13 @@ governing permissions and limitations under the License.
 
 import { spawnSync } from "child_process";
 import path from "path";
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 import fs from "fs";
 
 const REACTOR_CLIENT_ID = "f401a5fe22184c91a85fd441a8aa2976";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkgDir = path.resolve(__dirname, "..");
-const { name, version } = JSON.parse(
-  fs.readFileSync(path.join(pkgDir, "package.json"), "utf8"),
-);
 
 const run = (cmd, args, opts = {}) => {
   const result = spawnSync(cmd, args, {
@@ -44,30 +41,72 @@ const run = (cmd, args, opts = {}) => {
   }
 };
 
-// Build + zip the extension. The `package` script writes
-// package-adobe-alloy-<version>.zip into the package dir.
-console.log(`Building ${name}@${version} extension package...`);
-run("pnpm", ["run", "package"]);
+// Reactor keeps a single "development" extension package per name+platform
+// and drops its dev-availability record once released. Re-running this
+// script for a version that was already fully released can't find a dev
+// record to PATCH, so it POSTs a new one instead; Reactor rejects that as
+// "invalid-version", reporting the attempted version as older than "the
+// latest version: <that same version>". The message gets JSON-stringified
+// twice on its way to the console, so quotes may or may not be
+// backslash-escaped depending on nesting depth. Recognize this exact
+// already-released shape (both sides of the comparison equal) rather than
+// treating it as a real failure.
+export const isAlreadyReleasedError = (output) => {
+  const match = output.match(
+    /detail\\?"\s*:\s*\\?"([^"\\]+) is older than latest version: ([^"\\]+)/,
+  );
+  return Boolean(match) && match[1] === match[2];
+};
 
-const zipName = `package-adobe-alloy-${version}.zip`;
-const zipPath = path.join(pkgDir, zipName);
-if (!fs.existsSync(zipPath)) {
-  throw new Error(`Expected packaged zip at ${zipPath}`);
+const invokedAsCli =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedAsCli) {
+  const { name, version } = JSON.parse(
+    fs.readFileSync(path.join(pkgDir, "package.json"), "utf8"),
+  );
+
+  // Build + zip the extension. The `package` script writes
+  // package-adobe-alloy-<version>.zip into the package dir.
+  console.log(`Building ${name}@${version} extension package...`);
+  run("pnpm", ["run", "package"]);
+
+  const zipName = `package-adobe-alloy-${version}.zip`;
+  const zipPath = path.join(pkgDir, zipName);
+  if (!fs.existsSync(zipPath)) {
+    throw new Error(`Expected packaged zip at ${zipPath}`);
+  }
+
+  console.log(`Uploading ${zipName} to Reactor...`);
+  const upload = spawnSync(
+    "pnpm",
+    [
+      "exec",
+      "reactor-uploader",
+      zipPath,
+      `--auth.client-id=${REACTOR_CLIENT_ID}`,
+      "--upload-timeout=300",
+    ],
+    { cwd: pkgDir, env: process.env, encoding: "utf8" },
+  );
+  process.stdout.write(upload.stdout ?? "");
+  process.stderr.write(upload.stderr ?? "");
+  if (upload.status !== 0) {
+    const output = `${upload.stdout ?? ""}${upload.stderr ?? ""}`;
+    if (isAlreadyReleasedError(output)) {
+      console.log(
+        `${name}@${version} is already released on Reactor; skipping.`,
+      );
+      process.exit(0);
+    }
+    process.exit(upload.status ?? 1);
+  }
+
+  console.log(`Releasing ${name}@${version}...`);
+  run("pnpm", [
+    "exec",
+    "reactor-releaser",
+    `--auth.client-id=${REACTOR_CLIENT_ID}`,
+    "--confirm-package-release",
+  ]);
 }
-
-console.log(`Uploading ${zipName} to Reactor...`);
-run("pnpm", [
-  "exec",
-  "reactor-uploader",
-  zipPath,
-  `--auth.client-id=${REACTOR_CLIENT_ID}`,
-  "--upload-timeout=300",
-]);
-
-console.log(`Releasing ${name}@${version}...`);
-run("pnpm", [
-  "exec",
-  "reactor-releaser",
-  `--auth.client-id=${REACTOR_CLIENT_ID}`,
-  "--confirm-package-release",
-]);

--- a/packages/reactor-extension/scripts/release.mjs
+++ b/packages/reactor-extension/scripts/release.mjs
@@ -46,14 +46,18 @@ const run = (cmd, args, opts = {}) => {
 // script for a version that was already fully released can't find a dev
 // record to PATCH, so it POSTs a new one instead; Reactor rejects that as
 // "invalid-version", reporting the attempted version as older than "the
-// latest version: <that same version>". The message gets JSON-stringified
-// twice on its way to the console, so quotes may or may not be
-// backslash-escaped depending on nesting depth. Recognize this exact
-// already-released shape (both sides of the comparison equal) rather than
-// treating it as a real failure.
+// latest version: <that same version>". The message is JSON-stringified
+// twice on its way to the console, so backslash-escaped quotes are
+// collapsed before matching. The "invalid-version" code is required
+// alongside the equal-version detail so an unrelated error that happens to
+// contain similar wording can't be mistaken for this specific case.
 export const isAlreadyReleasedError = (output) => {
-  const match = output.match(
-    /detail\\?"\s*:\s*\\?"([^"\\]+) is older than latest version: ([^"\\]+)/,
+  const normalized = output.replace(/\\"/g, '"');
+  if (!/"code":\s*"invalid-version"/.test(normalized)) {
+    return false;
+  }
+  const match = normalized.match(
+    /"detail":"([^"]+) is older than latest version: ([^"]+)"/,
   );
   return Boolean(match) && match[1] === match[2];
 };
@@ -61,7 +65,7 @@ export const isAlreadyReleasedError = (output) => {
 const invokedAsCli =
   process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 
-if (invokedAsCli) {
+const main = () => {
   const { name, version } = JSON.parse(
     fs.readFileSync(path.join(pkgDir, "package.json"), "utf8"),
   );
@@ -87,19 +91,44 @@ if (invokedAsCli) {
       `--auth.client-id=${REACTOR_CLIENT_ID}`,
       "--upload-timeout=300",
     ],
-    { cwd: pkgDir, env: process.env, encoding: "utf8" },
+    {
+      cwd: pkgDir,
+      env: process.env,
+      encoding: "utf8",
+      // Buffered rather than "inherit" so the output can be inspected below;
+      // sized well above spawnSync's default so verbose uploader output
+      // can't get silently truncated before the check runs.
+      maxBuffer: 10 * 1024 * 1024,
+    },
   );
   process.stdout.write(upload.stdout ?? "");
   process.stderr.write(upload.stderr ?? "");
+
+  // Checked before inspecting output for the already-released case: a spawn
+  // failure or signal kill must never be mistaken for a successful skip just
+  // because matching text happens to appear in whatever output was captured.
+  if (upload.error) {
+    console.error(
+      `Failed to spawn "reactor-uploader": ${upload.error.message}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  if (upload.signal) {
+    console.error(`"reactor-uploader" killed by signal ${upload.signal}`);
+    process.exitCode = 1;
+    return;
+  }
   if (upload.status !== 0) {
     const output = `${upload.stdout ?? ""}${upload.stderr ?? ""}`;
     if (isAlreadyReleasedError(output)) {
       console.log(
         `${name}@${version} is already released on Reactor; skipping.`,
       );
-      process.exit(0);
+      return;
     }
-    process.exit(upload.status ?? 1);
+    process.exitCode = upload.status ?? 1;
+    return;
   }
 
   console.log(`Releasing ${name}@${version}...`);
@@ -109,4 +138,8 @@ if (invokedAsCli) {
     `--auth.client-id=${REACTOR_CLIENT_ID}`,
     "--confirm-package-release",
   ]);
+};
+
+if (invokedAsCli) {
+  main();
 }

--- a/packages/reactor-extension/scripts/release.spec.js
+++ b/packages/reactor-extension/scripts/release.spec.js
@@ -10,8 +10,16 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { describe, expect, test } from "vitest";
-import { isAlreadyReleasedError } from "./release.mjs";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { spawnSync } from "child_process";
+import fs from "fs";
+
+vi.mock("child_process", () => ({ spawnSync: vi.fn() }));
+vi.mock("fs", () => ({
+  default: { readFileSync: vi.fn(), existsSync: vi.fn() },
+}));
+
+import { isAlreadyReleasedError, main } from "./release.mjs";
 
 // Captured verbatim from https://github.com/adobe/alloy/actions/runs/29958621025/job/89057883911
 const CAPTURED_ALREADY_RELEASED_OUTPUT = `No development extension package was found on the server with the name adobe-alloy. A new extension package will be created.
@@ -57,5 +65,117 @@ describe("isAlreadyReleasedError()", () => {
     const output =
       '{"errors":[{"code":"some-other-code","detail":"2.37.1.pre.beta.4 is older than latest version: 2.37.1.pre.beta.4"}]}';
     expect(isAlreadyReleasedError(output)).toBe(false);
+  });
+});
+
+const PACKAGE_JSON = JSON.stringify({
+  name: "reactor-extension-alloy",
+  version: "2.37.1-beta.4",
+});
+
+const ALREADY_RELEASED_OUTPUT =
+  '{"errors":[{"code":"invalid-version","detail":"2.37.1-beta.4 is older than latest version: 2.37.1-beta.4"}]}';
+
+const RELEASER_ARGS = expect.arrayContaining(["reactor-releaser"]);
+
+describe("main()", () => {
+  beforeEach(() => {
+    vi.mocked(fs.readFileSync).mockReturnValue(PACKAGE_JSON);
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(spawnSync).mockReset();
+    process.exitCode = undefined;
+  });
+
+  // Only the "reactor-uploader" call is under test; the package build and
+  // reactor-releaser steps are unrelated to this fix, so they're stubbed to
+  // succeed unconditionally.
+  const mockUpload = (uploadResult) => {
+    vi.mocked(spawnSync).mockImplementation((cmd, args) =>
+      args.includes("reactor-uploader") ? uploadResult : { status: 0 },
+    );
+  };
+
+  test("skips reactor-releaser and leaves the exit code clean on an already-released upload", () => {
+    mockUpload({ status: 1, stdout: ALREADY_RELEASED_OUTPUT, stderr: "" });
+
+    main();
+
+    expect(spawnSync).not.toHaveBeenCalledWith(
+      "pnpm",
+      RELEASER_ARGS,
+      expect.anything(),
+    );
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  test("sets a non-zero exit code and skips reactor-releaser on an unrelated upload failure", () => {
+    mockUpload({ status: 1, stdout: "", stderr: "boom" });
+
+    main();
+
+    expect(spawnSync).not.toHaveBeenCalledWith(
+      "pnpm",
+      RELEASER_ARGS,
+      expect.anything(),
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  test("continues to reactor-releaser when the upload succeeds", () => {
+    mockUpload({ status: 0, stdout: "", stderr: "" });
+
+    main();
+
+    expect(spawnSync).toHaveBeenCalledWith(
+      "pnpm",
+      RELEASER_ARGS,
+      expect.anything(),
+    );
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  test("treats a spawn error from the uploader as a failure even if its captured output looks like an already-released skip", () => {
+    mockUpload({
+      error: new Error("spawn pnpm ENOENT"),
+      status: null,
+      stdout: ALREADY_RELEASED_OUTPUT,
+      stderr: "",
+    });
+
+    main();
+
+    expect(spawnSync).not.toHaveBeenCalledWith(
+      "pnpm",
+      RELEASER_ARGS,
+      expect.anything(),
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  test("treats a signal kill of the uploader as a failure even if its captured output looks like an already-released skip", () => {
+    mockUpload({
+      signal: "SIGTERM",
+      status: null,
+      stdout: ALREADY_RELEASED_OUTPUT,
+      stderr: "",
+    });
+
+    main();
+
+    expect(spawnSync).not.toHaveBeenCalledWith(
+      "pnpm",
+      RELEASER_ARGS,
+      expect.anything(),
+    );
+    expect(process.exitCode).toBe(1);
   });
 });

--- a/packages/reactor-extension/scripts/release.spec.js
+++ b/packages/reactor-extension/scripts/release.spec.js
@@ -52,4 +52,10 @@ describe("isAlreadyReleasedError()", () => {
     const output = "Error: connect ETIMEDOUT 1.2.3.4:443";
     expect(isAlreadyReleasedError(output)).toBe(false);
   });
+
+  test("requires the invalid-version code, not just matching wording", () => {
+    const output =
+      '{"errors":[{"code":"some-other-code","detail":"2.37.1.pre.beta.4 is older than latest version: 2.37.1.pre.beta.4"}]}';
+    expect(isAlreadyReleasedError(output)).toBe(false);
+  });
 });

--- a/packages/reactor-extension/scripts/release.spec.js
+++ b/packages/reactor-extension/scripts/release.spec.js
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { describe, expect, test } from "vitest";
+import { isAlreadyReleasedError } from "./release.mjs";
+
+// Captured verbatim from https://github.com/adobe/alloy/actions/runs/29958621025/job/89057883911
+const CAPTURED_ALREADY_RELEASED_OUTPUT = `No development extension package was found on the server with the name adobe-alloy. A new extension package will be created.
+ERROR
+Failed to POST the extension package to the server.
+No extension package ID was returned from the API.
+--verbose output
+/home/runner/work/alloy/alloy/node_modules/.pnpm/@adobe+reactor-uploader@6.0.2_@types+node@25.6.2/node_modules/@adobe/reactor-uploader/bin/handleResponseError.js:36
+  throw new Error(messagePrefix + ' ' + message);
+        ^
+
+Error: Error uploading extension package. {"stack":"Error: {\\"errors\\":[{\\"id\\":\\"df1cc5c1-b84a-48d1-befe-287c63dac60b\\",\\"code\\":\\"invalid-version\\",\\"title\\":\\"Invalid version\\",\\"detail\\":\\"2.37.1.pre.beta.4 is older than latest version: 2.37.1.pre.beta.4\\",\\"meta\\":{\\"request_id\\":\\"a3ba7103-0639-4859-ba1f-6472b5e81aff\\"},\\"source\\":{\\"pointer\\":\\"/data/attributes/version\\"}}]}\\n    at module.exports (/home/runner/work/alloy/alloy/node_modules/.pnpm/@adobe+reactor-uploader@6.0.2_@types+node@25.6.2/node_modules/@adobe/reactor-uploader/bin/uploadZip.js:63:32)\\n    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)\\n    at async /home/runner/work/alloy/alloy/node_modules/.pnpm/@adobe+reactor-uploader@6.0.2_@types+node@25.6.2/node_modules/@adobe/reactor-uploader/bin/index.js:97:32","message":"{\\"errors\\":[{\\"id\\":\\"df1cc5c1-b84a-48d1-befe-287c63dac60b\\",\\"code\\":\\"invalid-version\\",\\"title\\":\\"Invalid version\\",\\"detail\\":\\"2.37.1.pre.beta.4 is older than latest version: 2.37.1.pre.beta.4\\",\\"meta\\":{\\"request_id\\":\\"a3ba7103-0639-4859-ba1f-6472b5e81aff\\"},\\"source\\":{\\"pointer\\":\\"/data/attributes/version\\"}}]}"}.
+    at module.exports (/home/runner/work/alloy/alloy/node_modules/.pnpm/@adobe+reactor-uploader@6.0.2_@types+node@25.6.2/node_modules/@adobe/reactor-uploader/bin/handleResponseError.js:36:9)
+    at module.exports (/home/runner/work/alloy/alloy/node_modules/.pnpm/@adobe+reactor-uploader@6.0.2_@types+node@25.6.2/node_modules/@adobe/reactor-uploader/bin/uploadZip.js:84:5)
+    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
+    at async /home/runner/work/alloy/alloy/node_modules/.pnpm/@adobe+reactor-uploader@6.0.2_@types+node@25.6.2/node_modules/@adobe/reactor-uploader/bin/index.js:97:32
+
+Node.js v24.18.0`;
+
+describe("isAlreadyReleasedError()", () => {
+  test("recognizes the exact output captured from a real already-released failure", () => {
+    expect(isAlreadyReleasedError(CAPTURED_ALREADY_RELEASED_OUTPUT)).toBe(true);
+  });
+
+  test("recognizes the unescaped, single-stringified shape too", () => {
+    const output =
+      '{"errors":[{"code":"invalid-version","detail":"2.37.1.pre.beta.4 is older than latest version: 2.37.1.pre.beta.4"}]}';
+    expect(isAlreadyReleasedError(output)).toBe(true);
+  });
+
+  test("does not treat a genuinely older version as already-released", () => {
+    const output =
+      '{"errors":[{"code":"invalid-version","detail":"2.37.0 is older than latest version: 2.37.1.pre.beta.4"}]}';
+    expect(isAlreadyReleasedError(output)).toBe(false);
+  });
+
+  test("does not match unrelated errors", () => {
+    const output = "Error: connect ETIMEDOUT 1.2.3.4:443";
+    expect(isAlreadyReleasedError(output)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Changed Packages
- [ ] core
- [x] reactor-extension

## Description

Reactor keeps a single "development" extension package per name+platform and
drops its dev-availability record once a version is released. Re-running
`release.mjs` for that version (e.g. on a workflow retry, or any monorepo
publish push that doesn't bump this package) can't find a dev record to PATCH,
so it POSTs a new one instead — Reactor rejects that as `invalid-version`,
reporting the attempted version as older than the identical latest version.
Previously this hard-failed the release step every time.

This PR:
- Extracts `isAlreadyReleasedError` to recognize that exact already-released
  shape in the uploader's captured output and treats it as a no-op skip
  instead of a failure, keeping the release step idempotent.
- Hardens the detection against false positives: checks the uploader
  subprocess's spawn error/signal *before* inspecting output text, and
  requires Reactor's `invalid-version` error code alongside the
  equal-version detail (not just similar wording).
- Switches from `process.exit()` to `process.exitCode` after writing
  captured output, avoiding truncation of pending stdout/stderr writes.
- Adds test coverage for the upload control flow itself (skip / unrelated
  failure / spawn error / signal / success paths) — previously only the
  extracted regex helper was tested, not the branch that actually caused
  the incident.

## Related Issue

N/A — no tracked issue; this was found and fixed while investigating a
failed reactor-extension publish step in CI.

## Motivation and Context

A production release run failed because `release.mjs` treated an
already-released version as a hard failure rather than a no-op, blocking
the automated publish pipeline.

## Documentation
N/A — internal release tooling, no consumer-facing behavior change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] No changeset added — this only changes internal release tooling
      (`scripts/release.mjs`), not published package code or behavior.
- [x] I have signed the Adobe Open Source CLA / am an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [ ] Sandbox run — N/A, this is a release script, not run in the sandbox.
