### PR TITLE
FEAT: Implement consent and context components in Node SDK

### DIFF
--- a/.changeset/thick-toys-glow.md
+++ b/.changeset/thick-toys-glow.md
@@ -1,0 +1,6 @@
+---
+"@adobe/alloy-node": minor
+"@adobe/alloy-core": patch
+---
+
+Added Consent and a minimal Context component to the Node SDK. `setConsent` is now available (scoped per-visitor), and every event now carries `implementationDetails`. `forRequest({ request })` accepts the real incoming HTTP request to forward the visitor's `User-Agent`/`Accept-Language` headers to Edge Network and derive `web.webPageDetails.URL` from the `Referer` header.

--- a/packages/browser/bundlesize.json
+++ b/packages/browser/bundlesize.json
@@ -5,14 +5,14 @@
     "brotiliSize": 133
   },
   "dist/alloy.js": {
-    "uncompressedSize": 767491,
-    "gzippedSize": 127342,
-    "brotiliSize": 98138
+    "uncompressedSize": 773021,
+    "gzippedSize": 129308,
+    "brotiliSize": 99734
   },
   "dist/alloy.min.js": {
-    "uncompressedSize": 157961,
-    "gzippedSize": 52864,
-    "brotiliSize": 45581
+    "uncompressedSize": 158747,
+    "gzippedSize": 53165,
+    "brotiliSize": 45815
   },
   "dist/alloyServiceWorker.js": {
     "uncompressedSize": 22249,

--- a/packages/browser/bundlesize.json
+++ b/packages/browser/bundlesize.json
@@ -5,14 +5,14 @@
     "brotiliSize": 133
   },
   "dist/alloy.js": {
-    "uncompressedSize": 767477,
-    "gzippedSize": 127336,
-    "brotiliSize": 98129
+    "uncompressedSize": 767491,
+    "gzippedSize": 127342,
+    "brotiliSize": 98138
   },
   "dist/alloy.min.js": {
-    "uncompressedSize": 157954,
-    "gzippedSize": 52858,
-    "brotiliSize": 45544
+    "uncompressedSize": 157961,
+    "gzippedSize": 52864,
+    "brotiliSize": 45581
   },
   "dist/alloyServiceWorker.js": {
     "uncompressedSize": 22249,

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -39,6 +39,14 @@ import * as optionalComponents from "./core/componentCreators.js";
 export { default as createCoreConfigs } from "./core/config/createCoreConfigs.js";
 
 /**
+ * The Consent component creator, exported individually (rather than only
+ * available bundled into `createInstance`'s full component set) so runtimes
+ * like `@adobe/alloy-node` can opt into it without importing core's deep
+ * internal paths directly.
+ */
+export { default as consent } from "./components/Consent/index.js";
+
+/**
  * Creates a custom Alloy instance which can reduce the library size and increase performance.
  *
  * @param {Object} [options] - Configuration options for the instance.

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -106,10 +106,11 @@ A minimal, always-on Context component attaches `implementationDetails` to
 every event automatically. There's no DOM to read device/viewport/timezone
 info from like the browser version does, but if you pass the real incoming
 request to `forRequest({ request })`, Context also derives
-`web.webPageDetails.URL` from its `Referer` header, and the real visitor's
-`User-Agent`/`Accept-Language` headers get forwarded upstream to Edge
-Network — so its own server-side device/locale parsing has real data to
-work with instead of whatever Node's own `fetch()` would send by default:
+`web.webPageDetails.URL` from its `Referer` header, and the visitor's real
+headers (`User-Agent`, client hints, `X-Forwarded-For`, etc. — see
+`pickForwardableHeaders`) get forwarded upstream to Edge Network, so its own
+server-side device/locale/geo parsing has real data to work with instead of
+whatever Node's own `fetch()` would send by default:
 
 ```js
 const request = alloy.forRequest({

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -1,9 +1,10 @@
 # @adobe/alloy-node
 
 > [!WARNING]
-> **Alpha. Only `configure`, `sendEvent`, Identity's commands, and
-> fetch-only Personalization are exercised so far.** Most optional
-> components (Consent, Audiences, etc.) are not wired up yet.
+> **Alpha. Only `configure`, `sendEvent`, Identity's commands, Consent, a
+> minimal Context, and fetch-only Personalization are exercised so far.**
+> Most other optional components (Audiences, RulesEngine, etc.) are not
+> wired up yet.
 
 Node.js entrypoint for the Adobe Experience Platform Web SDK.
 
@@ -21,10 +22,11 @@ await alloy.sendEvent({ xdm: { eventType: "..." } });
 Unlike the browser bundle's `alloy("commandName", options)` calling
 convention, `createInstance`/`createCustomInstance` return an object with
 real methods (`configure`, `sendEvent`, `getIdentity`,
-`appendIdentityToUrl`, `applyResponse`, `getLibraryInfo`, `setDebug`). The
-browser bundle uses a callable string-command dispatcher so a synchronous
-stub can queue calls before the library finishes loading asynchronously —
-that doesn't apply in Node, so methods are used instead for discoverability.
+`appendIdentityToUrl`, `applyResponse`, `getLibraryInfo`, `setDebug`,
+`setConsent`). The browser bundle uses a callable string-command dispatcher
+so a synchronous stub can queue calls before the library finishes loading
+asynchronously — that doesn't apply in Node, so methods are used instead for
+discoverability.
 
 ## One instance per process, `forRequest()` per request
 
@@ -78,6 +80,49 @@ display-notification batching, since there's no page to render into in
 Node. That's the client's job once it calls `applyPropositions`; use
 `createCustomInstance({ components: [] })` to omit this component entirely.
 
+## Consent
+
+`createInstance()` includes Consent, so `setConsent` is available the same
+way it is in the browser — call it per-request, on the `forRequest()` handle,
+with whatever consent value the visitor already recorded in their browser:
+
+```js
+await request.setConsent({
+  consent: [{ standard: "Adobe", version: "1.0", value: { general: "in" } }],
+});
+```
+
+Like identity, consent state is tied to the visitor's cookies (read/written
+through `platformServices.cookie`), so it's automatically scoped correctly
+by whatever `cookie` override you already pass to `forRequest()` — no
+separate wiring needed. If you build a custom instance with
+`createCustomInstance({ components: [...] })` and leave `consent` out,
+`setConsent` will still exist as a method but will reject when called, the
+same as calling an unregistered command in the browser bundle.
+
+## Context
+
+A minimal, always-on Context component attaches `implementationDetails` to
+every event automatically. There's no DOM to read device/viewport/timezone
+info from like the browser version does, but if you pass the real incoming
+request to `forRequest({ request })`, Context also derives
+`web.webPageDetails.URL` from its `Referer` header, and the real visitor's
+`User-Agent`/`Accept-Language` headers get forwarded upstream to Edge
+Network — so its own server-side device/locale parsing has real data to
+work with instead of whatever Node's own `fetch()` would send by default:
+
+```js
+const request = alloy.forRequest({
+  cookie: createCookieServiceForThisRequest(req, res),
+  request: req, // any { headers } object — a raw request, Express req, etc.
+});
+```
+
+Everything else the browser's Context collects (screen size, viewport,
+local timezone) has no honest server-side source and isn't guessed at here —
+merge real values directly via `sendEvent({ xdm: { ... } })` if you have
+them.
+
 ## Platform services
 
 Both `createInstance(options)` and `forRequest(overrides)` accept a
@@ -105,7 +150,10 @@ implement the `CookieService` interface (`get`, `getAll`, `set`, `remove`,
 Everything ECID/identity-related — the `kndctr_`/`AMCV_` cookies, edge
 cluster/location-hint affinity, consent cookies forwarded to the Edge
 Network — goes through `cookie`, so it's already correctly bucketed by
-`forRequest()`'s per-request override. `storage`'s current uses (debug-flag
+`forRequest()`'s per-request override. `request` (the real incoming HTTP
+request, see [Context](#context)) is inherently per-request too, and is
+never inherited from the top-level instance the way `cookie`/`storage`
+aren't. `storage`'s current uses (debug-flag
 persistence, an Assurance validation client ID) are process-level
 bookkeeping, not visitor state, _except_ that Assurance client ID: it's
 meant to be a stable per-visitor value, but with the default in-memory

--- a/packages/node/jsconfig.json
+++ b/packages/node/jsconfig.json
@@ -2,6 +2,12 @@
   "extends": "../../jsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
+    // Overrides the shared ES2020/bundler settings from jsconfig.base.json:
+    // this package ships raw ESM source run directly by Node (no bundler),
+    // and import attributes (`with { type: "json" }`) need one of
+    // esnext/node18/node20/nodenext/preserve.
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "lib": ["ES2022", "DOM"],
     "strict": true,
     "noUncheckedIndexedAccess": true,

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -11,7 +11,7 @@
   "author": "Adobe Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "files": [
     "src",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/alloy-node",
-  "version": "1.0.0-beta.0",
+  "version": "0.0.1-beta.0",
   "description": "Adobe Experience Platform Web SDK - Node.js entrypoint",
   "type": "module",
   "repository": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0-beta.0",
   "description": "Adobe Experience Platform Web SDK - Node.js entrypoint",
   "type": "module",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/adobe/alloy.git",

--- a/packages/node/src/alloy-core.d.ts
+++ b/packages/node/src/alloy-core.d.ts
@@ -7,4 +7,6 @@ declare module "@adobe/alloy-core" {
   ): (commandName: string, options?: Record<string, unknown>) => Promise<any>;
 
   export function createCoreConfigs(): unknown;
+
+  export function consent(options: Record<string, unknown>): unknown;
 }

--- a/packages/node/src/components/context.js
+++ b/packages/node/src/components/context.js
@@ -12,31 +12,21 @@ governing permissions and limitations under the License.
 
 /** @import { NodeRequestLike } from "../services/createNodePlatformServices.js" */
 
+import { createRequire } from "node:module";
 import getHeader from "../services/getHeader.js";
 
-// Mirrors @adobe/alloy-core/constants/libraryName.js, hardcoded here rather
-// than imported to avoid pulling core's build-time __VERSION__ placeholder
-// (never replaced in Node's unbundled source) and to keep Node's own
-// implementationDetails.version tied to @adobe/alloy-node's own version,
-// which is independent of the browser bundle's.
+// Mirrors @adobe/alloy-core/constants/libraryName.js — hardcoded rather than
+// imported since it's independent of @adobe/alloy-node's own version.
 const LIBRARY_NAME = "https://ns.adobe.com/experience/alloy";
-const LIBRARY_VERSION = "1.0.0-beta.0";
+const { version: LIBRARY_VERSION } = createRequire(import.meta.url)(
+  "../../package.json",
+);
 
 /**
- * Required (always active) Node component analogous to the browser bundle's
- * Context component. There's no DOM to read device/viewport/timezone info
- * from, so unlike the browser version this only attaches:
- *
- * - `implementationDetails`, unconditionally.
- * - `web.webPageDetails.URL`, best-effort, from the `Referer` header of the
- *   request passed to `forRequest({ request })` — the closest Node
- *   equivalent of "the page the visitor is on," since it's usually the page
- *   that called this server's endpoint in a hybrid-personalization setup.
- *
- * Everything else the browser's Context collects (screen size, viewport,
- * local timezone) has no honest server-side source and is deliberately not
- * guessed at here — a caller who has real values for those can still merge
- * them directly via `sendEvent({ xdm })`.
+ * Node's analog to the browser bundle's Context component. No DOM to read
+ * device/viewport/timezone from, so this only attaches `implementationDetails`
+ * and, best-effort, `web.webPageDetails.URL` from the `Referer` header of
+ * `forRequest({ request })`.
  *
  * @param {Object} params
  * @param {{ request?: NodeRequestLike }} params.platformServices

--- a/packages/node/src/components/context.js
+++ b/packages/node/src/components/context.js
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/** @import { NodeRequestLike } from "../services/createNodePlatformServices.js" */
+
+import getHeader from "../services/getHeader.js";
+
+// Mirrors @adobe/alloy-core/constants/libraryName.js, hardcoded here rather
+// than imported to avoid pulling core's build-time __VERSION__ placeholder
+// (never replaced in Node's unbundled source) and to keep Node's own
+// implementationDetails.version tied to @adobe/alloy-node's own version,
+// which is independent of the browser bundle's.
+const LIBRARY_NAME = "https://ns.adobe.com/experience/alloy";
+const LIBRARY_VERSION = "1.0.0-beta.0";
+
+/**
+ * Required (always active) Node component analogous to the browser bundle's
+ * Context component. There's no DOM to read device/viewport/timezone info
+ * from, so unlike the browser version this only attaches:
+ *
+ * - `implementationDetails`, unconditionally.
+ * - `web.webPageDetails.URL`, best-effort, from the `Referer` header of the
+ *   request passed to `forRequest({ request })` — the closest Node
+ *   equivalent of "the page the visitor is on," since it's usually the page
+ *   that called this server's endpoint in a hybrid-personalization setup.
+ *
+ * Everything else the browser's Context collects (screen size, viewport,
+ * local timezone) has no honest server-side source and is deliberately not
+ * guessed at here — a caller who has real values for those can still merge
+ * them directly via `sendEvent({ xdm })`.
+ *
+ * @param {Object} params
+ * @param {{ request?: NodeRequestLike }} params.platformServices
+ */
+const createContext = ({ platformServices }) => ({
+  lifecycle: {
+    /** @param {{ event: any }} params */
+    onBeforeEvent({ event }) {
+      event.mergeXdm({
+        implementationDetails: {
+          name: LIBRARY_NAME,
+          version: LIBRARY_VERSION,
+          environment: "server",
+        },
+      });
+
+      const referer = getHeader(platformServices.request?.headers, "referer");
+      if (typeof referer === "string" && referer) {
+        event.mergeXdm({
+          web: { webPageDetails: { URL: referer } },
+        });
+      }
+
+      return Promise.resolve();
+    },
+  },
+});
+
+createContext.namespace = "Context";
+
+export default createContext;

--- a/packages/node/src/components/context.js
+++ b/packages/node/src/components/context.js
@@ -12,15 +12,11 @@ governing permissions and limitations under the License.
 
 /** @import { NodeRequestLike } from "../services/createNodePlatformServices.js" */
 
-import { createRequire } from "node:module";
+import packageJson from "../../package.json" with { type: "json" };
 import getHeader from "../services/getHeader.js";
 
-// Mirrors @adobe/alloy-core/constants/libraryName.js — hardcoded rather than
-// imported since it's independent of @adobe/alloy-node's own version.
 const LIBRARY_NAME = "https://ns.adobe.com/experience/alloy";
-const { version: LIBRARY_VERSION } = createRequire(import.meta.url)(
-  "../../package.json",
-);
+const { version: LIBRARY_VERSION } = packageJson;
 
 /**
  * Node's analog to the browser bundle's Context component. No DOM to read

--- a/packages/node/src/components/requiredComponentCreators.js
+++ b/packages/node/src/components/requiredComponentCreators.js
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-// This file contains the optional components that can be included in a Node
-// build. Mirrors the shape of packages/browser/src/allOptionalComponents.js.
+// This file contains the components that are always active in a Node build,
+// regardless of what's passed to `components`. Mirrors the shape of
+// packages/browser/src/components/requiredComponentCreators.js.
 
-export { default as personalization } from "./components/personalization.js";
-export { consent } from "@adobe/alloy-core";
+export { default as context } from "./context.js";

--- a/packages/node/src/createNodeAlloy.js
+++ b/packages/node/src/createNodeAlloy.js
@@ -18,6 +18,9 @@ import {
   createCoreConfigs,
 } from "@adobe/alloy-core";
 import createNodePlatformServices from "./services/createNodePlatformServices.js";
+import * as allRequiredComponents from "./components/requiredComponentCreators.js";
+
+/** @import { NodeRequestLike } from "./services/createNodePlatformServices.js" */
 
 /**
  * @typedef {Object} PlatformServiceOverrides
@@ -44,6 +47,7 @@ const COMMAND_NAMES = [
   "getIdentity",
   "appendIdentityToUrl",
   "getLibraryInfo",
+  "setConsent",
 ];
 
 /**
@@ -78,8 +82,15 @@ const createNodeAlloy = ({
   components = [],
   platformServices = {},
 } = {}) => {
+  // Mirrors packages/browser/src/index.js: components a consumer can't opt
+  // out of (currently just Context), prepended to whatever they passed in.
+  const allComponents = [
+    ...Object.values(allRequiredComponents),
+    ...components,
+  ];
+
   const executeCommand = createCoreCustomInstance(
-    { name, monitors, components },
+    { name, monitors, components: allComponents },
     () => createNodePlatformServices(platformServices),
     createCoreConfigs(),
   );
@@ -114,21 +125,32 @@ const createNodeAlloy = ({
    * instead. Only the (stateless) `network`/`runtime`/`legacy`/`globals`
    * slots are safe to inherit as instance-wide defaults.
    *
-   * @param {PlatformServiceOverrides} [requestPlatformServices]
+   * `request` isn't a platform service override — it's this request's real
+   * incoming HTTP request (anything with a `headers` object; a raw Node
+   * `IncomingMessage`, an Express `req`, or a plain `{ headers }`), used to
+   * forward the real visitor's `User-Agent`/`Accept-Language` upstream to
+   * Edge Network and to populate `web.webPageDetails.URL` (see
+   * components/context.js). Pass it whenever this call is proxying a real
+   * visitor's request, so Edge Network's own device/geo parsing has real
+   * data instead of whatever Node's own fetch() would send by default.
+   *
+   * @param {PlatformServiceOverrides & { request?: NodeRequestLike }} [requestOverrides]
    */
-  const forRequest = (requestPlatformServices = {}) => {
+  const forRequest = (requestOverrides = {}) => {
     if (!capturedConfig) {
       throw new Error(
         "forRequest() can only be called after configure() has resolved.",
       );
     }
+    const { request, ...requestPlatformServices } = requestOverrides;
     const { cookie, storage, ...sharedPlatformServices } = platformServices;
     const requestExecuteCommand = createCoreCustomInstance(
-      { name, monitors, components },
+      { name, monitors, components: allComponents },
       () =>
         createNodePlatformServices({
           ...sharedPlatformServices,
           ...requestPlatformServices,
+          request,
         }),
       // Fresh validators per request: orgId/datastreamId are being
       // reconfigured with the exact same values on purpose here, once per

--- a/packages/node/src/createNodeAlloy.js
+++ b/packages/node/src/createNodeAlloy.js
@@ -99,40 +99,25 @@ const createNodeAlloy = ({
   let capturedConfig;
 
   /**
-   * A handle scoped to a single request: backed by its own fresh underlying
-   * instance, reconfigured with the same config this instance was configured
-   * with, but with `requestPlatformServices` overrides layered on top of
-   * this instance's own platformServices — typically `cookie`, so identity
-   * resolves from that request's cookies instead of shared in-memory state.
-   * Call `configure()` on this instance before calling `forRequest()`.
+   * A handle scoped to a single request, backed by its own fresh instance
+   * reconfigured with this instance's config plus `requestOverrides`
+   * layered on top of its platformServices. Requires `configure()` to have
+   * already resolved on this instance.
    *
-   * Building a whole new instance (not just swapping platformServices on a
-   * shared one) is load-bearing, not incidental: core's Identity component
-   * caches its resolved ECID/namespaces in plain closures once acquired
-   * (see createIdentity.js's awaitIdentityPromise and
-   * components/Identity/createComponent.js's cached namespaces/edge) —
-   * those closures live for as long as the instance they were created in,
-   * regardless of which cookie jar is passed in later. Reusing an instance
-   * across requests and only swapping `cookie` would silently leak one
-   * visitor's identity into another's. Don't "optimize" this into instance
-   * reuse without re-deriving that state per request too.
+   * A fresh instance (not just a swapped `cookie`) is required because
+   * Identity caches its resolved ECID in a plain closure for the life of
+   * the instance — reusing one across requests would leak identity between
+   * visitors regardless of which cookie jar was passed in.
    *
-   * `cookie`/`storage` specifically never fall back to this instance's own
-   * platformServices, even if it configured one — those two hold per-visitor
-   * state, so inheriting a shared, stateful one as a silent default would
-   * leak identity across visitors exactly like reusing the instance would.
-   * If a request doesn't override them here, it gets a fresh, empty default
-   * instead. Only the (stateless) `network`/`runtime`/`legacy`/`globals`
-   * slots are safe to inherit as instance-wide defaults.
+   * For the same reason, `cookie`/`storage` never fall back to this
+   * instance's own platformServices; only the stateless
+   * `network`/`runtime`/`legacy`/`globals` slots do.
    *
-   * `request` isn't a platform service override — it's this request's real
-   * incoming HTTP request (anything with a `headers` object; a raw Node
-   * `IncomingMessage`, an Express `req`, or a plain `{ headers }`), used to
-   * forward the real visitor's `User-Agent`/`Accept-Language` upstream to
-   * Edge Network and to populate `web.webPageDetails.URL` (see
-   * components/context.js). Pass it whenever this call is proxying a real
-   * visitor's request, so Edge Network's own device/geo parsing has real
-   * data instead of whatever Node's own fetch() would send by default.
+   * `request` (any object with a `headers` property — a Node
+   * `IncomingMessage`, an Express `req`, a fetch `Request`, etc.) is the
+   * real incoming request this call is proxying, used to forward the
+   * visitor's real headers to Edge Network and populate
+   * `web.webPageDetails.URL` (see components/context.js).
    *
    * @param {PlatformServiceOverrides & { request?: NodeRequestLike }} [requestOverrides]
    */

--- a/packages/node/src/node-builtins.d.ts
+++ b/packages/node/src/node-builtins.d.ts
@@ -1,0 +1,7 @@
+// Minimal ambient declarations for the Node builtins this package uses,
+// scoped to just what's needed — avoids pulling in @types/node wholesale,
+// which would conflict with the DOM lib types this package already relies
+// on for fetch/Response.
+declare module "node:module" {
+  export function createRequire(url: string): (id: string) => any;
+}

--- a/packages/node/src/node-builtins.d.ts
+++ b/packages/node/src/node-builtins.d.ts
@@ -1,7 +1,0 @@
-// Minimal ambient declarations for the Node builtins this package uses,
-// scoped to just what's needed — avoids pulling in @types/node wholesale,
-// which would conflict with the DOM lib types this package already relies
-// on for fetch/Response.
-declare module "node:module" {
-  export function createRequire(url: string): (id: string) => any;
-}

--- a/packages/node/src/services/createNodeNetworkService.js
+++ b/packages/node/src/services/createNodeNetworkService.js
@@ -16,9 +16,15 @@ governing permissions and limitations under the License.
  * Node has no `navigator.sendBeacon`, so there is no separate unload-safe
  * transport — both network strategies use `fetch`.
  *
+ * @param {Object} [options]
+ * @param {Record<string, string>} [options.headers] Extra headers merged
+ * into every outgoing request — e.g. a real visitor's `User-Agent` from
+ * `pickForwardableHeaders`, so Edge Network's own device parsing has real
+ * data instead of whatever Node's fetch() sends by default. Can't override
+ * `Content-Type`.
  * @returns {NetworkService}
  */
-const createNodeNetworkService = () => {
+const createNodeNetworkService = ({ headers: forwardedHeaders = {} } = {}) => {
   /**
    * @param {string} url
    * @param {string} body
@@ -27,6 +33,7 @@ const createNodeNetworkService = () => {
     fetch(url, {
       method: "POST",
       headers: {
+        ...forwardedHeaders,
         "Content-Type": "text/plain; charset=UTF-8",
       },
       body,

--- a/packages/node/src/services/createNodeNetworkService.js
+++ b/packages/node/src/services/createNodeNetworkService.js
@@ -18,10 +18,8 @@ governing permissions and limitations under the License.
  *
  * @param {Object} [options]
  * @param {Record<string, string>} [options.headers] Extra headers merged
- * into every outgoing request — e.g. a real visitor's `User-Agent` from
- * `pickForwardableHeaders`, so Edge Network's own device parsing has real
- * data instead of whatever Node's fetch() sends by default. Can't override
- * `Content-Type`.
+ * into every outgoing request (e.g. from `pickForwardableHeaders`). Can't
+ * override `Content-Type`.
  * @returns {NetworkService}
  */
 const createNodeNetworkService = ({ headers: forwardedHeaders = {} } = {}) => {

--- a/packages/node/src/services/createNodePlatformServices.js
+++ b/packages/node/src/services/createNodePlatformServices.js
@@ -19,6 +19,19 @@ import createNodeCookieService from "./createNodeCookieService.js";
 import createNodeRuntimeService from "./createNodeRuntimeService.js";
 import createNodeLegacyService from "./createNodeLegacyService.js";
 import createNodeGlobalsService from "./createNodeGlobalsService.js";
+import pickForwardableHeaders from "./pickForwardableHeaders.js";
+
+/**
+ * @typedef {Record<string, string | string[] | undefined> | Headers} NodeRequestHeaders
+ * Either a plain headers object (Node's `IncomingMessage.headers`,
+ * Express's `req.headers`) or a WHATWG `Headers` instance (fetch-standard
+ * `Request.headers`). See `getHeader.js`.
+ */
+
+/**
+ * @typedef {Object} NodeRequestLike
+ * @property {NodeRequestHeaders} [headers]
+ */
 
 /**
  * Each override replaces the corresponding default in-memory Node
@@ -32,7 +45,14 @@ import createNodeGlobalsService from "./createNodeGlobalsService.js";
  * @param {RuntimeService} [overrides.runtime]
  * @param {LegacyService} [overrides.legacy]
  * @param {GlobalsService} [overrides.globals]
- * @returns {PlatformServices}
+ * @param {NodeRequestLike} [overrides.request] The real incoming HTTP
+ * request Node is proxying an event on behalf of, if any. Used, when
+ * `network` isn't explicitly overridden, to forward the visitor's real
+ * `User-Agent`/`Accept-Language` headers upstream to Edge Network, and
+ * exposed as-is on the returned object (a Node-only extension beyond the
+ * shared `PlatformServices` interface) for the Context component to derive
+ * `web.webPageDetails.URL` from.
+ * @returns {PlatformServices & { request?: NodeRequestLike }}
  */
 const createNodePlatformServices = ({
   network,
@@ -41,14 +61,20 @@ const createNodePlatformServices = ({
   runtime,
   legacy,
   globals,
+  request,
 } = {}) => ({
   createNetworkService: (logger) =>
-    network ? network(logger) : createNodeNetworkService(),
+    network
+      ? network(logger)
+      : createNodeNetworkService({
+          headers: pickForwardableHeaders(request?.headers),
+        }),
   storage: storage || createNodeStorageService(),
   cookie: cookie || createNodeCookieService(),
   runtime: runtime || createNodeRuntimeService(),
   legacy: legacy || createNodeLegacyService(),
   globals: globals || createNodeGlobalsService(),
+  request,
 });
 
 export default createNodePlatformServices;

--- a/packages/node/src/services/createNodePlatformServices.js
+++ b/packages/node/src/services/createNodePlatformServices.js
@@ -45,13 +45,10 @@ import pickForwardableHeaders from "./pickForwardableHeaders.js";
  * @param {RuntimeService} [overrides.runtime]
  * @param {LegacyService} [overrides.legacy]
  * @param {GlobalsService} [overrides.globals]
- * @param {NodeRequestLike} [overrides.request] The real incoming HTTP
- * request Node is proxying an event on behalf of, if any. Used, when
- * `network` isn't explicitly overridden, to forward the visitor's real
- * `User-Agent`/`Accept-Language` headers upstream to Edge Network, and
- * exposed as-is on the returned object (a Node-only extension beyond the
- * shared `PlatformServices` interface) for the Context component to derive
- * `web.webPageDetails.URL` from.
+ * @param {NodeRequestLike} [overrides.request] The real incoming request
+ * Node is proxying an event for, if any — forwarded to Edge Network via
+ * `pickForwardableHeaders` (unless `network` is overridden), and exposed
+ * as-is on the returned object for the Context component to read.
  * @returns {PlatformServices & { request?: NodeRequestLike }}
  */
 const createNodePlatformServices = ({

--- a/packages/node/src/services/getHeader.js
+++ b/packages/node/src/services/getHeader.js
@@ -1,0 +1,38 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/** @import { NodeRequestHeaders } from "./createNodePlatformServices.js" */
+
+/**
+ * Reads a single header off either shape `request.headers` can be, since
+ * `forRequest({ request })` is documented to accept "any object with
+ * headers" and fetch-standard `Request`s (as used by Next.js Route
+ * Handlers, Hono, and other fetch-based Node frameworks) are a realistic
+ * shape for that: their `.headers` is a WHATWG `Headers` instance, not a
+ * plain object, and bracket access on a `Headers` instance always returns
+ * `undefined` — it only exposes values through `.get()`.
+ *
+ * @param {NodeRequestHeaders} [headers]
+ * @param {string} name Lowercase header name.
+ * @returns {string | string[] | undefined}
+ */
+const getHeader = (headers, name) => {
+  if (!headers) {
+    return undefined;
+  }
+  if (typeof headers.get === "function") {
+    return headers.get(name) ?? undefined;
+  }
+  return headers[name];
+};
+
+export default getHeader;

--- a/packages/node/src/services/getHeader.js
+++ b/packages/node/src/services/getHeader.js
@@ -21,7 +21,7 @@ governing permissions and limitations under the License.
  * plain object, and bracket access on a `Headers` instance always returns
  * `undefined` — it only exposes values through `.get()`.
  *
- * @param {NodeRequestHeaders} [headers]
+ * @param {NodeRequestHeaders | undefined} headers
  * @param {string} name Lowercase header name.
  * @returns {string | string[] | undefined}
  */
@@ -29,7 +29,7 @@ const getHeader = (headers, name) => {
   if (!headers) {
     return undefined;
   }
-  if (typeof headers.get === "function") {
+  if (headers instanceof Headers) {
     return headers.get(name) ?? undefined;
   }
   return headers[name];

--- a/packages/node/src/services/getHeader.js
+++ b/packages/node/src/services/getHeader.js
@@ -13,13 +13,10 @@ governing permissions and limitations under the License.
 /** @import { NodeRequestHeaders } from "./createNodePlatformServices.js" */
 
 /**
- * Reads a single header off either shape `request.headers` can be, since
- * `forRequest({ request })` is documented to accept "any object with
- * headers" and fetch-standard `Request`s (as used by Next.js Route
- * Handlers, Hono, and other fetch-based Node frameworks) are a realistic
- * shape for that: their `.headers` is a WHATWG `Headers` instance, not a
- * plain object, and bracket access on a `Headers` instance always returns
- * `undefined` — it only exposes values through `.get()`.
+ * Reads a single header from either shape `request.headers` can be — a
+ * plain object, or a WHATWG `Headers` instance (e.g. fetch-standard
+ * `Request`s, as used by Next.js Route Handlers, Hono, etc.), which only
+ * exposes values through `.get()`.
  *
  * @param {NodeRequestHeaders | undefined} headers
  * @param {string} name Lowercase header name.

--- a/packages/node/src/services/pickForwardableHeaders.js
+++ b/packages/node/src/services/pickForwardableHeaders.js
@@ -1,0 +1,40 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/** @import { NodeRequestHeaders } from "./createNodePlatformServices.js" */
+
+import getHeader from "./getHeader.js";
+
+// Headers worth forwarding upstream to Edge Network when Node is proxying a
+// request on a real visitor's behalf, so Edge Network's own server-side
+// device/locale parsing (which normally reads these off the direct
+// browser -> Edge Network request) still has something real to parse instead
+// of whatever Node's own fetch() would send by default.
+const FORWARDABLE_HEADER_NAMES = ["user-agent", "accept-language"];
+
+/**
+ * @param {NodeRequestHeaders} [headers]
+ * @returns {Record<string, string>}
+ */
+const pickForwardableHeaders = (headers) => {
+  /** @type {Record<string, string>} */
+  const picked = {};
+  FORWARDABLE_HEADER_NAMES.forEach((name) => {
+    const value = getHeader(headers, name);
+    if (typeof value === "string" && value) {
+      picked[name] = value;
+    }
+  });
+  return picked;
+};
+
+export default pickForwardableHeaders;

--- a/packages/node/src/services/pickForwardableHeaders.js
+++ b/packages/node/src/services/pickForwardableHeaders.js
@@ -14,12 +14,27 @@ governing permissions and limitations under the License.
 
 import getHeader from "./getHeader.js";
 
-// Headers worth forwarding upstream to Edge Network when Node is proxying a
-// request on a real visitor's behalf, so Edge Network's own server-side
-// device/locale parsing (which normally reads these off the direct
-// browser -> Edge Network request) still has something real to parse instead
-// of whatever Node's own fetch() would send by default.
-const FORWARDABLE_HEADER_NAMES = ["user-agent", "accept-language"];
+// Forwarded so Edge Network's own device/locale/geo parsing sees the real
+// visitor instead of this Node process.
+const FORWARDABLE_HEADER_NAMES = [
+  "user-agent",
+  "accept-language",
+  // User-Agent Client Hints
+  "sec-ch-ua",
+  "sec-ch-ua-mobile",
+  "sec-ch-ua-platform",
+  "sec-ch-ua-platform-version",
+  "sec-ch-ua-arch",
+  "sec-ch-ua-bitness",
+  "sec-ch-ua-full-version-list",
+  "sec-ch-ua-model",
+  "sec-ch-ua-wow64",
+  // Client IP, as set by a proxy/load balancer in front of this server —
+  // otherwise Edge Network attributes every request to this server's IP.
+  "x-forwarded-for",
+  "forwarded",
+  "x-real-ip",
+];
 
 /**
  * @param {NodeRequestHeaders} [headers]

--- a/packages/node/test/integration/nodeConsumer.spec.js
+++ b/packages/node/test/integration/nodeConsumer.spec.js
@@ -179,4 +179,51 @@ describe("Node consumer integration", () => {
 
     expect(Array.isArray(result.propositions)).toBe(true);
   });
+
+  // Proves Consent is real, wired-up core component (not just a stub): the
+  // real /privacy/set-consent round trip succeeds and writes a real consent
+  // cookie to whatever cookie service the caller supplies — the same
+  // pattern proven for identity above, now for consent state.
+  it("setConsent() writes a real consent cookie to a request-scoped cookie service", async () => {
+    const alloy = node.createInstance();
+    await alloy.configure(config);
+
+    const cookie = createNodeCookieService();
+    const request = alloy.forRequest({ cookie });
+
+    await request.setConsent({
+      consent: [
+        { standard: "Adobe", version: "1.0", value: { general: "in" } },
+      ],
+    });
+
+    const cookieNames = Object.keys(cookie.getAll());
+    expect(cookieNames.some((name) => name.endsWith("_consent"))).toBe(true);
+  });
+
+  // Proves the Context component's request-forwarding actually reaches a
+  // real Edge Network round trip without erroring — the forwarded
+  // User-Agent/Accept-Language headers and the derived web.webPageDetails.URL
+  // are exercised by the real request pipeline, not just mocked in unit
+  // tests. There's no way to inspect what Edge Network received/parsed from
+  // here, so this only proves the plumbing doesn't break the request.
+  it("forRequest({ request }) sends a real event without error", async () => {
+    const alloy = node.createInstance();
+    await alloy.configure(config);
+
+    const request = alloy.forRequest({
+      cookie: createNodeCookieService(),
+      request: {
+        headers: {
+          "user-agent": "Mozilla/5.0 (nodeConsumer integration test)",
+          "accept-language": "en-US",
+          referer: "https://example.com/sample-page",
+        },
+      },
+    });
+
+    await expect(
+      request.sendEvent({ xdm: { eventType: "test.nodeConsumer" } }),
+    ).resolves.toBeDefined();
+  });
 });

--- a/packages/node/test/integration/nodeConsumer.spec.js
+++ b/packages/node/test/integration/nodeConsumer.spec.js
@@ -201,6 +201,102 @@ describe("Node consumer integration", () => {
     expect(cookieNames.some((name) => name.endsWith("_consent"))).toBe(true);
   });
 
+  // These consent tests pass `decisionScopes` and check for `propositions`
+  // in the result as a real, observable signal that the request actually
+  // reached Edge Network — a plain sendEvent() resolves to `{}` whether or
+  // not consent blocked it, so it can't tell the two cases apart on its own.
+
+  it("real defaultConsent: pending holds sendEvent, then a real opt-in unblocks it", async () => {
+    const alloy = node.createInstance();
+    await alloy.configure({ ...config, defaultConsent: "pending" });
+
+    let resolved = false;
+    const pending = alloy
+      .sendEvent({
+        xdm: { eventType: "test.nodeConsumer" },
+        decisionScopes: ["test-nodeConsumer-scope"],
+      })
+      .then((result) => {
+        resolved = true;
+        return result;
+      });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(resolved).toBe(false);
+
+    await alloy.setConsent({
+      consent: [
+        { standard: "Adobe", version: "1.0", value: { general: "in" } },
+      ],
+    });
+    const result = await pending;
+
+    expect(resolved).toBe(true);
+    expect(Array.isArray(result.propositions)).toBe(true);
+  });
+
+  it("a real opt-out setConsent blocks a subsequent sendEvent", async () => {
+    const alloy = node.createInstance();
+    await alloy.configure(config);
+
+    await alloy.setConsent({
+      consent: [
+        { standard: "Adobe", version: "1.0", value: { general: "out" } },
+      ],
+    });
+    const result = await alloy.sendEvent({
+      xdm: { eventType: "test.nodeConsumer" },
+      decisionScopes: ["test-nodeConsumer-scope"],
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it("consent persists across two forRequest() calls sharing a cookie jar, without a second setConsent", async () => {
+    const sharedCookie = createNodeCookieService();
+    const alloy = node.createInstance();
+    await alloy.configure({ ...config, defaultConsent: "out" });
+
+    await alloy.forRequest({ cookie: sharedCookie }).setConsent({
+      consent: [
+        { standard: "Adobe", version: "1.0", value: { general: "in" } },
+      ],
+    });
+
+    const result = await alloy.forRequest({ cookie: sharedCookie }).sendEvent({
+      xdm: { eventType: "test.nodeConsumer" },
+      decisionScopes: ["test-nodeConsumer-scope"],
+    });
+
+    expect(Array.isArray(result.propositions)).toBe(true);
+  });
+
+  it("the real Edge Network interprets the Adobe 2.0 standard's collect.val the same way our code assumes", async () => {
+    const alloy = node.createInstance();
+    await alloy.configure(config);
+
+    await alloy.setConsent({
+      consent: [
+        { standard: "Adobe", version: "2.0", value: { collect: { val: "n" } } },
+      ],
+    });
+    const declined = await alloy.sendEvent({
+      xdm: { eventType: "test.nodeConsumer" },
+      decisionScopes: ["test-nodeConsumer-scope"],
+    });
+    expect(declined).toEqual({});
+
+    await alloy.setConsent({
+      consent: [
+        { standard: "Adobe", version: "2.0", value: { collect: { val: "y" } } },
+      ],
+    });
+    const allowed = await alloy.sendEvent({
+      xdm: { eventType: "test.nodeConsumer" },
+      decisionScopes: ["test-nodeConsumer-scope"],
+    });
+    expect(Array.isArray(allowed.propositions)).toBe(true);
+  });
+
   // Proves the Context component's request-forwarding actually reaches a
   // real Edge Network round trip without erroring — the forwarded
   // User-Agent/Accept-Language headers and the derived web.webPageDetails.URL
@@ -225,5 +321,18 @@ describe("Node consumer integration", () => {
     await expect(
       request.sendEvent({ xdm: { eventType: "test.nodeConsumer" } }),
     ).resolves.toBeDefined();
+  });
+
+  it("appendIdentityToUrl() appends a real ECID query param to a real URL", async () => {
+    const alloy = node.createInstance();
+    await alloy.configure(config);
+
+    const request = alloy.forRequest({ cookie: createNodeCookieService() });
+    const result = await request.appendIdentityToUrl({
+      url: "https://example.com/?a=b",
+    });
+
+    expect(result.url).toMatch(/^https:\/\/example\.com\/\?a=b/);
+    expect(result.url).not.toBe("https://example.com/?a=b");
   });
 });

--- a/packages/node/test/unit/specs/components/context.spec.js
+++ b/packages/node/test/unit/specs/components/context.spec.js
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { describe, it, expect, vi } from "vitest";
+import createContext from "../../../../src/components/context.js";
+
+const createFakeEvent = () => ({
+  mergeXdm: vi.fn(),
+});
+
+describe("Node context component", () => {
+  it("has the Context namespace", () => {
+    expect(createContext.namespace).toBe("Context");
+  });
+
+  it("always attaches implementationDetails with a server environment", async () => {
+    const event = createFakeEvent();
+    const { lifecycle } = createContext({ platformServices: {} });
+
+    await lifecycle.onBeforeEvent({ event });
+
+    expect(event.mergeXdm).toHaveBeenCalledWith({
+      implementationDetails: expect.objectContaining({
+        environment: "server",
+      }),
+    });
+  });
+
+  it("does not merge web.webPageDetails when no request was given", async () => {
+    const event = createFakeEvent();
+    const { lifecycle } = createContext({ platformServices: {} });
+
+    await lifecycle.onBeforeEvent({ event });
+
+    expect(event.mergeXdm).not.toHaveBeenCalledWith(
+      expect.objectContaining({ web: expect.anything() }),
+    );
+  });
+
+  it("does not merge web.webPageDetails when the request has no referer header", async () => {
+    const event = createFakeEvent();
+    const { lifecycle } = createContext({
+      platformServices: { request: { headers: {} } },
+    });
+
+    await lifecycle.onBeforeEvent({ event });
+
+    expect(event.mergeXdm).not.toHaveBeenCalledWith(
+      expect.objectContaining({ web: expect.anything() }),
+    );
+  });
+
+  it("merges web.webPageDetails.URL from the request's referer header", async () => {
+    const event = createFakeEvent();
+    const { lifecycle } = createContext({
+      platformServices: {
+        request: { headers: { referer: "https://example.com/page" } },
+      },
+    });
+
+    await lifecycle.onBeforeEvent({ event });
+
+    expect(event.mergeXdm).toHaveBeenCalledWith({
+      web: { webPageDetails: { URL: "https://example.com/page" } },
+    });
+  });
+
+  it("merges web.webPageDetails.URL from a WHATWG Headers instance's referer header", async () => {
+    const event = createFakeEvent();
+    const { lifecycle } = createContext({
+      platformServices: {
+        request: {
+          headers: new Headers({ referer: "https://example.com/page" }),
+        },
+      },
+    });
+
+    await lifecycle.onBeforeEvent({ event });
+
+    expect(event.mergeXdm).toHaveBeenCalledWith({
+      web: { webPageDetails: { URL: "https://example.com/page" } },
+    });
+  });
+});

--- a/packages/node/test/unit/specs/components/requiredComponentCreators.spec.js
+++ b/packages/node/test/unit/specs/components/requiredComponentCreators.spec.js
@@ -1,0 +1,30 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { describe, it, expect } from "vitest";
+import * as allRequiredComponents from "../../../../src/components/requiredComponentCreators.js";
+
+describe("Node requiredComponentCreators", () => {
+  it("exports only component creator functions", () => {
+    const componentCreators = Object.values(allRequiredComponents);
+
+    expect(componentCreators.length).toBeGreaterThan(0);
+    componentCreators.forEach((componentCreator) => {
+      expect(componentCreator).toBeTypeOf("function");
+      expect(componentCreator.namespace).toBeTypeOf("string");
+    });
+  });
+
+  it("includes context", () => {
+    expect(allRequiredComponents.context).toBeTypeOf("function");
+  });
+});

--- a/packages/node/test/unit/specs/consent.spec.js
+++ b/packages/node/test/unit/specs/consent.spec.js
@@ -1,0 +1,290 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { consent } from "@adobe/alloy-core";
+import createNodeAlloy from "../../../src/createNodeAlloy.js";
+import createNodeCookieService from "../../../src/services/createNodeCookieService.js";
+import createFakeEdgeNetworkFetch from "./helpers/fakeEdgeNetworkFetch.js";
+
+const config = {
+  orgId: "TEST_ORG@AdobeOrg",
+  datastreamId: "test-datastream-id",
+};
+
+const interactCalls = (fetchMock) =>
+  fetchMock.mock.calls.filter(([url]) => /\/v1\/interact\b/.test(url));
+
+const setConsentCalls = (fetchMock) =>
+  fetchMock.mock.calls.filter(([url]) => /\/privacy\/set-consent\b/.test(url));
+
+const inOption = {
+  standard: "Adobe",
+  version: "1.0",
+  value: { general: "in" },
+};
+const outOption = {
+  standard: "Adobe",
+  version: "1.0",
+  value: { general: "out" },
+};
+
+describe("Consent", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("holds sendEvent while defaultConsent is pending, then sends after opt-in", async () => {
+    const fetchMock = createFakeEdgeNetworkFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const alloy = createNodeAlloy({ components: [consent] });
+    await alloy.configure({ ...config, defaultConsent: "pending" });
+
+    let resolved = false;
+    const pending = alloy
+      .sendEvent({ xdm: { eventType: "test" } })
+      .then((result) => {
+        resolved = true;
+        return result;
+      });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(resolved).toBe(false);
+    expect(interactCalls(fetchMock)).toHaveLength(0);
+
+    await alloy.setConsent({ consent: [inOption] });
+    await pending;
+    expect(resolved).toBe(true);
+    expect(interactCalls(fetchMock)).toHaveLength(1);
+  });
+
+  it("opt-out blocks the event: no /v1/interact request fires and sendEvent resolves empty", async () => {
+    const fetchMock = createFakeEdgeNetworkFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const alloy = createNodeAlloy({ components: [consent] });
+    await alloy.configure(config);
+    await alloy.setConsent({ consent: [outOption] });
+
+    const result = await alloy.sendEvent({ xdm: { eventType: "test" } });
+
+    expect(result).toEqual({});
+    expect(interactCalls(fetchMock)).toHaveLength(0);
+  });
+
+  it("revoking consent after an opt-in blocks later events", async () => {
+    const fetchMock = createFakeEdgeNetworkFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const alloy = createNodeAlloy({ components: [consent] });
+    await alloy.configure(config);
+
+    await alloy.setConsent({ consent: [inOption] });
+    await alloy.sendEvent({ xdm: { eventType: "while-in" } });
+    expect(interactCalls(fetchMock)).toHaveLength(1);
+
+    await alloy.setConsent({ consent: [outOption] });
+    const result = await alloy.sendEvent({ xdm: { eventType: "while-out" } });
+
+    expect(result).toEqual({});
+    expect(interactCalls(fetchMock)).toHaveLength(1);
+  });
+
+  it("defaultConsent: out blocks events until an explicit opt-in", async () => {
+    const fetchMock = createFakeEdgeNetworkFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const alloy = createNodeAlloy({ components: [consent] });
+    await alloy.configure({ ...config, defaultConsent: "out" });
+
+    await alloy.sendEvent({ xdm: { eventType: "before-opt-in" } });
+    expect(interactCalls(fetchMock)).toHaveLength(0);
+
+    await alloy.setConsent({ consent: [inOption] });
+    await alloy.sendEvent({ xdm: { eventType: "after-opt-in" } });
+
+    expect(interactCalls(fetchMock)).toHaveLength(1);
+  });
+
+  it("transmits the consent value to Edge and writes it to the cookie", async () => {
+    const fetchMock = createFakeEdgeNetworkFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const cookie = createNodeCookieService();
+    const alloy = createNodeAlloy({
+      components: [consent],
+      platformServices: { cookie },
+    });
+    await alloy.configure(config);
+
+    await alloy.setConsent({ consent: [outOption] });
+
+    const [, requestInit] = setConsentCalls(fetchMock).at(-1);
+    expect(JSON.parse(requestInit.body).consent).toEqual([outOption]);
+    expect(cookie.get("kndctr_TEST_ORG_AdobeOrg_consent")).toBe("general=out");
+  });
+
+  it("forwards an identityMap on setConsent", async () => {
+    const fetchMock = createFakeEdgeNetworkFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const alloy = createNodeAlloy({ components: [consent] });
+    await alloy.configure(config);
+
+    await alloy.setConsent({
+      consent: [inOption],
+      identityMap: {
+        CRMID: [
+          { id: "known-customer-id", authenticatedState: "authenticated" },
+        ],
+      },
+    });
+
+    const [, requestInit] = setConsentCalls(fetchMock).at(-1);
+    expect(JSON.parse(requestInit.body).identityMap).toEqual({
+      CRMID: [{ id: "known-customer-id", authenticatedState: "authenticated" }],
+    });
+  });
+
+  it("persists consent across two requests sharing a cookie jar, without re-calling setConsent", async () => {
+    const fetchMock = createFakeEdgeNetworkFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const sharedCookie = createNodeCookieService();
+    const alloy = createNodeAlloy({ components: [consent] });
+    await alloy.configure({ ...config, defaultConsent: "out" });
+
+    await alloy.forRequest({ cookie: sharedCookie }).setConsent({
+      consent: [inOption],
+    });
+
+    fetchMock.mockClear();
+    await alloy.forRequest({ cookie: sharedCookie }).sendEvent({
+      xdm: { eventType: "test" },
+    });
+
+    expect(interactCalls(fetchMock)).toHaveLength(1);
+  });
+
+  it("clears stored consent when the identity cookie is missing", async () => {
+    const fetchMock = createFakeEdgeNetworkFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const cookie = createNodeCookieService();
+    // A consent cookie with no matching identity cookie shouldn't be trusted
+    // — it's tied to an identity this visitor no longer has.
+    cookie.set("kndctr_TEST_ORG_AdobeOrg_consent", "general=in");
+    const alloy = createNodeAlloy({
+      components: [consent],
+      platformServices: { cookie },
+    });
+    await alloy.configure({ ...config, defaultConsent: "out" });
+
+    const result = await alloy.sendEvent({ xdm: { eventType: "test" } });
+
+    expect(result).toEqual({});
+    expect(interactCalls(fetchMock)).toHaveLength(0);
+    expect(cookie.get("kndctr_TEST_ORG_AdobeOrg_consent")).toBeUndefined();
+  });
+
+  it("gates events on the Adobe 2.0 standard's collect.val", async () => {
+    const fetchMock = createFakeEdgeNetworkFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const alloy = createNodeAlloy({ components: [consent] });
+    await alloy.configure(config);
+
+    await alloy.setConsent({
+      consent: [
+        { standard: "Adobe", version: "2.0", value: { collect: { val: "n" } } },
+      ],
+    });
+    const declined = await alloy.sendEvent({ xdm: { eventType: "test" } });
+    expect(declined).toEqual({});
+    expect(interactCalls(fetchMock)).toHaveLength(0);
+
+    await alloy.setConsent({
+      consent: [
+        { standard: "Adobe", version: "2.0", value: { collect: { val: "y" } } },
+      ],
+    });
+    await alloy.sendEvent({ xdm: { eventType: "test" } });
+    expect(interactCalls(fetchMock)).toHaveLength(1);
+  });
+
+  it("rejects setConsent with invalid options instead of resolving silently", async () => {
+    const alloy = createNodeAlloy({ components: [consent] });
+    await alloy.configure(config);
+
+    await expect(alloy.setConsent({})).rejects.toThrow();
+  });
+
+  it("rejects setConsent when Edge responds with a 4xx instead of resolving silently", async () => {
+    const fetchMock = createFakeEdgeNetworkFetch({ setConsentStatus: 400 });
+    vi.stubGlobal("fetch", fetchMock);
+    const alloy = createNodeAlloy({ components: [consent] });
+    await alloy.configure(config);
+
+    await expect(alloy.setConsent({ consent: [inOption] })).rejects.toThrow();
+  });
+
+  it("still resolves getIdentity after a failed setConsent call", async () => {
+    const fetchMock = createFakeEdgeNetworkFetch({ setConsentStatus: 400 });
+    vi.stubGlobal("fetch", fetchMock);
+    const alloy = createNodeAlloy({ components: [consent] });
+    await alloy.configure(config);
+
+    await alloy.setConsent({ consent: [inOption] }).catch(() => {});
+
+    const identity = await alloy.getIdentity();
+    expect(identity.identity.ECID).toBeDefined();
+  });
+
+  it("holds getIdentity while consent is pending, then resolves after opt-in", async () => {
+    const fetchMock = createFakeEdgeNetworkFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const alloy = createNodeAlloy({ components: [consent] });
+    await alloy.configure({ ...config, defaultConsent: "pending" });
+
+    let resolved = false;
+    const pending = alloy.getIdentity().then((result) => {
+      resolved = true;
+      return result;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(resolved).toBe(false);
+
+    await alloy.setConsent({ consent: [inOption] });
+    const identity = await pending;
+
+    expect(resolved).toBe(true);
+    expect(identity.identity.ECID).toBeDefined();
+  });
+
+  it("resolves appendIdentityToUrl with the unchanged URL while consent is pending, instead of hanging", async () => {
+    const fetchMock = createFakeEdgeNetworkFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const alloy = createNodeAlloy({ components: [consent] });
+    await alloy.configure({ ...config, defaultConsent: "pending" });
+
+    const result = await alloy.appendIdentityToUrl({
+      url: "https://example.com/?a=b",
+    });
+
+    expect(result).toEqual({ url: "https://example.com/?a=b" });
+    expect(interactCalls(fetchMock)).toHaveLength(0);
+  });
+
+  it("dedupes duplicate identical setConsent calls to a single /privacy/set-consent request", async () => {
+    const fetchMock = createFakeEdgeNetworkFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const alloy = createNodeAlloy({ components: [consent] });
+    await alloy.configure(config);
+
+    await alloy.setConsent({ consent: [inOption] });
+    await alloy.setConsent({ consent: [inOption] });
+    await alloy.setConsent({ consent: [inOption] });
+
+    expect(setConsentCalls(fetchMock)).toHaveLength(1);
+  });
+});

--- a/packages/node/test/unit/specs/createNodeAlloy.spec.js
+++ b/packages/node/test/unit/specs/createNodeAlloy.spec.js
@@ -17,7 +17,7 @@ governing permissions and limitations under the License.
 // complementing, not duplicating, the real-network coverage in
 // packages/node/test/integration/nodeConsumer.spec.js.
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import createNodeAlloy from "../../../src/createNodeAlloy.js";
 
 const config = {
@@ -32,7 +32,13 @@ const COMMAND_METHOD_NAMES = [
   "getIdentity",
   "appendIdentityToUrl",
   "getLibraryInfo",
+  "setConsent",
 ];
+
+const fakeEdgeNetworkResponse = () =>
+  new Response(JSON.stringify({ requestId: "test-request-id", handle: [] }), {
+    status: 200,
+  });
 
 const createSpyCookieService = () => {
   const jar = new Map();
@@ -154,5 +160,57 @@ describe("createNodeAlloy", () => {
 
     await expect(alloy.configure({})).rejects.toThrow();
     expect(() => alloy.forRequest()).toThrow(/configure/);
+  });
+
+  describe("Context", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("is always active — attaches implementationDetails even when no components were requested", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(fakeEdgeNetworkResponse());
+      vi.stubGlobal("fetch", fetchMock);
+      const alloy = createNodeAlloy({
+        platformServices: { cookie: createSpyCookieService() },
+      });
+      await alloy.configure(config);
+
+      await alloy.sendEvent({ xdm: { eventType: "test" } });
+
+      const [, requestInit] = fetchMock.mock.calls.at(-1);
+      const { xdm } = JSON.parse(requestInit.body).events[0];
+      expect(xdm.implementationDetails).toEqual(
+        expect.objectContaining({ environment: "server" }),
+      );
+    });
+
+    it("forRequest({ request }) forwards the visitor's real headers to the default network service", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(fakeEdgeNetworkResponse());
+      vi.stubGlobal("fetch", fetchMock);
+      const alloy = createNodeAlloy({
+        platformServices: { cookie: createSpyCookieService() },
+      });
+      await alloy.configure(config);
+
+      const request = alloy.forRequest({
+        cookie: createSpyCookieService(),
+        request: {
+          headers: {
+            "user-agent": "Mozilla/5.0",
+            referer: "https://example.com/page",
+          },
+        },
+      });
+      await request.sendEvent({ xdm: { eventType: "test" } });
+
+      const [, requestInit] = fetchMock.mock.calls.at(-1);
+      expect(requestInit.headers).toEqual(
+        expect.objectContaining({ "user-agent": "Mozilla/5.0" }),
+      );
+      const { xdm } = JSON.parse(requestInit.body).events[0];
+      expect(xdm.web).toEqual({
+        webPageDetails: { URL: "https://example.com/page" },
+      });
+    });
   });
 });

--- a/packages/node/test/unit/specs/createNodeAlloy.spec.js
+++ b/packages/node/test/unit/specs/createNodeAlloy.spec.js
@@ -212,5 +212,105 @@ describe("createNodeAlloy", () => {
         webPageDetails: { URL: "https://example.com/page" },
       });
     });
+
+    it("forwards Accept-Language in addition to User-Agent", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(fakeEdgeNetworkResponse());
+      vi.stubGlobal("fetch", fetchMock);
+      const alloy = createNodeAlloy({
+        platformServices: { cookie: createSpyCookieService() },
+      });
+      await alloy.configure(config);
+
+      const request = alloy.forRequest({
+        cookie: createSpyCookieService(),
+        request: { headers: { "accept-language": "en-US,en;q=0.9" } },
+      });
+      await request.sendEvent({ xdm: { eventType: "test" } });
+
+      const [, requestInit] = fetchMock.mock.calls.at(-1);
+      expect(requestInit.headers).toEqual(
+        expect.objectContaining({ "accept-language": "en-US,en;q=0.9" }),
+      );
+    });
+
+    it("does not leak one request's referer-derived URL into a later request with no referer", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockImplementation(async () => fakeEdgeNetworkResponse());
+      vi.stubGlobal("fetch", fetchMock);
+      const alloy = createNodeAlloy({
+        platformServices: { cookie: createSpyCookieService() },
+      });
+      await alloy.configure(config);
+
+      await alloy
+        .forRequest({
+          cookie: createSpyCookieService(),
+          request: { headers: { referer: "https://example.com/page" } },
+        })
+        .sendEvent({ xdm: { eventType: "with-referer" } });
+
+      await alloy
+        .forRequest({ cookie: createSpyCookieService() })
+        .sendEvent({ xdm: { eventType: "without-referer" } });
+
+      const [, requestInit] = fetchMock.mock.calls.at(-1);
+      const { xdm } = JSON.parse(requestInit.body).events[0];
+      expect(xdm.web).toBeUndefined();
+    });
+
+    it("attaches implementationDetails and the referer-derived URL to every event sent on one forRequest handle", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockImplementation(async () => fakeEdgeNetworkResponse());
+      vi.stubGlobal("fetch", fetchMock);
+      const alloy = createNodeAlloy({
+        platformServices: { cookie: createSpyCookieService() },
+      });
+      await alloy.configure(config);
+
+      const request = alloy.forRequest({
+        cookie: createSpyCookieService(),
+        request: { headers: { referer: "https://example.com/page" } },
+      });
+      await request.sendEvent({ xdm: { eventType: "first" } });
+      await request.sendEvent({ xdm: { eventType: "second" } });
+
+      fetchMock.mock.calls.slice(-2).forEach(([, requestInit]) => {
+        const { xdm } = JSON.parse(requestInit.body).events[0];
+        expect(xdm.implementationDetails).toEqual(
+          expect.objectContaining({ environment: "server" }),
+        );
+        expect(xdm.web).toEqual({
+          webPageDetails: { URL: "https://example.com/page" },
+        });
+      });
+    });
+
+    it("lets a caller-supplied xdm.web.webPageDetails.URL win over the referer-derived one", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(fakeEdgeNetworkResponse());
+      vi.stubGlobal("fetch", fetchMock);
+      const alloy = createNodeAlloy({
+        platformServices: { cookie: createSpyCookieService() },
+      });
+      await alloy.configure(config);
+
+      const request = alloy.forRequest({
+        cookie: createSpyCookieService(),
+        request: { headers: { referer: "https://referer.example.com/" } },
+      });
+      await request.sendEvent({
+        xdm: {
+          eventType: "test",
+          web: { webPageDetails: { URL: "https://explicit.example.com/" } },
+        },
+      });
+
+      const [, requestInit] = fetchMock.mock.calls.at(-1);
+      const { xdm } = JSON.parse(requestInit.body).events[0];
+      expect(xdm.web).toEqual({
+        webPageDetails: { URL: "https://explicit.example.com/" },
+      });
+    });
   });
 });

--- a/packages/node/test/unit/specs/helpers/fakeEdgeNetworkFetch.js
+++ b/packages/node/test/unit/specs/helpers/fakeEdgeNetworkFetch.js
@@ -1,0 +1,141 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { vi } from "vitest";
+import getNamespacedCookieName from "@adobe/alloy-core/utils/getNamespacedCookieName.js";
+import {
+  CONSENT,
+  IDENTITY,
+} from "@adobe/alloy-core/constants/cookieNameKey.js";
+
+const jsonResponse = (body, status = 200) =>
+  new Response(JSON.stringify(body), { status });
+
+const resolveGeneralConsent = (consentOptions = []) => {
+  let generalConsent = "in";
+  consentOptions.forEach((option) => {
+    if (option.standard === "Adobe" && option.version === "1.0") {
+      if (option.value?.general === "out") {
+        generalConsent = "out";
+      }
+    } else if (option.standard === "Adobe" && option.version === "2.0") {
+      if (option.value?.collect?.val === "n") {
+        generalConsent = "out";
+      }
+    }
+  });
+  return generalConsent;
+};
+
+const identityCookiePayload = ({ orgId, ecid }) => ({
+  key: getNamespacedCookieName(orgId, IDENTITY),
+  value: `fake-identity-cookie-value-${ecid}`,
+  maxAge: 34128000,
+});
+
+const buildInteractResponse = ({ orgId, ecid }) => ({
+  requestId: "fake-interact-request-id",
+  handle: [
+    {
+      type: "identity:result",
+      payload: [{ id: ecid, namespace: { code: "ECID" } }],
+    },
+    {
+      type: "state:store",
+      payload: [identityCookiePayload({ orgId, ecid })],
+    },
+  ],
+});
+
+const buildIdentityAcquireResponse = ({ ecid }) => ({
+  requestId: "fake-identity-acquire-request-id",
+  handle: [
+    {
+      type: "identity:result",
+      payload: [{ id: ecid, namespace: { code: "ECID" } }],
+    },
+  ],
+});
+
+const buildSetConsentResponse = ({ orgId, ecid, requestBody }) => {
+  const generalConsent = resolveGeneralConsent(requestBody?.consent);
+  const migratedEcid = requestBody?.identityMap?.ECID?.[0]?.id || ecid;
+  return {
+    requestId: "fake-set-consent-request-id",
+    handle: [
+      {
+        type: "identity:result",
+        payload: [{ id: migratedEcid, namespace: { code: "ECID" } }],
+      },
+      {
+        type: "state:store",
+        payload: [
+          identityCookiePayload({ orgId, ecid: migratedEcid }),
+          {
+            key: getNamespacedCookieName(orgId, CONSENT),
+            value: `general=${generalConsent}`,
+            maxAge: 15552000,
+          },
+        ],
+      },
+    ],
+  };
+};
+
+/**
+ * A `vi.fn()`-based fetch stub standing in for Edge Network's real
+ * `/v1/interact` and `/v1/privacy/set-consent` endpoints, realistic enough
+ * for consent tests: every response includes a `state:store` handle (so
+ * cookies actually get written through the real cookie service), and
+ * set-consent's response general in/out is derived from the request body
+ * the same way the real endpoint would (Adobe 1.0 `general`, Adobe 2.0
+ * `collect.val`).
+ *
+ * @param {Object} [options]
+ * @param {string} [options.orgId]
+ * @param {string} [options.ecid]
+ * @param {number} [options.setConsentStatus] When set, every set-consent
+ * call responds with this status and an error body instead, for testing
+ * how a rejected setConsent() is handled.
+ */
+const createFakeEdgeNetworkFetch = ({
+  orgId = "TEST_ORG@AdobeOrg",
+  ecid = "fake-ecid",
+  setConsentStatus,
+} = {}) =>
+  vi.fn(async (url, init) => {
+    const requestBody = init?.body ? JSON.parse(init.body) : {};
+
+    if (/\/v1\/privacy\/set-consent\b/.test(url)) {
+      if (setConsentStatus !== undefined) {
+        return jsonResponse(
+          { type: "https://ns.adobe.com/aep/errors/EXEG-0104-422" },
+          setConsentStatus,
+        );
+      }
+      return jsonResponse(
+        buildSetConsentResponse({ orgId, ecid, requestBody }),
+      );
+    }
+
+    if (/\/v1\/interact\b/.test(url)) {
+      return jsonResponse(buildInteractResponse({ orgId, ecid }));
+    }
+
+    if (/\/v1\/identity\/acquire\b/.test(url)) {
+      return jsonResponse(buildIdentityAcquireResponse({ ecid }));
+    }
+
+    throw new Error(`fakeEdgeNetworkFetch: no handler configured for ${url}`);
+  });
+
+export default createFakeEdgeNetworkFetch;

--- a/packages/node/test/unit/specs/services/createNodeNetworkService.spec.js
+++ b/packages/node/test/unit/specs/services/createNodeNetworkService.spec.js
@@ -55,4 +55,26 @@ describe("createNodeNetworkService", () => {
 
     expect(sendBeaconRequest).toBe(sendFetchRequest);
   });
+
+  it("merges given headers into the outgoing request without letting them override Content-Type", async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(""));
+    const { sendFetchRequest } = createNodeNetworkService({
+      headers: {
+        "user-agent": "Mozilla/5.0",
+        "Content-Type": "should-not-win",
+      },
+    });
+
+    await sendFetchRequest("https://example.com", "payload");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com",
+      expect.objectContaining({
+        headers: {
+          "user-agent": "Mozilla/5.0",
+          "Content-Type": "text/plain; charset=UTF-8",
+        },
+      }),
+    );
+  });
 });

--- a/packages/node/test/unit/specs/services/createNodePlatformServices.spec.js
+++ b/packages/node/test/unit/specs/services/createNodePlatformServices.spec.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import createNodePlatformServices from "../../../../src/services/createNodePlatformServices.js";
 
 describe("createNodePlatformServices", () => {
@@ -57,5 +57,81 @@ describe("createNodePlatformServices", () => {
     expect(platformServices.createNetworkService("the-logger")).toBe(
       fakeNetworkService,
     );
+  });
+
+  describe("request", () => {
+    const fetchMock = vi.fn();
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("exposes the given request as-is, for components (e.g. Context) to read", () => {
+      const request = { headers: { referer: "https://example.com/page" } };
+
+      const platformServices = createNodePlatformServices({ request });
+
+      expect(platformServices.request).toBe(request);
+    });
+
+    it("is undefined by default", () => {
+      const platformServices = createNodePlatformServices();
+
+      expect(platformServices.request).toBeUndefined();
+    });
+
+    it("forwards the request's forwardable headers to the default network service", async () => {
+      fetchMock.mockResolvedValueOnce(new Response("", { status: 200 }));
+      vi.stubGlobal("fetch", fetchMock);
+      const request = {
+        headers: { "user-agent": "Mozilla/5.0", cookie: "not-forwarded" },
+      };
+
+      const platformServices = createNodePlatformServices({ request });
+      const network = platformServices.createNetworkService(console);
+      await network.sendFetchRequest("https://example.com", "payload");
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://example.com",
+        expect.objectContaining({
+          headers: expect.objectContaining({ "user-agent": "Mozilla/5.0" }),
+        }),
+      );
+    });
+
+    it("forwards headers from a WHATWG Headers instance, e.g. a fetch-standard Request", async () => {
+      fetchMock.mockResolvedValueOnce(new Response("", { status: 200 }));
+      vi.stubGlobal("fetch", fetchMock);
+      const request = {
+        headers: new Headers({
+          "user-agent": "Mozilla/5.0",
+          cookie: "not-forwarded",
+        }),
+      };
+
+      const platformServices = createNodePlatformServices({ request });
+      const network = platformServices.createNetworkService(console);
+      await network.sendFetchRequest("https://example.com", "payload");
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://example.com",
+        expect.objectContaining({
+          headers: expect.objectContaining({ "user-agent": "Mozilla/5.0" }),
+        }),
+      );
+    });
+
+    it("does not forward request headers when network is explicitly overridden", () => {
+      const network = vi.fn(() => ({ fake: "network" }));
+      const request = { headers: { "user-agent": "Mozilla/5.0" } };
+
+      const platformServices = createNodePlatformServices({
+        network,
+        request,
+      });
+      platformServices.createNetworkService(console);
+
+      expect(network).toHaveBeenCalledWith(console);
+    });
   });
 });

--- a/packages/node/test/unit/specs/services/getHeader.spec.js
+++ b/packages/node/test/unit/specs/services/getHeader.spec.js
@@ -1,0 +1,48 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { describe, it, expect } from "vitest";
+import getHeader from "../../../../src/services/getHeader.js";
+
+describe("getHeader", () => {
+  it("returns undefined when called with no headers", () => {
+    expect(getHeader(undefined, "user-agent")).toBeUndefined();
+  });
+
+  it("reads a header off a plain headers object", () => {
+    const headers = { "user-agent": "Mozilla/5.0" };
+
+    expect(getHeader(headers, "user-agent")).toBe("Mozilla/5.0");
+  });
+
+  it("returns undefined for a header missing from a plain headers object", () => {
+    expect(getHeader({}, "user-agent")).toBeUndefined();
+  });
+
+  it("reads a header off a WHATWG Headers instance via .get(), not bracket access", () => {
+    const headers = new Headers({ "user-agent": "Mozilla/5.0" });
+
+    expect(getHeader(headers, "user-agent")).toBe("Mozilla/5.0");
+  });
+
+  it("returns undefined, not null, for a header missing from a Headers instance", () => {
+    const headers = new Headers();
+
+    expect(getHeader(headers, "user-agent")).toBeUndefined();
+  });
+
+  it("is case-insensitive for a Headers instance, as the WHATWG spec requires", () => {
+    const headers = new Headers({ "User-Agent": "Mozilla/5.0" });
+
+    expect(getHeader(headers, "user-agent")).toBe("Mozilla/5.0");
+  });
+});

--- a/packages/node/test/unit/specs/services/pickForwardableHeaders.spec.js
+++ b/packages/node/test/unit/specs/services/pickForwardableHeaders.spec.js
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { describe, it, expect } from "vitest";
+import pickForwardableHeaders from "../../../../src/services/pickForwardableHeaders.js";
+
+describe("pickForwardableHeaders", () => {
+  it("returns an empty object when called with no headers", () => {
+    expect(pickForwardableHeaders()).toEqual({});
+  });
+
+  it("picks user-agent and accept-language, dropping everything else", () => {
+    const picked = pickForwardableHeaders({
+      "user-agent": "Mozilla/5.0",
+      "accept-language": "en-US,en;q=0.9",
+      cookie: "should-not-be-forwarded",
+      host: "example.com",
+    });
+
+    expect(picked).toEqual({
+      "user-agent": "Mozilla/5.0",
+      "accept-language": "en-US,en;q=0.9",
+    });
+  });
+
+  it("drops a header that's an array (repeated header) instead of forwarding a stringified version", () => {
+    const picked = pickForwardableHeaders({
+      "user-agent": ["Mozilla/5.0", "SomethingElse/1.0"],
+    });
+
+    expect(picked).toEqual({});
+  });
+
+  it("drops an empty-string header value", () => {
+    const picked = pickForwardableHeaders({ "user-agent": "" });
+
+    expect(picked).toEqual({});
+  });
+
+  it("picks headers off a WHATWG Headers instance, e.g. a fetch-standard Request", () => {
+    const headers = new Headers({
+      "user-agent": "Mozilla/5.0",
+      "accept-language": "en-US,en;q=0.9",
+      cookie: "should-not-be-forwarded",
+    });
+
+    const picked = pickForwardableHeaders(headers);
+
+    expect(picked).toEqual({
+      "user-agent": "Mozilla/5.0",
+      "accept-language": "en-US,en;q=0.9",
+    });
+  });
+});

--- a/packages/node/test/unit/specs/services/pickForwardableHeaders.spec.js
+++ b/packages/node/test/unit/specs/services/pickForwardableHeaders.spec.js
@@ -18,10 +18,14 @@ describe("pickForwardableHeaders", () => {
     expect(pickForwardableHeaders()).toEqual({});
   });
 
-  it("picks user-agent and accept-language, dropping everything else", () => {
+  it("picks user-agent, accept-language, client hints, and IP-forwarding headers, dropping everything else", () => {
     const picked = pickForwardableHeaders({
       "user-agent": "Mozilla/5.0",
       "accept-language": "en-US,en;q=0.9",
+      "sec-ch-ua": '"Chromium";v="128"',
+      "sec-ch-ua-mobile": "?0",
+      "sec-ch-ua-platform": '"macOS"',
+      "x-forwarded-for": "203.0.113.1",
       cookie: "should-not-be-forwarded",
       host: "example.com",
     });
@@ -29,6 +33,10 @@ describe("pickForwardableHeaders", () => {
     expect(picked).toEqual({
       "user-agent": "Mozilla/5.0",
       "accept-language": "en-US,en;q=0.9",
+      "sec-ch-ua": '"Chromium";v="128"',
+      "sec-ch-ua-mobile": "?0",
+      "sec-ch-ua-platform": '"macOS"',
+      "x-forwarded-for": "203.0.113.1",
     });
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,202 +1,3 @@
----
-lockfileVersion: '9.0'
-
-importers:
-
-  .:
-    configDependencies: {}
-    packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 11.11.0
-        version: 11.11.0
-      pnpm:
-        specifier: 11.11.0
-        version: 11.11.0
-
-packages:
-
-  '@pnpm/exe@11.11.0':
-    resolution: {integrity: sha512-OpTrbkAU0Ur8gBwhAT6mbWwlA1bFU8zPcFNdp/img/RqFIc7Dn0j0crW9rz5hxTWo/UBQjy6Sb9jh+N5bRSd+g==}
-    hasBin: true
-
-  '@pnpm/linux-arm64@11.11.0':
-    resolution: {integrity: sha512-62K/kQY3jaoQ96MNUi0NLcTSSDO2QrtziOA2IK5R/m+DxpSwXbxFSQHYx8oOg0r1+MFVqwuDkFjXe6DyW3y58g==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@pnpm/linux-x64@11.11.0':
-    resolution: {integrity: sha512-rwMbNJR+PstRu+ymWoApei1CWrAnsnW3tm+3H8qOxbp8duiaj6u7DxlMzhKbVpFwylxcJdeGwZ5tReBFOVpsdw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@pnpm/linuxstatic-arm64@11.11.0':
-    resolution: {integrity: sha512-OcmrMw1hxNee7KTBpE0yToTZziH/SCmJWwjB7YN2NmsxZVPKM2vtOWFdZufW0YN5JffKMaHbPZ2ulgYBM5qAQw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@pnpm/linuxstatic-x64@11.11.0':
-    resolution: {integrity: sha512-pWeAYeS+PPah6mXcJbOr+nPwEpyQau4iPcsqNUhTK9G5/qpG5dU1m8oHeIH83PuUUvvdJddLE1PXUkGM+QCI6g==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@pnpm/macos-arm64@11.11.0':
-    resolution: {integrity: sha512-62P8Pe4yvMkdl2nxswCjM5X835i9Judk68CZvv8OnWsm7CVCEZ61SEBnNTpjJ4kXzdayFjRpPwE/jfJSvPaWww==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@pnpm/win-arm64@11.11.0':
-    resolution: {integrity: sha512-yYAx+A1oT+mSgrIzysuAvdYYMYEfAa+z3/UCGY3L5VC9oabs9qi71LbTan1cDui/AadrIvD177k9mV4V38KAJg==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@pnpm/win-x64@11.11.0':
-    resolution: {integrity: sha512-ehTuyM5Rrp4ye0SdtAJkUS+9ykfwdDY9SPqiK3+bxXPx3LD5aeDw2EBksTh/xRTgqFdYmoFR86cABFt9yBr0GA==}
-    cpu: [x64]
-    os: [win32]
-
-  '@reflink/reflink-darwin-arm64@0.1.19':
-    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@reflink/reflink-darwin-x64@0.1.19':
-    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@reflink/reflink-linux-arm64-musl@0.1.19':
-    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@reflink/reflink-linux-x64-gnu@0.1.19':
-    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@reflink/reflink-linux-x64-musl@0.1.19':
-    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@reflink/reflink-win32-x64-msvc@0.1.19':
-    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@reflink/reflink@0.1.19':
-    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
-    engines: {node: '>= 10'}
-
-  detect-libc@2.1.2:
-    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
-    engines: {node: '>=8'}
-
-  pnpm@11.11.0:
-    resolution: {integrity: sha512-RGP2X9gO2A1pvB1L8WPulPYFxzgPwxi7Wy6+FfjNEtScUaTVnpUbQB52TTtsp1HL9RvFDtcAGmvLSTXmhMNIgg==}
-    engines: {node: '>=22.13'}
-    hasBin: true
-
-snapshots:
-
-  '@pnpm/exe@11.11.0':
-    dependencies:
-      '@reflink/reflink': 0.1.19
-      detect-libc: 2.1.2
-    optionalDependencies:
-      '@pnpm/linux-arm64': 11.11.0
-      '@pnpm/linux-x64': 11.11.0
-      '@pnpm/linuxstatic-arm64': 11.11.0
-      '@pnpm/linuxstatic-x64': 11.11.0
-      '@pnpm/macos-arm64': 11.11.0
-      '@pnpm/win-arm64': 11.11.0
-      '@pnpm/win-x64': 11.11.0
-
-  '@pnpm/linux-arm64@11.11.0':
-    optional: true
-
-  '@pnpm/linux-x64@11.11.0':
-    optional: true
-
-  '@pnpm/linuxstatic-arm64@11.11.0':
-    optional: true
-
-  '@pnpm/linuxstatic-x64@11.11.0':
-    optional: true
-
-  '@pnpm/macos-arm64@11.11.0':
-    optional: true
-
-  '@pnpm/win-arm64@11.11.0':
-    optional: true
-
-  '@pnpm/win-x64@11.11.0':
-    optional: true
-
-  '@reflink/reflink-darwin-arm64@0.1.19':
-    optional: true
-
-  '@reflink/reflink-darwin-x64@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-arm64-musl@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-x64-gnu@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-x64-musl@0.1.19':
-    optional: true
-
-  '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    optional: true
-
-  '@reflink/reflink-win32-x64-msvc@0.1.19':
-    optional: true
-
-  '@reflink/reflink@0.1.19':
-    optionalDependencies:
-      '@reflink/reflink-darwin-arm64': 0.1.19
-      '@reflink/reflink-darwin-x64': 0.1.19
-      '@reflink/reflink-linux-arm64-gnu': 0.1.19
-      '@reflink/reflink-linux-arm64-musl': 0.1.19
-      '@reflink/reflink-linux-x64-gnu': 0.1.19
-      '@reflink/reflink-linux-x64-musl': 0.1.19
-      '@reflink/reflink-win32-arm64-msvc': 0.1.19
-      '@reflink/reflink-win32-x64-msvc': 0.1.19
-
-  detect-libc@2.1.2: {}
-
-  pnpm@11.11.0: {}
-
----
 lockfileVersion: '9.0'
 
 settings:
@@ -252,7 +53,7 @@ importers:
         version: 1.6.17(eslint@10.3.0)(typescript@6.0.3)(vitest@4.1.8)
       baseline-browser-mapping:
         specifier: ^2.10.27
-        version: 2.11.12
+        version: 2.11.15
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -397,7 +198,7 @@ importers:
     dependencies:
       '@adobe/aep-rules-engine':
         specifier: ^3.1.1
-        version: 3.1.1(@vitest/browser@4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8))(vitest@4.1.10(@types/node@25.6.2)(@vitest/browser-playwright@4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8))(@vitest/coverage-v8@4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8))(happy-dom@20.9.0)(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0)))
+        version: 3.1.1(@vitest/browser@4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8))(vitest@4.1.11(@types/node@25.6.2)(@vitest/browser-playwright@4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8))(@vitest/coverage-v8@4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8))(happy-dom@20.9.0)(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0)))
       '@adobe/reactor-query-string':
         specifier: ^2.0.0
         version: 2.0.0
@@ -4697,14 +4498,14 @@ packages:
       vitest:
         optional: true
 
-  '@vitest/expect@4.1.10':
-    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
 
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
-  '@vitest/mocker@4.1.10':
-    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -4725,32 +4526,32 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.10':
-    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
 
   '@vitest/pretty-format@4.1.8':
     resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
 
-  '@vitest/runner@4.1.10':
-    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
 
   '@vitest/runner@4.1.8':
     resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
 
-  '@vitest/snapshot@4.1.10':
-    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
 
   '@vitest/snapshot@4.1.8':
     resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
 
-  '@vitest/spy@4.1.10':
-    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
 
   '@vitest/spy@4.1.8':
     resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
 
-  '@vitest/utils@4.1.10':
-    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
   '@vitest/utils@4.1.8':
     resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
@@ -5158,8 +4959,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.11.12:
-    resolution: {integrity: sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==}
+  baseline-browser-mapping@2.11.15:
+    resolution: {integrity: sha512-FwMjJJ7HnyZpWe+oWxegG0fezZyBZUagI5LZEoO3GCbtbKNwRfMH9Ue5d5v01PNePBy1QSfPSDTTeVL0Hb9EzA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -5952,8 +5753,8 @@ packages:
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
-  es-module-lexer@2.3.1:
-    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -9644,20 +9445,20 @@ packages:
       '@types/react-dom':
         optional: true
 
-  vitest@4.1.10:
-    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.10
-      '@vitest/browser-preview': 4.1.10
-      '@vitest/browser-webdriverio': 4.1.10
-      '@vitest/coverage-istanbul': 4.1.10
-      '@vitest/coverage-v8': 4.1.10
-      '@vitest/ui': 4.1.10
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -9918,9 +9719,9 @@ packages:
 
 snapshots:
 
-  '@adobe/aep-rules-engine@3.1.1(@vitest/browser@4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8))(vitest@4.1.10(@types/node@25.6.2)(@vitest/browser-playwright@4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8))(@vitest/coverage-v8@4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8))(happy-dom@20.9.0)(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0)))':
+  '@adobe/aep-rules-engine@3.1.1(@vitest/browser@4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8))(vitest@4.1.11(@types/node@25.6.2)(@vitest/browser-playwright@4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8))(@vitest/coverage-v8@4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8))(happy-dom@20.9.0)(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0)))':
     dependencies:
-      '@vitest/coverage-v8': 3.2.4(@vitest/browser@4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8))(vitest@4.1.10(@types/node@25.6.2)(@vitest/browser-playwright@4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8))(@vitest/coverage-v8@4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8))(happy-dom@20.9.0)(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0)))
+      '@vitest/coverage-v8': 3.2.4(@vitest/browser@4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8))(vitest@4.1.11(@types/node@25.6.2)(@vitest/browser-playwright@4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8))(@vitest/coverage-v8@4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8))(happy-dom@20.9.0)(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0)))
     transitivePeerDependencies:
       - '@vitest/browser'
       - supports-color
@@ -20641,7 +20442,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@3.2.4(@vitest/browser@4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8))(vitest@4.1.10(@types/node@25.6.2)(@vitest/browser-playwright@4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8))(@vitest/coverage-v8@4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8))(happy-dom@20.9.0)(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0)))':
+  '@vitest/coverage-v8@3.2.4(@vitest/browser@4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8))(vitest@4.1.11(@types/node@25.6.2)(@vitest/browser-playwright@4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8))(@vitest/coverage-v8@4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8))(happy-dom@20.9.0)(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0)))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -20656,7 +20457,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 4.1.10(@types/node@25.6.2)(@vitest/browser-playwright@4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8))(@vitest/coverage-v8@4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8))(happy-dom@20.9.0)(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@25.6.2)(@vitest/browser-playwright@4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8))(@vitest/coverage-v8@4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8))(happy-dom@20.9.0)(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))
     optionalDependencies:
       '@vitest/browser': 4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8)
     transitivePeerDependencies:
@@ -20689,12 +20490,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@4.1.10':
+  '@vitest/expect@4.1.11':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
@@ -20707,9 +20508,9 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.11(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.1.10
+      '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
@@ -20725,7 +20526,7 @@ snapshots:
       msw: 2.14.5(@types/node@25.6.2)(typescript@6.0.3)
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0)
 
-  '@vitest/pretty-format@4.1.10':
+  '@vitest/pretty-format@4.1.11':
     dependencies:
       tinyrainbow: 3.1.1
 
@@ -20733,9 +20534,9 @@ snapshots:
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.10':
+  '@vitest/runner@4.1.11':
     dependencies:
-      '@vitest/utils': 4.1.10
+      '@vitest/utils': 4.1.11
       pathe: 2.0.3
 
   '@vitest/runner@4.1.8':
@@ -20743,10 +20544,10 @@ snapshots:
       '@vitest/utils': 4.1.8
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.10':
+  '@vitest/snapshot@4.1.11':
     dependencies:
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/utils': 4.1.10
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
       magic-string: 0.30.21
       pathe: 2.0.3
 
@@ -20757,13 +20558,13 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.10': {}
+  '@vitest/spy@4.1.11': {}
 
   '@vitest/spy@4.1.8': {}
 
-  '@vitest/utils@4.1.10':
+  '@vitest/utils@4.1.11':
     dependencies:
-      '@vitest/pretty-format': 4.1.10
+      '@vitest/pretty-format': 4.1.11
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
 
@@ -21290,7 +21091,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.11.12: {}
+  baseline-browser-mapping@2.11.15: {}
 
   basic-ftp@5.2.2: {}
 
@@ -21371,7 +21172,7 @@ snapshots:
 
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.11.12
+      baseline-browser-mapping: 2.11.15
       caniuse-lite: 1.0.30001762
       electron-to-chromium: 1.5.267
       node-releases: 2.0.27
@@ -22157,7 +21958,7 @@ snapshots:
 
   es-module-lexer@2.0.0: {}
 
-  es-module-lexer@2.3.1: {}
+  es-module-lexer@2.3.2: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -26730,16 +26531,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  vitest@4.1.10(@types/node@25.6.2)(@vitest/browser-playwright@4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8))(@vitest/coverage-v8@4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8))(happy-dom@20.9.0)(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0)):
+  vitest@4.1.11(@types/node@25.6.2)(@vitest/browser-playwright@4.1.8(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))(vitest@4.1.8))(@vitest/coverage-v8@4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8))(happy-dom@20.9.0)(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.1
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(terser@5.44.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.3.2
       expect-type: 1.4.0
       magic-string: 0.30.21
       obug: 2.1.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
         version: 1.6.17(eslint@10.3.0)(typescript@6.0.3)(vitest@4.1.8)
       baseline-browser-mapping:
         specifier: ^2.10.27
-        version: 2.11.15
+        version: 2.11.20
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -4954,8 +4954,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.11.15:
-    resolution: {integrity: sha512-FwMjJJ7HnyZpWe+oWxegG0fezZyBZUagI5LZEoO3GCbtbKNwRfMH9Ue5d5v01PNePBy1QSfPSDTTeVL0Hb9EzA==}
+  baseline-browser-mapping@2.11.20:
+    resolution: {integrity: sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -7768,6 +7768,10 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
+    engines: {node: '>=12'}
+
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
@@ -9766,59 +9770,59 @@ snapshots:
       '@react-aria/ssr': 3.9.10(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/visually-hidden': 3.8.31(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/accordion': 3.0.16(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/actionbar': 3.6.17(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/actiongroup': 3.11.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/avatar': 3.0.29(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/badge': 3.1.33(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/breadcrumbs': 3.9.27(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/buttongroup': 3.6.29(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/calendar': 3.7.11(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/checkbox': 3.10.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/color': 3.1.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/combobox': 3.16.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/contextualhelp': 3.6.31(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/datepicker': 3.14.11(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/dialog': 3.9.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/accordion': 3.0.16(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/actionbar': 3.6.17(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/actiongroup': 3.11.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/avatar': 3.0.29(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/badge': 3.1.33(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/breadcrumbs': 3.9.27(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/buttongroup': 3.6.29(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/calendar': 3.7.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/checkbox': 3.10.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/color': 3.1.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/combobox': 3.16.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/contextualhelp': 3.6.31(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/datepicker': 3.14.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/dialog': 3.9.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/divider': 3.5.30(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/dnd': 3.6.5(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/dropzone': 3.0.21(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/filetrigger': 3.0.21(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/icon': 3.8.12(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/illustratedmessage': 3.5.17(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/image': 3.6.5(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/inlinealert': 3.2.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/labeledvalue': 3.2.10(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/link': 3.6.25(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/list': 3.10.11(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/listbox': 3.15.11(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/menu': 3.22.11(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/meter': 3.5.17(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/numberfield': 3.10.5(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/picker': 3.16.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/dnd': 3.6.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/dropzone': 3.0.21(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/filetrigger': 3.0.21(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/icon': 3.8.12(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/illustratedmessage': 3.5.17(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/image': 3.6.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/inlinealert': 3.2.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/labeledvalue': 3.2.10(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/link': 3.6.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/list': 3.10.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/listbox': 3.15.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/menu': 3.22.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/meter': 3.5.17(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/numberfield': 3.10.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/picker': 3.16.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/radio': 3.7.24(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/searchfield': 3.8.26(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/slider': 3.8.5(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/statuslight': 3.5.29(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/switch': 3.6.9(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/table': 3.17.11(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/tabs': 3.8.30(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/tag': 3.3.10(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/textfield': 3.14.5(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/radio': 3.7.24(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/searchfield': 3.8.26(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/slider': 3.8.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/statuslight': 3.5.29(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/switch': 3.6.9(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/table': 3.17.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/tabs': 3.8.30(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/tag': 3.3.10(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/textfield': 3.14.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/theme-dark': 3.5.24(react@17.0.2)
       '@react-spectrum/theme-default': 3.5.24(react@17.0.2)
       '@react-spectrum/theme-light': 3.4.24(react@17.0.2)
-      '@react-spectrum/toast': 3.1.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/tooltip': 3.8.2(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/tree': 3.1.11(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/view': 3.6.26(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/toast': 3.1.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/tooltip': 3.8.2(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/tree': 3.1.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/view': 3.6.26(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/well': 3.4.30(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/collections': 3.12.10(react@17.0.2)
       '@react-stately/data': 3.15.2(react@17.0.2)
@@ -9835,59 +9839,59 @@ snapshots:
       '@react-aria/ssr': 3.9.10(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/visually-hidden': 3.8.31(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/accordion': 3.0.16(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/actionbar': 3.6.17(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/actiongroup': 3.11.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/avatar': 3.0.29(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/badge': 3.1.33(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/breadcrumbs': 3.9.27(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/buttongroup': 3.6.29(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/calendar': 3.7.11(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/checkbox': 3.10.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/color': 3.1.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/combobox': 3.16.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/contextualhelp': 3.6.31(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/datepicker': 3.14.11(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/dialog': 3.9.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/accordion': 3.0.16(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/actionbar': 3.6.17(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/actiongroup': 3.11.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/avatar': 3.0.29(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/badge': 3.1.33(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/breadcrumbs': 3.9.27(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/buttongroup': 3.6.29(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/calendar': 3.7.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/checkbox': 3.10.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/color': 3.1.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/combobox': 3.16.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/contextualhelp': 3.6.31(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/datepicker': 3.14.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/dialog': 3.9.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/divider': 3.5.30(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/dnd': 3.6.5(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/dropzone': 3.0.21(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/filetrigger': 3.0.21(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/icon': 3.8.12(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/illustratedmessage': 3.5.17(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/image': 3.6.5(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/inlinealert': 3.2.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/labeledvalue': 3.2.10(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/link': 3.6.25(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/list': 3.10.11(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/listbox': 3.15.11(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/menu': 3.22.11(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/meter': 3.5.17(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/numberfield': 3.10.5(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/picker': 3.16.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/dnd': 3.6.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/dropzone': 3.0.21(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/filetrigger': 3.0.21(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/icon': 3.8.12(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/illustratedmessage': 3.5.17(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/image': 3.6.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/inlinealert': 3.2.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/labeledvalue': 3.2.10(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/link': 3.6.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/list': 3.10.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/listbox': 3.15.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/menu': 3.22.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/meter': 3.5.17(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/numberfield': 3.10.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/picker': 3.16.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/radio': 3.7.24(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/searchfield': 3.8.26(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/slider': 3.8.5(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/statuslight': 3.5.29(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/switch': 3.6.9(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/table': 3.17.11(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/tabs': 3.8.30(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/tag': 3.3.10(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/textfield': 3.14.5(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/radio': 3.7.24(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/searchfield': 3.8.26(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/slider': 3.8.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/statuslight': 3.5.29(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/switch': 3.6.9(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/table': 3.17.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/tabs': 3.8.30(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/tag': 3.3.10(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/textfield': 3.14.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/theme-dark': 3.5.24(react@18.3.1)
       '@react-spectrum/theme-default': 3.5.24(react@18.3.1)
       '@react-spectrum/theme-light': 3.4.24(react@18.3.1)
-      '@react-spectrum/toast': 3.1.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/tooltip': 3.8.2(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/tree': 3.1.11(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/view': 3.6.26(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/toast': 3.1.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/tooltip': 3.8.2(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/tree': 3.1.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/view': 3.6.26(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/well': 3.4.30(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/collections': 3.12.10(react@18.3.1)
       '@react-stately/data': 3.15.2(react@18.3.1)
@@ -15540,25 +15544,25 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/accordion@3.0.16(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/accordion@3.0.16(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-aria-components: 1.16.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/accordion@3.0.16(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/accordion@3.0.16(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-aria-components: 1.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -15576,44 +15580,44 @@ snapshots:
       react-aria-components: 1.16.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/actionbar@3.6.17(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/actionbar@3.6.17(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/interactions': 3.27.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/live-announcer': 3.4.4
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/actiongroup': 3.11.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/actiongroup': 3.11.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/collections': 3.12.10(react@17.0.2)
       '@react-types/actionbar': 3.1.21(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/actionbar@3.6.17(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/actionbar@3.6.17(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/interactions': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/live-announcer': 3.4.4
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/actiongroup': 3.11.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/actiongroup': 3.11.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/collections': 3.12.10(react@18.3.1)
       '@react-types/actionbar': 3.1.21(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -15639,48 +15643,48 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/actiongroup@3.11.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/actiongroup@3.11.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/actiongroup': 3.7.24(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/interactions': 3.27.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/menu': 3.22.11(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/tooltip': 3.8.2(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/menu': 3.22.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/tooltip': 3.8.2(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/collections': 3.12.10(react@17.0.2)
       '@react-stately/list': 3.13.4(react@17.0.2)
       '@react-types/actiongroup': 3.4.23(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@spectrum-icons/workflow': 4.2.28(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/workflow': 4.2.28(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/actiongroup@3.11.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/actiongroup@3.11.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/actiongroup': 3.7.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/interactions': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/menu': 3.22.11(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/tooltip': 3.8.2(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/menu': 3.22.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/tooltip': 3.8.2(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/collections': 3.12.10(react@18.3.1)
       '@react-stately/list': 3.13.4(react@18.3.1)
       '@react-types/actiongroup': 3.4.23(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@spectrum-icons/workflow': 4.2.28(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/workflow': 4.2.28(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -15708,10 +15712,10 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/avatar@3.0.29(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/avatar@3.0.29(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/avatar': 3.0.21(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
@@ -15719,10 +15723,10 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/avatar@3.0.29(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/avatar@3.0.29(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/avatar': 3.0.21(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
@@ -15741,11 +15745,11 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/badge@3.1.33(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/badge@3.1.33(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/badge': 3.1.23(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
@@ -15753,11 +15757,11 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/badge@3.1.33(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/badge@3.1.33(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/badge': 3.1.23(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
@@ -15777,40 +15781,40 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/breadcrumbs@3.9.27(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/breadcrumbs@3.9.27(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/breadcrumbs': 3.5.32(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/interactions': 3.27.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/menu': 3.22.11(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/menu': 3.22.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/collections': 3.12.10(react@17.0.2)
       '@react-types/breadcrumbs': 3.7.19(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/breadcrumbs@3.9.27(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/breadcrumbs@3.9.27(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/breadcrumbs': 3.5.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/interactions': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/menu': 3.22.11(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/menu': 3.22.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/collections': 3.12.10(react@18.3.1)
       '@react-types/breadcrumbs': 3.7.19(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -15834,40 +15838,40 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/button@3.17.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/button@3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/button': 3.14.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/interactions': 3.27.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/toggle': 3.9.5(react@17.0.2)
       '@react-types/button': 3.15.1(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/button@3.17.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/button@3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/button': 3.14.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/interactions': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/toggle': 3.9.5(react@18.3.1)
       '@react-types/button': 3.15.1(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -15891,10 +15895,10 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/buttongroup@3.6.29(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/buttongroup@3.6.29(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/buttongroup': 3.3.23(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
@@ -15902,10 +15906,10 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/buttongroup@3.6.29(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/buttongroup@3.6.29(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/buttongroup': 3.3.23(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
@@ -15924,7 +15928,7 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/calendar@3.7.11(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/calendar@3.7.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@internationalized/date': 3.12.0
       '@react-aria/calendar': 3.9.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -15933,20 +15937,20 @@ snapshots:
       '@react-aria/interactions': 3.27.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/visually-hidden': 3.8.31(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/calendar': 3.9.3(react@17.0.2)
       '@react-types/button': 3.15.1(react@17.0.2)
       '@react-types/calendar': 3.8.3(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/calendar@3.7.11(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/calendar@3.7.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@internationalized/date': 3.12.0
       '@react-aria/calendar': 3.9.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -15955,15 +15959,15 @@ snapshots:
       '@react-aria/interactions': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/visually-hidden': 3.8.31(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/calendar': 3.9.3(react@18.3.1)
       '@react-types/button': 3.15.1(react@18.3.1)
       '@react-types/calendar': 3.8.3(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -15990,39 +15994,39 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/checkbox@3.10.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/checkbox@3.10.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/checkbox': 3.16.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/interactions': 3.27.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/checkbox': 3.7.5(react@17.0.2)
       '@react-stately/toggle': 3.9.5(react@17.0.2)
       '@react-types/checkbox': 3.10.4(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-aria-components: 1.16.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/checkbox@3.10.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/checkbox@3.10.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/checkbox': 3.16.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/interactions': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/checkbox': 3.7.5(react@18.3.1)
       '@react-stately/toggle': 3.9.5(react@18.3.1)
       '@react-types/checkbox': 3.10.4(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-aria-components: 1.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -16047,22 +16051,22 @@ snapshots:
       react-aria-components: 1.16.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/color@3.1.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/color@3.1.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/color': 3.1.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/interactions': 3.27.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/dialog': 3.9.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/picker': 3.16.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/textfield': 3.14.5(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/dialog': 3.9.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/picker': 3.16.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/textfield': 3.14.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/view': 3.6.26(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/view': 3.6.26(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/color': 3.9.5(react@17.0.2)
       '@react-types/color': 3.1.4(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
@@ -16072,22 +16076,22 @@ snapshots:
       react-aria-components: 1.16.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/color@3.1.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/color@3.1.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/color': 3.1.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/interactions': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/dialog': 3.9.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/picker': 3.16.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/textfield': 3.14.5(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/dialog': 3.9.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/picker': 3.16.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/textfield': 3.14.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/view': 3.6.26(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/view': 3.6.26(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/color': 3.9.5(react@18.3.1)
       '@react-types/color': 3.1.4(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
@@ -16122,7 +16126,7 @@ snapshots:
       react-aria-components: 1.16.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/combobox@3.16.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/combobox@3.16.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/button': 3.14.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/combobox': 3.15.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -16134,26 +16138,26 @@ snapshots:
       '@react-aria/label': 3.7.25(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/overlays': 3.31.2(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/listbox': 3.15.11(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/textfield': 3.14.5(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/listbox': 3.15.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/textfield': 3.14.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/collections': 3.12.10(react@17.0.2)
       '@react-stately/combobox': 3.13.0(react@17.0.2)
       '@react-types/button': 3.15.1(react@17.0.2)
       '@react-types/combobox': 3.14.0(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/combobox@3.16.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/combobox@3.16.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/button': 3.14.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/combobox': 3.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -16165,21 +16169,21 @@ snapshots:
       '@react-aria/label': 3.7.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/overlays': 3.31.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/listbox': 3.15.11(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/textfield': 3.14.5(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/listbox': 3.15.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/textfield': 3.14.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/collections': 3.12.10(react@18.3.1)
       '@react-stately/combobox': 3.13.0(react@18.3.1)
       '@react-types/button': 3.15.1(react@18.3.1)
       '@react-types/combobox': 3.14.0(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -16215,32 +16219,32 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/contextualhelp@3.6.31(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/contextualhelp@3.6.31(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/dialog': 3.9.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/dialog': 3.9.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/contextualhelp': 3.2.24(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
-      '@spectrum-icons/workflow': 4.2.28(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/workflow': 4.2.28(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/contextualhelp@3.6.31(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/contextualhelp@3.6.31(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/dialog': 3.9.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/dialog': 3.9.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/contextualhelp': 3.2.24(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
-      '@spectrum-icons/workflow': 4.2.28(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/workflow': 4.2.28(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -16260,7 +16264,7 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/datepicker@3.14.11(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/datepicker@3.14.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@internationalized/date': 3.12.0
       '@react-aria/datepicker': 3.16.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -16268,25 +16272,25 @@ snapshots:
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/interactions': 3.27.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/calendar': 3.7.11(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/dialog': 3.9.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/calendar': 3.7.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/dialog': 3.9.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/view': 3.6.26(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/view': 3.6.26(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/datepicker': 3.16.1(react@17.0.2)
       '@react-types/datepicker': 3.13.5(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@spectrum-icons/workflow': 4.2.28(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/workflow': 4.2.28(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/datepicker@3.14.11(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/datepicker@3.14.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@internationalized/date': 3.12.0
       '@react-aria/datepicker': 3.16.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -16294,20 +16298,20 @@ snapshots:
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/interactions': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/calendar': 3.7.11(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/dialog': 3.9.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/calendar': 3.7.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/dialog': 3.9.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/view': 3.6.26(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/view': 3.6.26(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/datepicker': 3.16.1(react@18.3.1)
       '@react-types/datepicker': 3.13.5(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@spectrum-icons/workflow': 4.2.28(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/workflow': 4.2.28(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -16338,52 +16342,52 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/dialog@3.9.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/dialog@3.9.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/dialog': 3.5.34(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/interactions': 3.27.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/overlays': 3.31.2(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/buttongroup': 3.6.29(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/buttongroup': 3.6.29(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/divider': 3.5.30(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/view': 3.6.26(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/view': 3.6.26(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/overlays': 3.6.23(react@17.0.2)
       '@react-types/button': 3.15.1(react@17.0.2)
       '@react-types/dialog': 3.5.24(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/dialog@3.9.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/dialog@3.9.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/dialog': 3.5.34(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/interactions': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/overlays': 3.31.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/buttongroup': 3.6.29(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/buttongroup': 3.6.29(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/divider': 3.5.30(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/view': 3.6.26(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/view': 3.6.26(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/overlays': 3.6.23(react@18.3.1)
       '@react-types/button': 3.15.1(react@18.3.1)
       '@react-types/dialog': 3.5.24(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -16443,20 +16447,20 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/dnd@3.6.5(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/dnd@3.6.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/dnd': 3.11.6(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-stately/dnd': 3.7.4(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/dnd@3.6.5(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/dnd@3.6.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/dnd': 3.11.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-stately/dnd': 3.7.4(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
       '@swc/helpers': 0.5.21
@@ -16473,11 +16477,11 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/dropzone@3.0.21(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/dropzone@3.0.21(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
       '@swc/helpers': 0.5.21
@@ -16485,11 +16489,11 @@ snapshots:
       react-aria-components: 1.16.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/dropzone@3.0.21(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/dropzone@3.0.21(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
       '@swc/helpers': 0.5.21
@@ -16509,17 +16513,17 @@ snapshots:
       react-aria-components: 1.16.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/filetrigger@3.0.21(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/filetrigger@3.0.21(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-aria-components: 1.16.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/filetrigger@3.0.21(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/filetrigger@3.0.21(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-aria-components: 1.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -16533,10 +16537,10 @@ snapshots:
       react-aria-components: 1.16.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/form@3.7.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/form@3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/form': 3.2.4(react@17.0.2)
       '@react-types/form': 3.7.18(react@17.0.2)
@@ -16545,10 +16549,10 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/form@3.7.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/form@3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/form': 3.2.4(react@18.3.1)
       '@react-types/form': 3.7.18(react@18.3.1)
@@ -16568,26 +16572,6 @@ snapshots:
       '@swc/helpers': 0.5.21
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-
-  '@react-spectrum/icon@3.8.12(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
-    dependencies:
-      '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-types/shared': 3.33.1(react@17.0.2)
-      '@swc/helpers': 0.5.21
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-
-  '@react-spectrum/icon@3.8.12(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-types/shared': 3.33.1(react@18.3.1)
-      '@swc/helpers': 0.5.21
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
 
   '@react-spectrum/icon@3.8.12(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
@@ -16619,11 +16603,11 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/illustratedmessage@3.5.17(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/illustratedmessage@3.5.17(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/illustratedmessage': 3.3.23(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
@@ -16631,11 +16615,11 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/illustratedmessage@3.5.17(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/illustratedmessage@3.5.17(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/illustratedmessage': 3.3.23(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
@@ -16655,10 +16639,10 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/image@3.6.5(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/image@3.6.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/image': 3.5.4(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
@@ -16666,10 +16650,10 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/image@3.6.5(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/image@3.6.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/image': 3.5.4(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
@@ -16688,30 +16672,30 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/inlinealert@3.2.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/inlinealert@3.2.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/inlinealert@3.2.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/inlinealert@3.2.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -16730,32 +16714,32 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/label@3.16.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/label@3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/label': 3.9.17(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/label@3.16.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/label@3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/label': 3.9.17(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -16775,26 +16759,26 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/labeledvalue@3.2.10(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/labeledvalue@3.2.10(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@internationalized/date': 3.12.0
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/labeledvalue@3.2.10(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/labeledvalue@3.2.10(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@internationalized/date': 3.12.0
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
       '@swc/helpers': 0.5.21
@@ -16814,10 +16798,10 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/layout@3.6.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/layout@3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/layout': 3.3.29(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
@@ -16825,10 +16809,10 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/layout@3.6.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/layout@3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/layout': 3.3.29(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
@@ -16847,13 +16831,13 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/link@3.6.25(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/link@3.6.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/interactions': 3.27.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/link': 3.8.9(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/link': 3.6.7(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
@@ -16861,13 +16845,13 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/link@3.6.25(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/link@3.6.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/interactions': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/link': 3.8.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/link': 3.6.7(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
@@ -16889,7 +16873,7 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/list@3.10.11(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/list@3.10.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/button': 3.14.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -16900,12 +16884,12 @@ snapshots:
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/virtualizer': 4.1.13(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/visually-hidden': 3.8.31(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/checkbox': 3.10.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/dnd': 3.6.5(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/checkbox': 3.10.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/dnd': 3.6.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/collections': 3.12.10(react@17.0.2)
       '@react-stately/layout': 4.6.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -16913,13 +16897,13 @@ snapshots:
       '@react-stately/virtualizer': 4.4.6(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/grid': 3.3.8(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       react-transition-group: 4.4.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
 
-  '@react-spectrum/list@3.10.11(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/list@3.10.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/button': 3.14.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -16930,12 +16914,12 @@ snapshots:
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/virtualizer': 4.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/visually-hidden': 3.8.31(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/checkbox': 3.10.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/dnd': 3.6.5(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/checkbox': 3.10.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/dnd': 3.6.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/collections': 3.12.10(react@18.3.1)
       '@react-stately/layout': 4.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -16943,7 +16927,7 @@ snapshots:
       '@react-stately/virtualizer': 4.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/grid': 3.3.8(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -16979,7 +16963,7 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
       react-transition-group: 4.4.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  '@react-spectrum/listbox@3.15.11(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/listbox@3.15.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -16987,10 +16971,10 @@ snapshots:
       '@react-aria/listbox': 3.15.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/virtualizer': 4.1.13(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/collections': 3.12.10(react@17.0.2)
       '@react-stately/layout': 4.6.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -16998,12 +16982,12 @@ snapshots:
       '@react-stately/virtualizer': 4.4.6(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/listbox': 3.7.6(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/listbox@3.15.11(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/listbox@3.15.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -17011,10 +16995,10 @@ snapshots:
       '@react-aria/listbox': 3.15.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/virtualizer': 4.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/collections': 3.12.10(react@18.3.1)
       '@react-stately/layout': 4.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -17022,7 +17006,7 @@ snapshots:
       '@react-stately/virtualizer': 4.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/listbox': 3.7.6(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -17051,7 +17035,7 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/menu@3.22.11(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/menu@3.22.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -17060,11 +17044,11 @@ snapshots:
       '@react-aria/overlays': 3.31.2(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/separator': 3.4.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/collections': 3.12.10(react@17.0.2)
       '@react-stately/menu': 3.9.11(react@17.0.2)
@@ -17073,13 +17057,13 @@ snapshots:
       '@react-types/menu': 3.10.7(react@17.0.2)
       '@react-types/overlays': 3.9.4(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@spectrum-icons/workflow': 4.2.28(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/workflow': 4.2.28(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/menu@3.22.11(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/menu@3.22.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -17088,11 +17072,11 @@ snapshots:
       '@react-aria/overlays': 3.31.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/separator': 3.4.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/collections': 3.12.10(react@18.3.1)
       '@react-stately/menu': 3.9.11(react@18.3.1)
@@ -17101,8 +17085,8 @@ snapshots:
       '@react-types/menu': 3.10.7(react@18.3.1)
       '@react-types/overlays': 3.9.4(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@spectrum-icons/workflow': 4.2.28(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/workflow': 4.2.28(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -17135,11 +17119,11 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/meter@3.5.17(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/meter@3.5.17(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/meter': 3.4.30(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/meter': 3.4.15(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
@@ -17147,11 +17131,11 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/meter@3.5.17(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/meter@3.5.17(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/meter': 3.4.30(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/meter': 3.4.15(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
@@ -17171,7 +17155,7 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/numberfield@3.10.5(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/numberfield@3.10.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/button': 3.14.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -17179,22 +17163,22 @@ snapshots:
       '@react-aria/interactions': 3.27.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/numberfield': 3.12.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/textfield': 3.14.5(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/textfield': 3.14.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/numberfield': 3.11.0(react@17.0.2)
       '@react-types/button': 3.15.1(react@17.0.2)
       '@react-types/numberfield': 3.8.18(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@spectrum-icons/workflow': 4.2.28(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/workflow': 4.2.28(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/numberfield@3.10.5(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/numberfield@3.10.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/button': 3.14.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -17202,17 +17186,17 @@ snapshots:
       '@react-aria/interactions': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/numberfield': 3.12.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/textfield': 3.14.5(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/textfield': 3.14.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/numberfield': 3.11.0(react@18.3.1)
       '@react-types/button': 3.15.1(react@18.3.1)
       '@react-types/numberfield': 3.8.18(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@spectrum-icons/workflow': 4.2.28(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/workflow': 4.2.28(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -17240,12 +17224,12 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/overlays@5.9.3(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/overlays@5.9.3(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/interactions': 3.27.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/overlays': 3.31.2(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/overlays': 3.6.23(react@17.0.2)
       '@react-types/overlays': 3.9.4(react@17.0.2)
@@ -17255,12 +17239,12 @@ snapshots:
       react-dom: 17.0.2(react@17.0.2)
       react-transition-group: 4.4.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
 
-  '@react-spectrum/overlays@5.9.3(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/overlays@5.9.3(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/interactions': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/overlays': 3.31.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/overlays': 3.6.23(react@18.3.1)
       '@react-types/overlays': 3.9.4(react@18.3.1)
@@ -17285,50 +17269,50 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
       react-transition-group: 4.4.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  '@react-spectrum/picker@3.16.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/picker@3.16.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/interactions': 3.27.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/select': 3.17.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/listbox': 3.15.11(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/listbox': 3.15.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/collections': 3.12.10(react@17.0.2)
       '@react-stately/select': 3.9.2(react@17.0.2)
       '@react-types/select': 3.12.2(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/picker@3.16.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/picker@3.16.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/interactions': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/select': 3.17.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/listbox': 3.15.11(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/listbox': 3.15.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/collections': 3.12.10(react@18.3.1)
       '@react-stately/select': 3.9.2(react@18.3.1)
       '@react-types/select': 3.12.2(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -17357,11 +17341,11 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/progress@3.7.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/progress@3.7.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/progress': 3.4.30(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/progress': 3.5.18(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
@@ -17369,11 +17353,11 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/progress@3.7.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/progress@3.7.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/progress': 3.4.30(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/progress': 3.5.18(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
@@ -17432,14 +17416,14 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/radio@3.7.24(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/radio@3.7.24(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/interactions': 3.27.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/radio': 3.12.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/radio': 3.11.5(react@17.0.2)
       '@react-types/radio': 3.9.4(react@17.0.2)
@@ -17448,14 +17432,14 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/radio@3.7.24(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/radio@3.7.24(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/interactions': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/radio': 3.12.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/radio': 3.11.5(react@18.3.1)
       '@react-types/radio': 3.9.4(react@18.3.1)
@@ -17480,34 +17464,34 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/searchfield@3.8.26(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/searchfield@3.8.26(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/searchfield': 3.8.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/textfield': 3.14.5(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/textfield': 3.14.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/searchfield': 3.5.19(react@17.0.2)
       '@react-types/searchfield': 3.6.8(react@17.0.2)
       '@react-types/textfield': 3.12.8(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/searchfield@3.8.26(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/searchfield@3.8.26(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/searchfield': 3.8.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/textfield': 3.14.5(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/textfield': 3.14.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/searchfield': 3.5.19(react@18.3.1)
       '@react-types/searchfield': 3.6.8(react@18.3.1)
       '@react-types/textfield': 3.12.8(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -17528,7 +17512,7 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/slider@3.8.5(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/slider@3.8.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -17536,7 +17520,7 @@ snapshots:
       '@react-aria/slider': 3.8.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/visually-hidden': 3.8.31(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/slider': 3.7.5(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
@@ -17545,7 +17529,7 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/slider@3.8.5(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/slider@3.8.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -17553,7 +17537,7 @@ snapshots:
       '@react-aria/slider': 3.8.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/visually-hidden': 3.8.31(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/slider': 3.7.5(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
@@ -17579,10 +17563,10 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/statuslight@3.5.29(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/statuslight@3.5.29(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
       '@react-types/statuslight': 3.3.23(react@17.0.2)
@@ -17590,10 +17574,10 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/statuslight@3.5.29(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/statuslight@3.5.29(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
       '@react-types/statuslight': 3.3.23(react@18.3.1)
@@ -17612,12 +17596,12 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/switch@3.6.9(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/switch@3.6.9(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/interactions': 3.27.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/switch': 3.7.11(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/toggle': 3.9.5(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
@@ -17626,12 +17610,12 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/switch@3.6.9(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/switch@3.6.9(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/interactions': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/switch': 3.7.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/toggle': 3.9.5(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
@@ -17654,7 +17638,7 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/table@3.17.11(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/table@3.17.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/button': 3.14.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -17666,13 +17650,13 @@ snapshots:
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/virtualizer': 4.1.13(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/visually-hidden': 3.8.31(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/checkbox': 3.10.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/dnd': 3.6.5(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/menu': 3.22.11(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/tooltip': 3.8.2(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/checkbox': 3.10.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/dnd': 3.6.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/menu': 3.22.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/tooltip': 3.8.2(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/flags': 3.1.2
       '@react-stately/layout': 4.6.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -17681,12 +17665,12 @@ snapshots:
       '@react-types/grid': 3.3.8(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
       '@react-types/table': 3.13.6(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/table@3.17.11(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/table@3.17.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/button': 3.14.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -17698,13 +17682,13 @@ snapshots:
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/virtualizer': 4.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/visually-hidden': 3.8.31(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/checkbox': 3.10.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/dnd': 3.6.5(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/menu': 3.22.11(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/tooltip': 3.8.2(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/checkbox': 3.10.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/dnd': 3.6.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/layout': 3.6.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/menu': 3.22.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/progress': 3.7.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/tooltip': 3.8.2(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/flags': 3.1.2
       '@react-stately/layout': 4.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -17713,7 +17697,7 @@ snapshots:
       '@react-types/grid': 3.3.8(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
       '@react-types/table': 3.13.6(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -17750,16 +17734,16 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/tabs@3.8.30(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/tabs@3.8.30(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/interactions': 3.27.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/tabs': 3.11.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/picker': 3.16.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/picker': 3.16.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/collections': 3.12.10(react@17.0.2)
       '@react-stately/list': 3.13.4(react@17.0.2)
@@ -17771,16 +17755,16 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/tabs@3.8.30(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/tabs@3.8.30(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/interactions': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/tabs': 3.11.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/picker': 3.16.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/picker': 3.16.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/collections': 3.12.10(react@18.3.1)
       '@react-stately/list': 3.13.4(react@18.3.1)
@@ -17813,7 +17797,7 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/tag@3.3.10(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/tag@3.3.10(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -17821,11 +17805,11 @@ snapshots:
       '@react-aria/selection': 3.27.2(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/tag': 3.8.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/collections': 3.12.10(react@17.0.2)
       '@react-stately/list': 3.13.4(react@17.0.2)
@@ -17834,7 +17818,7 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/tag@3.3.10(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/tag@3.3.10(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -17842,11 +17826,11 @@ snapshots:
       '@react-aria/selection': 3.27.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/tag': 3.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/collections': 3.12.10(react@18.3.1)
       '@react-stately/list': 3.13.4(react@18.3.1)
@@ -17876,10 +17860,10 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/text@3.5.25(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/text@3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
       '@react-types/text': 3.3.23(react@17.0.2)
@@ -17888,10 +17872,10 @@ snapshots:
       react-aria-components: 1.16.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/text@3.5.25(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/text@3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
       '@react-types/text': 3.3.23(react@18.3.1)
@@ -17912,40 +17896,40 @@ snapshots:
       react-aria-components: 1.16.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/textfield@3.14.5(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/textfield@3.14.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/interactions': 3.27.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/textfield': 3.18.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/utils': 3.11.0(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
       '@react-types/textfield': 3.12.8(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/textfield@3.14.5(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/textfield@3.14.5(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/interactions': 3.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/textfield': 3.18.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/form': 3.7.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/label': 3.16.22(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/utils': 3.11.0(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
       '@react-types/textfield': 3.12.8(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -18023,37 +18007,37 @@ snapshots:
       '@swc/helpers': 0.5.21
       react: 19.2.0
 
-  '@react-spectrum/toast@3.1.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/toast@3.1.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/overlays': 3.31.2(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/toast': 3.0.11(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/toast': 3.1.3(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       use-sync-external-store: 1.6.0(react@17.0.2)
 
-  '@react-spectrum/toast@3.1.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/toast@3.1.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/overlays': 3.31.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/toast': 3.0.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/button': 3.17.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/toast': 3.1.3(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -18077,38 +18061,38 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
       use-sync-external-store: 1.6.0(react@19.2.0)
 
-  '@react-spectrum/tooltip@3.8.2(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/tooltip@3.8.2(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/overlays': 3.31.2(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/tooltip': 3.9.2(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-stately/tooltip': 3.5.11(react@17.0.2)
       '@react-types/overlays': 3.9.4(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
       '@react-types/tooltip': 3.5.2(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/tooltip@3.8.2(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/tooltip@3.8.2(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/focus': 3.21.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/overlays': 3.31.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/tooltip': 3.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/overlays': 5.9.3(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-stately/tooltip': 3.5.11(react@18.3.1)
       '@react-types/overlays': 3.9.4(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
       '@react-types/tooltip': 3.5.2(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -18131,35 +18115,35 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/tree@3.1.11(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/tree@3.1.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/button': 3.14.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/i18n': 3.12.16(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/tree': 3.1.7(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/checkbox': 3.10.7(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/checkbox': 3.10.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-aria-components: 1.16.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/tree@3.1.11(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/tree@3.1.11(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/button': 3.14.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/i18n': 3.12.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/tree': 3.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/checkbox': 3.10.7(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/checkbox': 3.10.7(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-spectrum/text': 3.5.25(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
-      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@spectrum-icons/ui': 3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-aria-components: 1.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -18215,10 +18199,10 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-spectrum/view@3.6.26(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-spectrum/view@3.6.26(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@react-aria/utils': 3.33.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@react-types/shared': 3.33.1(react@17.0.2)
       '@react-types/view': 3.4.23(react@17.0.2)
@@ -18226,10 +18210,10 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@react-spectrum/view@3.6.26(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-spectrum/view@3.6.26(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/utils': 3.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/shared': 3.33.1(react@18.3.1)
       '@react-types/view': 3.4.23(react@18.3.1)
@@ -20087,22 +20071,22 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@spectrum-icons/ui@3.6.23(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@spectrum-icons/ui@3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@adobe/react-spectrum-ui': 1.2.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@babel/runtime': 7.28.4
-      '@react-spectrum/icon': 3.8.12(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/icon': 3.8.12(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@swc/helpers': 0.5.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@spectrum-icons/ui@3.6.23(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@spectrum-icons/ui@3.6.23(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@adobe/react-spectrum-ui': 1.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@babel/runtime': 7.28.4
-      '@react-spectrum/icon': 3.8.12(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/icon': 3.8.12(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-spectrum/provider': 3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@swc/helpers': 0.5.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -20116,24 +20100,6 @@ snapshots:
       '@swc/helpers': 0.5.21
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-
-  '@spectrum-icons/workflow@4.2.28(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
-    dependencies:
-      '@adobe/react-spectrum-workflow': 2.3.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/icon': 3.8.12(@react-spectrum/provider@3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@react-spectrum/provider': 3.10.14(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@swc/helpers': 0.5.21
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-
-  '@spectrum-icons/workflow@4.2.28(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@adobe/react-spectrum-workflow': 2.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/icon': 3.8.12(@react-spectrum/provider@3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-spectrum/provider': 3.10.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@swc/helpers': 0.5.21
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
 
   '@spectrum-icons/workflow@4.2.28(@react-spectrum/provider@3.10.14(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
@@ -21115,7 +21081,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.11.15: {}
+  baseline-browser-mapping@2.11.20: {}
 
   basic-ftp@5.2.2: {}
 
@@ -21196,7 +21162,7 @@ snapshots:
 
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.11.15
+      baseline-browser-mapping: 2.11.20
       caniuse-lite: 1.0.30001762
       electron-to-chromium: 1.5.267
       node-releases: 2.0.27
@@ -24160,6 +24126,8 @@ snapshots:
 
   picomatch@4.0.5: {}
 
+  picomatch@4.0.7: {}
+
   pify@2.3.0: {}
 
   pify@3.0.0: {}
@@ -26564,7 +26532,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.4
       pathe: 2.0.3
-      picomatch: 4.0.5
+      picomatch: 4.0.7
       std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.3.0


### PR DESCRIPTION
<!--- The title above will be used as a bullet point in the release notes. -->
<!--- In general, start the title with a past tense verb (i.e. added, optimized, removed.) -->
<!--- For bug fixes, start with "fixed" (i.e. fixed an issue, fixed broken.) -->
<!--- For PRs that should not be included in the release notes, attach the label "ignore-for-release" -->

## Changed Packages
<!--- Indicate which package your changes directly affect. -->
<!--- (i.e., do not choose the extension if it's only change is updating its core version). -->
- [x] core
- [x] node
- [ ] reactor-extension 

## Description

This branch implements two components to the Node SDK:
1. **Consent (`setConsent`)** — Node can now report a visitor's privacy consent state to Edge Network, matching the browser SDK. Previously there was no way to do this server-side at all.
2. **Context + real visitor signals** — server calls now tag events with basic metadata, capture what page the visitor was on, and forward the visitor's real browser/language info upstream instead of a generic Node signature — plus a fix ensuring that works on both classic (Express) and modern fetch-based (Next.js, edge runtime) backends.

## Related Issue

(Related to Universal JS Migration effort)

## Motivation and Context

Improves SDK functionality and enables new use cases for Node servers

## Screenshots (if appropriate):

N/A

## Documentation
[Doc ticket](https://jira.corp.adobe.com/browse/PDCL-16447)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have added a Changeset file with a consumer-facing description of my changes.
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] I have made any necessary test changes and all tests pass.
- [x] I have run the Sandbox successfully.
